### PR TITLE
FontUtils class

### DIFF
--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using BepInEx;
 using HarmonyLib;
 using Nautilus.Patchers;
@@ -56,5 +56,6 @@ public class Initializer : BaseUnityPlugin
         CustomSoundPatcher.Patch(_harmony);
         EatablePatcher.Patch(_harmony);
         MaterialUtils.Patch();
+        FontReferencesPatcher.Patch(_harmony);
     }
 }

--- a/Nautilus/Patchers/FontReferencesPatcher.cs
+++ b/Nautilus/Patchers/FontReferencesPatcher.cs
@@ -1,0 +1,26 @@
+using HarmonyLib;
+using Nautilus.Utility;
+using TMPro;
+
+namespace Nautilus.Patchers;
+
+internal static class FontReferencesPatcher
+{
+    public static void Patch(Harmony harmony)
+    {
+        harmony.Patch(AccessTools.Method(typeof(uGUI_MainMenu), nameof(uGUI_MainMenu.Start)),
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(FontReferencesPatcher), nameof(GetAllerRgFont))));
+        harmony.Patch(AccessTools.Method(typeof(uGUI), nameof(uGUI.Awake)),
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(FontReferencesPatcher), nameof(GetAllerWBdFont))));
+    }
+
+    internal static void GetAllerRgFont(uGUI_MainMenu __instance)
+    {
+         FontUtils.Aller_Rg = __instance.transform.Find("Panel/MainMenu/GraphicsDeviceName").GetComponent<TextMeshProUGUI>().font;
+    }
+
+    internal static void GetAllerWBdFont(uGUI_MainMenu __instance)
+    {
+        FontUtils.Aller_W_Bd = __instance.transform.Find("ScreenCanvas/HUD/Content/DepthCompass/Compass/NW").GetComponent<TextMeshProUGUI>().font;
+    }
+}

--- a/Nautilus/Patchers/SaveUtilsPatcher.cs
+++ b/Nautilus/Patchers/SaveUtilsPatcher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using HarmonyLib;

--- a/Nautilus/Utility/FontUtils.cs
+++ b/Nautilus/Utility/FontUtils.cs
@@ -1,10 +1,11 @@
 using TMPro;
+using UnityEngine;
 
 namespace Nautilus.Utility;
 
 /// <summary>
-/// <para>Contains references to frequently used font assets for use in the <see cref="TextMeshProUGUI"/> component, which is the preferred component for rendering text.</para>
-/// <para>The fonts referenced in this class should not be expected to exist until after the main menu scene has been loaded and both the <see cref="uGUI"/> and <see cref="uGUI_MainMenu"/> components have been initialized.</para>
+/// <para>Contains references to frequently used Font Assets for use in the <see cref="TextMeshProUGUI"/> component, which is the preferred component for rendering text.</para>
+/// <para>The fonts referenced in this class should not be expected to exist until after the Main Menu scene has been loaded and both the <see cref="uGUI"/> and <see cref="uGUI_MainMenu"/> components have been initialized.</para>
 /// </summary>
 public static class FontUtils
 {
@@ -16,4 +17,18 @@ public static class FontUtils
     /// Returns a bold alternative of the Aller font, referred to internally as 'Aller_W_Bd SDF'.
     /// </summary>
     public static TMP_FontAsset Aller_W_Bd { get; internal set; }
+
+    /// <summary>
+    /// Applies the given font to every <see cref="TextMeshProUGUI"/> component within <paramref name="rootGameObject"/> and its children (recursive).
+    /// </summary>
+    /// <param name="rootGameObject">The parent of all affected <see cref="TextMeshProUGUI"/> componentss.</param>
+    /// <param name="font">The Font Asset to be applied.</param>
+    public static void SetFontInChildren(GameObject rootGameObject, TMP_FontAsset font)
+    {
+        var textComponents = rootGameObject.GetComponentsInChildren<TextMeshProUGUI>(true);
+        foreach (var textComponent in textComponents)
+        {
+            textComponent.font = font;
+        }
+    }
 }

--- a/Nautilus/Utility/FontUtils.cs
+++ b/Nautilus/Utility/FontUtils.cs
@@ -1,0 +1,19 @@
+using TMPro;
+
+namespace Nautilus.Utility;
+
+/// <summary>
+/// <para>Contains references to frequently used font assets for use in the <see cref="TextMeshProUGUI"/> component, which is the preferred component for rendering text.</para>
+/// <para>The fonts referenced in this class should not be expected to exist until after the main menu scene has been loaded and both the <see cref="uGUI"/> and <see cref="uGUI_MainMenu"/> components have been initialized.</para>
+/// </summary>
+public static class FontUtils
+{
+    /// <summary>
+    /// Returns the regular version of the Aller font, referred to internally as 'Aller_Rg SDF'.
+    /// </summary>
+    public static TMP_FontAsset Aller_Rg { get; internal set; }
+    /// <summary>
+    /// Returns a bold alternative of the Aller font, referred to internally as 'Aller_W_Bd SDF'.
+    /// </summary>
+    public static TMP_FontAsset Aller_W_Bd { get; internal set; }
+}


### PR DESCRIPTION
### Changes made in this pull request

  - Added `FontUtils` class with references to common fonts
  - Added internal `FontReferencesPatcher`
    - Side note: In the future, I would suggest naming patcher classes after their purpose rather than after the class they patch (when applicable). This keeps patcher classes more maintainable and reduces the chance of one file having multiple purposes.
  - Added `SetFontInChildren`, self-explanatory.