### PR TITLE
AddLogEntry Overloads

### DIFF
--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -111,7 +111,8 @@ public static class PDAHandler
     /// </summary>
     /// <param name="key">The key (unique identifier) for this entry.</param>
     /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
-    /// <param name="sound">The sound that will be played once this log entry is unlocked or played through the PDA's Log tab.</param>
+    /// <param name="sound"><para>The sound that will be played once this log entry is unlocked or played through the PDA's Log tab.</para>
+    /// <para>Note that the SoundQueue system (which plays the PDA sounds) accesses the FMODAsset's "id" field rather than the path, so make sure it is assigned properly.</para></param>
     /// <param name="icon">The icon that will be used in the Log tab for this entry. if unassigned, it will use the default log entry icon.</param>
     public static void AddLogEntry(string key, string languageKey, FMODAsset sound, Sprite icon = null)
     {

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -1,4 +1,6 @@
 using BepInEx.Logging;
+using FMOD;
+using Nautilus.FMod.Interfaces;
 using Nautilus.Patchers;
 using Nautilus.Utility;
 using UnityEngine;
@@ -105,11 +107,11 @@ public static class PDAHandler
     }
 
     /// <summary>
-    /// Adds a custom PDA log entry message. Can be played by the Story Goal system or through <see cref="PDALog.Add"/>.
+    /// Adds a custom PDA log entry message. Should be played by the Story Goal system or through <see cref="PDALog.Add"/>.
     /// </summary>
     /// <param name="key">The key (unique identifier) for this entry.</param>
     /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
-    /// <param name="sound">The sound that will be played once this entry is triggered or played through the PDA's Log tab.</param>
+    /// <param name="sound">The sound that will be played once this log entry is unlocked or played through the PDA's Log tab.</param>
     /// <param name="icon">The icon that will be used in the Log tab for this entry. if unassigned, it will use the default log entry icon.</param>
     public static void AddLogEntry(string key, string languageKey, FMODAsset sound, Sprite icon = null)
     {
@@ -124,6 +126,56 @@ public static class PDAHandler
         
         if (uGUI.isMainLevel)
             PDALogPatcher.InitializePostfix();
+    }
+
+    /// <summary>
+    /// Adds a custom PDA log entry message. Should be played by the Story Goal system or through <see cref="PDALog.Add"/>.
+    /// </summary>
+    /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
+    /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
+    /// <param name="sound">The sound that will be played once this log entry is unlocked or played through the PDA's Log tab.</param>
+    /// <param name="icon">The icon that will be used in the Log tab for this entry. if unassigned, it will use the default log entry icon.</param>
+    public static void AddLogEntry(string key, string languageKey, Sound sound, Sprite icon = null)
+    {
+        CustomSoundHandler.RegisterCustomSound(key, sound, AudioUtils.BusPaths.PDAVoice);
+        AddLogEntry(key, languageKey, AudioUtils.GetFmodAsset(key), icon);
+    }
+
+    /// <summary>
+    /// Adds a custom PDA log entry message. Should be played by the Story Goal system or through <see cref="PDALog.Add"/>.
+    /// </summary>
+    /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
+    /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
+    /// <param name="audioClip">The sound that will be played once this log entry is unlocked or played through the PDA's Log tab. This is automatically converted to an FMOD sound.</param>
+    /// <param name="icon">The icon that will be used in the Log tab for this entry. if unassigned, it will use the default log entry icon.</param>
+    public static void AddLogEntry(string key, string languageKey, AudioClip audioClip, Sprite icon = null)
+    {
+        AddLogEntry(key, languageKey, CustomSoundHandler.RegisterCustomSound(key, audioClip, AudioUtils.BusPaths.PDAVoice), icon);
+    }
+
+    /// <summary>
+    /// Adds a custom PDA log entry message. Can be played by the Story Goal system or through <see cref="PDALog.Add"/>.
+    /// </summary>
+    /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
+    /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
+    /// <param name="filePath">The file path on the disk to the sound that will be played once this log entry is unlocked or played through the PDA's Log tab.</param>
+    /// <param name="icon">The icon that will be used in the Log tab for this entry. if unassigned, it will use the default log entry icon.</param>
+    public static void AddLogEntry(string key, string languageKey, string filePath, Sprite icon = null)
+    {
+        AddLogEntry(key, languageKey, CustomSoundHandler.RegisterCustomSound(key, filePath, AudioUtils.BusPaths.PDAVoice), icon);
+    }
+
+    /// <summary>
+    /// Adds a custom PDA log entry message. Can be played by the Story Goal system or through <see cref="PDALog.Add"/>.
+    /// </summary>
+    /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
+    /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
+    /// <param name="fmodSoundInterface">The IFModSound interface that accessed when this log entry is played.</param>
+    /// <param name="icon">The icon that will be used in the Log tab for this entry. if unassigned, it will use the default log entry icon.</param>
+    public static void AddLogEntry(string key, string languageKey, IFModSound fmodSoundInterface, Sprite icon = null)
+    {
+        CustomSoundHandler.RegisterCustomSound(key, fmodSoundInterface);
+        AddLogEntry(key, languageKey, AudioUtils.GetFmodAsset(key), icon);
     }
 
     /// <summary>

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -158,11 +158,11 @@ public static class PDAHandler
     /// </summary>
     /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
     /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
-    /// <param name="filePath">The file path on the disk to the sound that will be played once this log entry is unlocked or played through the PDA's Log tab.</param>
+    /// <param name="soundFilePath">The file path on the disk to the sound that will be played once this log entry is unlocked or played through the PDA's Log tab.</param>
     /// <param name="icon">The icon that will be used in the Log tab for this entry. if unassigned, it will use the default log entry icon.</param>
-    public static void AddLogEntry(string key, string languageKey, string filePath, Sprite icon = null)
+    public static void AddLogEntry(string key, string languageKey, string soundFilePath, Sprite icon = null)
     {
-        AddLogEntry(key, languageKey, CustomSoundHandler.RegisterCustomSound(key, filePath, AudioUtils.BusPaths.PDAVoice), icon);
+        AddLogEntry(key, languageKey, CustomSoundHandler.RegisterCustomSound(key, soundFilePath, AudioUtils.BusPaths.PDAVoice), icon);
     }
 
     /// <summary>

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -107,7 +107,7 @@ public static class PDAHandler
     }
 
     /// <summary>
-    /// Adds a custom PDA log entry message. Should be played by the Story Goal system or through <see cref="PDALog.Add"/>.
+    /// Adds a custom PDA log entry message. Should be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or through <see cref="PDALog.Add"/>.
     /// </summary>
     /// <param name="key">The key (unique identifier) for this entry.</param>
     /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
@@ -129,7 +129,7 @@ public static class PDAHandler
     }
 
     /// <summary>
-    /// Adds a custom PDA log entry message. Should be played by the Story Goal system or through <see cref="PDALog.Add"/>.
+    /// Adds a custom PDA log entry message. Should be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or through <see cref="PDALog.Add"/>.
     /// </summary>
     /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
     /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
@@ -142,7 +142,7 @@ public static class PDAHandler
     }
 
     /// <summary>
-    /// Adds a custom PDA log entry message. Should be played by the Story Goal system or through <see cref="PDALog.Add"/>.
+    /// Adds a custom PDA log entry message. Should be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or through <see cref="PDALog.Add"/>.
     /// </summary>
     /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
     /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
@@ -154,7 +154,7 @@ public static class PDAHandler
     }
 
     /// <summary>
-    /// Adds a custom PDA log entry message. Can be played by the Story Goal system or through <see cref="PDALog.Add"/>.
+    /// Adds a custom PDA log entry message. Should be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or through <see cref="PDALog.Add"/>.
     /// </summary>
     /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
     /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
@@ -166,7 +166,7 @@ public static class PDAHandler
     }
 
     /// <summary>
-    /// Adds a custom PDA log entry message. Can be played by the Story Goal system or through <see cref="PDALog.Add"/>.
+    /// Adds a custom PDA log entry message. Should be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or through <see cref="PDALog.Add"/>.
     /// </summary>
     /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
     /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -107,7 +107,7 @@ public static class PDAHandler
     }
 
     /// <summary>
-    /// Adds a custom PDA log entry message. Should be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or through <see cref="PDALog.Add"/>.
+    /// Adds a custom PDA log entry message. Can be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or manually through <see cref="PDALog.Add"/>.
     /// </summary>
     /// <param name="key">The key (unique identifier) for this entry.</param>
     /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
@@ -129,7 +129,7 @@ public static class PDAHandler
     }
 
     /// <summary>
-    /// Adds a custom PDA log entry message. Should be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or through <see cref="PDALog.Add"/>.
+    /// Adds a custom PDA log entry message. Can be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or manually through <see cref="PDALog.Add"/>.
     /// </summary>
     /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
     /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
@@ -142,7 +142,7 @@ public static class PDAHandler
     }
 
     /// <summary>
-    /// Adds a custom PDA log entry message. Should be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or through <see cref="PDALog.Add"/>.
+    /// Adds a custom PDA log entry message. Can be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or manually through <see cref="PDALog.Add"/>.
     /// </summary>
     /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
     /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
@@ -154,7 +154,7 @@ public static class PDAHandler
     }
 
     /// <summary>
-    /// Adds a custom PDA log entry message. Should be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or through <see cref="PDALog.Add"/>.
+    /// Adds a custom PDA log entry message. Can be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or manually through <see cref="PDALog.Add"/>.
     /// </summary>
     /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
     /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
@@ -166,7 +166,7 @@ public static class PDAHandler
     }
 
     /// <summary>
-    /// Adds a custom PDA log entry message. Should be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or through <see cref="PDALog.Add"/>.
+    /// Adds a custom PDA log entry message. Can be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or manually through <see cref="PDALog.Add"/>.
     /// </summary>
     /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
     /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -170,11 +170,11 @@ public static class PDAHandler
     /// </summary>
     /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
     /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
-    /// <param name="fmodSoundInterface">The IFModSound interface that accessed when this log entry is played.</param>
+    /// <param name="fmodSound">The <see cref="IFModSound"/> instance that is used to create a custom sound. IFModSound instances have custom logic for playing sounds. that is accessed when this log entry is played.</param>
     /// <param name="icon">The icon that will be used in the Log tab for this entry. if unassigned, it will use the default log entry icon.</param>
-    public static void AddLogEntry(string key, string languageKey, IFModSound fmodSoundInterface, Sprite icon = null)
+    public static void AddLogEntry(string key, string languageKey, IFModSound fmodSound, Sprite icon = null)
     {
-        CustomSoundHandler.RegisterCustomSound(key, fmodSoundInterface);
+        CustomSoundHandler.RegisterCustomSound(key, fmodSound);
         AddLogEntry(key, languageKey, AudioUtils.GetFmodAsset(key), icon);
     }
 

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -129,14 +129,7 @@ public static class PDAHandler
             PDALogPatcher.InitializePostfix();
     }
 
-    /// <summary>
-    /// Adds a custom PDA log entry message. Can be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or manually through <see cref="PDALog.Add"/>.
-    /// </summary>
-    /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
-    /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
-    /// <param name="sound">The sound that will be played once this log entry is unlocked or played through the PDA's Log tab.</param>
-    /// <param name="icon">The icon that will be used in the Log tab for this entry. if unassigned, it will use the default log entry icon.</param>
-    public static void AddLogEntry(string key, string languageKey, Sound sound, Sprite icon = null)
+    internal static void AddLogEntry(string key, string languageKey, Sound sound, Sprite icon = null)
     {
         /*
          * If there's an existing custom sound with the same key, we release the previous sound's handle.

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -138,8 +138,21 @@ public static class PDAHandler
     /// <param name="icon">The icon that will be used in the Log tab for this entry. if unassigned, it will use the default log entry icon.</param>
     public static void AddLogEntry(string key, string languageKey, Sound sound, Sprite icon = null)
     {
+        /*
+         * If there's an existing custom sound with the same key, we release the previous sound's handle.
+         * This is so we do not leave any unused objects in memory.
+         */
+        if (CustomSoundHandler.TryGetCustomSound(key, out var prevSound))
+        {
+            if (prevSound.hasHandle() && prevSound.handle != sound.handle)
+            {
+                prevSound.release();
+            }
+        }
+
         CustomSoundHandler.RegisterCustomSound(key, sound, AudioUtils.BusPaths.PDAVoice);
-        AddLogEntry(key, languageKey, AudioUtils.GetFmodAsset(key), icon);
+
+        AddLogEntry(key, languageKey, AudioUtils.GetFmodAsset(key, key), icon);
     }
 
     /// <summary>

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -129,7 +129,14 @@ public static class PDAHandler
             PDALogPatcher.InitializePostfix();
     }
 
-    internal static void AddLogEntry(string key, string languageKey, Sound sound, Sprite icon = null)
+    /// <summary>
+    /// Adds a custom PDA log entry message. Can be played by the Story Goal system (see <see cref="StoryGoalHandler"/>) or manually through <see cref="PDALog.Add"/>.
+    /// </summary>
+    /// <param name="key">The key (unique identifier) for this entry. Also used to create the sound asset, so make sure this string is <i>truly</i> unique!</param>
+    /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
+    /// <param name="sound">The sound that will be played once this log entry is unlocked or played through the PDA's Log tab.</param>
+    /// <param name="icon">The icon that will be used in the Log tab for this entry. if unassigned, it will use the default log entry icon.</param>
+    public static void AddLogEntry(string key, string languageKey, Sound sound, Sprite icon = null)
     {
         /*
          * If there's an existing custom sound with the same key, we release the previous sound's handle.

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -105,13 +105,12 @@ public static class PDAHandler
     }
 
     /// <summary>
-    /// Adds a custom log entry.
+    /// Adds a custom PDA log entry message. Can be played by the Story Goal system or through <see cref="PDALog.Add"/>.
     /// </summary>
-    /// <param name="key">The key to refer to this entry.</param>
-    /// <param name="languageKey">The subtitles language key for this entry.</param>
-    /// <param name="icon">The icon that will be used in the Log tab for this entry. if <c>null</c> It will use the default log entry icon.</param>
-    /// <param name="sound">The sound that will be played once this entry is triggered or played in the Log tab.<br/>
-    /// If <c>null</c> the Play button in the Log tab will disappear and a sound wont play when this entry is triggered.</param>
+    /// <param name="key">The key (unique identifier) for this entry.</param>
+    /// <param name="languageKey">The subtitles language key for this entry. Also see: <see cref="LanguageHandler.SetLanguageLine(string, string, string)"/>.</param>
+    /// <param name="sound">The sound that will be played once this entry is triggered or played through the PDA's Log tab.</param>
+    /// <param name="icon">The icon that will be used in the Log tab for this entry. if unassigned, it will use the default log entry icon.</param>
     public static void AddLogEntry(string key, string languageKey, FMODAsset sound, Sprite icon = null)
     {
         PDALog.EntryData entry = new()

--- a/Nautilus/Utility/AudioUtils.cs
+++ b/Nautilus/Utility/AudioUtils.cs
@@ -95,6 +95,7 @@ public static partial class AudioUtils
     /// <summary>
     /// <para>Returns a new <see cref="FMODAsset"/> with the given parameters. An FMODAsset is a data object that is required for various audio-related classes and methods, since it holds references to internal sound IDs.</para>
     /// <para>A list of vanilla sound paths for SN1 can also be viewed at this URL: <see href="https://github.com/SubnauticaModding/Nautilus/tree/master/Nautilus/Documentation/resources/SN1-FMODEvents.txt"/>.</para>
+    /// <para>The best way to assign a "path" to a custom sound asset is through <see cref="Handlers.CustomSoundHandler.RegisterCustomSound(string, Sound, string)"/>.</para>
     /// </summary>
     /// <param name="path">
     /// <para>An FMOD Event's 'path' is the part read by most audio systems within Subnautica.</para>


### PR DESCRIPTION
### Changes made in this pull request

  - Added `public static void AddLogEntry(string key, string languageKey, Sound sound, Sprite icon = null)`
  - Added `public static void AddLogEntry(string key, string languageKey, AudioClip audioClip, Sprite icon = null)`
  - Added `public static void AddLogEntry(string key, string languageKey, string soundFilePath, Sprite icon = null)`
  - Added `public static void AddLogEntry(string key, string languageKey, IFModSound fmodSoundInterface, Sprite icon = null)`

Can someone with more knowledge on FMOD (@Metious!) please review the logic of the added methods?