### PR TITLE
LanguagePatcher Dictionary Error.

### DIFF
--- a/Nautilus/Patchers/LanguagePatcher.cs
+++ b/Nautilus/Patchers/LanguagePatcher.cs
@@ -47,12 +47,12 @@ internal static class LanguagePatcher
     {
         if (!_customLines.TryGetValue(FallbackLanguage, out var fallbackStrings) & !_customLines.TryGetValue(_currentLanguage, out var currentStrings))
         {
-          return;
+            return;
         }
 
         fallbackStrings ??= new();
         currentStrings ??= new();
-        
+
         foreach (var fallbackString in fallbackStrings)
         {
             // Allow mixed-in English if the current language doesn't have a translation for a key. 

--- a/Nautilus/Patchers/LanguagePatcher.cs
+++ b/Nautilus/Patchers/LanguagePatcher.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using BepInEx.Logging;
@@ -45,6 +45,10 @@ internal static class LanguagePatcher
 
     internal static void InsertCustomLines(ref Language __instance)
     {
+        // Check to avoid errors. If there is no custom lines, we skip this.
+        if (_customLines is null || _customLines.Count == 0)
+            return;
+
         var fallbackStrings = _customLines[FallbackLanguage];
         var currentStrings = _customLines[_currentLanguage];
 

--- a/Nautilus/Patchers/LanguagePatcher.cs
+++ b/Nautilus/Patchers/LanguagePatcher.cs
@@ -45,9 +45,13 @@ internal static class LanguagePatcher
 
     internal static void InsertCustomLines(ref Language __instance)
     {
-        // Check to avoid errors. If there is no custom lines, we skip this.
-        if (_customLines is null || _customLines.Count == 0)
-            return;
+        if (!_customLines.TryGetValue(FallbackLanguage, out var fallbackStrings) & !_customLines.TryGetValue(_currentLanguage, out var currentStrings))
+        {
+          return;
+        }
+
+        fallbackStrings ??= new();
+        currentStrings ??= new();
 
         var fallbackStrings = _customLines[FallbackLanguage];
         var currentStrings = _customLines[_currentLanguage];

--- a/Nautilus/Patchers/LanguagePatcher.cs
+++ b/Nautilus/Patchers/LanguagePatcher.cs
@@ -52,10 +52,7 @@ internal static class LanguagePatcher
 
         fallbackStrings ??= new();
         currentStrings ??= new();
-
-        var fallbackStrings = _customLines[FallbackLanguage];
-        var currentStrings = _customLines[_currentLanguage];
-
+        
         foreach (var fallbackString in fallbackStrings)
         {
             // Allow mixed-in English if the current language doesn't have a translation for a key. 


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed an error where it tried to access an item from an empty dictionary. (`if (_customLines is null || _customLines.Count == 0) return;`)
