### PR TITLE
Clean up XML docs for various classes

### DIFF
--- a/Nautilus/Handlers/CoordinatedSpawnsHandler.cs
+++ b/Nautilus/Handlers/CoordinatedSpawnsHandler.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 namespace Nautilus.Handlers;
 
 /// <summary>
-/// a Handler that handles and registers Coordinated (<see cref="Vector3"/> spawns).
+/// A handler class for registering Coordinated Spawns.
 /// </summary>
 public static class CoordinatedSpawnsHandler 
 {

--- a/Nautilus/Handlers/CraftTreeHandler.cs
+++ b/Nautilus/Handlers/CraftTreeHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Nautilus.Crafting;
 using Nautilus.Patchers;
 using Nautilus.Utility;
@@ -6,7 +6,7 @@ using Nautilus.Utility;
 namespace Nautilus.Handlers;
 
 /// <summary>
-/// A handler class for creating and editing of crafting trees.
+/// A handler class for creating and modifying crafting trees.
 /// </summary>
 public static class CraftTreeHandler 
 {

--- a/Nautilus/Handlers/CustomSoundHandler.cs
+++ b/Nautilus/Handlers/CustomSoundHandler.cs
@@ -1,4 +1,4 @@
-﻿using FMOD;
+using FMOD;
 using FMOD.Studio;
 using FMODUnity;
 using Nautilus.FMod.Interfaces;
@@ -9,7 +9,7 @@ using UnityEngine;
 namespace Nautilus.Handlers;
 
 /// <summary>
-/// A handler class for adding and overriding Sounds.
+/// A handler class for adding and overriding Sounds. Also see the <see cref="AudioUtils"/> class.
 /// </summary>
 public static class CustomSoundHandler
 {

--- a/Nautilus/Handlers/EatableHandler.cs
+++ b/Nautilus/Handlers/EatableHandler.cs
@@ -1,9 +1,9 @@
-﻿using Nautilus.Patchers;
+using Nautilus.Patchers;
 
 namespace Nautilus.Handlers;
 
 /// <summary>
-/// A handler for editing values for eatable classes
+/// A handler class for modyfing the data of edible objects (objects with the <see cref="Eatable"/> component).
 /// </summary>
 public static class EatableHandler 
 {

--- a/Nautilus/Handlers/Enums/EnumBuilder.cs
+++ b/Nautilus/Handlers/Enums/EnumBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 using BepInEx.Logging;
@@ -8,7 +8,7 @@ using Nautilus.Utility;
 namespace Nautilus.Handlers;
 
 /// <summary>
-/// Represents a custom enum object. This class cannot be inherited
+/// Represents a custom enum object. This class cannot be inherited.
 /// </summary>
 /// <typeparam name="TEnum">Type of the enum.</typeparam>
 public sealed class EnumBuilder<TEnum> where TEnum : Enum

--- a/Nautilus/Handlers/ItemActionHandler.cs
+++ b/Nautilus/Handlers/ItemActionHandler.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 using Nautilus.Patchers;
 using Nautilus.Utility;
 
 namespace Nautilus.Handlers;
 
 /// <summary>
-/// A handler class for registering your custom middle click actions for items
+/// A handler class for registering custom actions when left clicking or middle clicking on an item.
 /// </summary>
 public static class ItemActionHandler
 {

--- a/Nautilus/Handlers/LanguageHandler.cs
+++ b/Nautilus/Handlers/LanguageHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 namespace Nautilus.Handlers;
 
 /// <summary>
-/// A handler for adding custom language lines.
+/// A handler class for adding or modifying language lines.
 /// </summary>
 public static class LanguageHandler
 {

--- a/Nautilus/Handlers/LootDistributionHandler.cs
+++ b/Nautilus/Handlers/LootDistributionHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using BepInEx.Logging;
 using Nautilus.Assets;
 using Nautilus.Patchers;
@@ -8,7 +8,7 @@ using UWE;
 namespace Nautilus.Handlers;
 
 /// <summary>
-/// A handler that manages Loot Distribution.
+/// A handler that manages the distribution of spawned resources throughout the world. Used for fish, items, outcrops, fragments, eggs, etc...
 /// </summary>
 public static class LootDistributionHandler
 {

--- a/Nautilus/Handlers/OptionsPanelHandler.cs
+++ b/Nautilus/Handlers/OptionsPanelHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using Nautilus.Json;
 using Nautilus.Options;
 using Nautilus.Options.Attributes;

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -8,7 +8,12 @@ using UnityEngine;
 namespace Nautilus.Handlers;
 
 /// <summary>
-/// A handler class for various scanner related data.
+/// A handler class for various PDA-related purposes:
+/// <list type="bullet">
+/// <item>Registering log entries</item>
+/// <item>Registering encyclopedia (databank) entries</item>
+/// <item>Defining data for scanning fragments and other items</item>
+/// </list>
 /// </summary>
 public static class PDAHandler 
 {

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -10,9 +10,9 @@ namespace Nautilus.Handlers;
 /// <summary>
 /// A handler class for various PDA-related purposes:
 /// <list type="bullet">
-/// <item>Registering log entries</item>
-/// <item>Registering encyclopedia (databank) entries</item>
-/// <item>Defining data for scanning fragments and other items</item>
+/// <item>Registering log entries.</item>
+/// <item>Registering encyclopedia (databank) entries.</item>
+/// <item>Defining data for scanning fragments and other items.</item>
 /// </list>
 /// </summary>
 public static class PDAHandler 

--- a/Nautilus/Handlers/StoryGoalHandler_Subnautica.cs
+++ b/Nautilus/Handlers/StoryGoalHandler_Subnautica.cs
@@ -8,33 +8,8 @@ namespace Nautilus.Handlers;
 
 #if SUBNAUTICA
 /// <summary>
-/// <para>A handler class for interacting with all of the major goal systems in Subnautica, which are essential in the game progression. Utilizes the following systems:</para>
-/// <list type="bullet">
-///    <item>
-///        <term><see cref="ItemGoalTracker"/></term>
-///        <description>Completes an <see cref="ItemGoal"/> (or multiple) when an object with the given TechType is picked up, equipped, or crafted through the Mobile Vehicle Bay.</description>
-///    </item>
-///    <item>
-///        <term><see cref="BiomeGoalTracker"/></term>
-///        <description>Completes a <see cref="BiomeGoal"/> when the player stays in a given biome for a specified period of time.</description>
-///    </item>
-///    <item>
-///        <term><see cref="LocationGoalTracker"/></term>
-///        <description>Completes a <see cref="LocationGoal"/> when the player stays within range of a certain position for a specified period of time.</description>
-///    </item>
-///    <item>
-///        <term><see cref="CompoundGoalTracker"/></term>
-///        <description>Completes a <see cref="CompoundGoal"/> when all required "precondition" goals have been completed.</description>
-///    </item>
-///    <item>
-///        <term><see cref="OnGoalUnlockTracker"/></term>
-///        <description>Handles the completion of a goal with the data defined in an <see cref="OnGoalUnlock"/> object. Defines the unlocked blueprints, signals, items, and achievements that should be unlocked.</description>
-///    </item>
-///    <item>
-///        <term><see cref="StoryGoalCustomEventHandler"/></term>
-///        <description>Handles arbitrary code that is executed after completing a goal, for use in more specific story events.</description>
-///    </item>
-/// </list>
+/// <para>A handler class for interacting with all of the major goal systems in Subnautica, which are essential for the's game progression.</para>
+/// <para>Allows for important game events to be triggered after a specified action is completed.</para>
 /// </summary>
 public static class StoryGoalHandler
 {

--- a/Nautilus/Handlers/SurvivalHandler.cs
+++ b/Nautilus/Handlers/SurvivalHandler.cs
@@ -5,7 +5,7 @@ using Nautilus.Patchers;
 namespace Nautilus.Handlers;
 
 /// <summary>
-/// a common handler for uses specified to the Survival component
+/// Handler class that relates to the <see cref="Survival"/> component. Allows the defining of oxygen or health gains when consuming specific items.
 /// </summary>
 public static class SurvivalHandler 
 {

--- a/Nautilus/Handlers/WorldEntityDatabaseHandler.cs
+++ b/Nautilus/Handlers/WorldEntityDatabaseHandler.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx.Logging;
+using BepInEx.Logging;
 using Nautilus.Patchers;
 using Nautilus.Utility;
 using UnityEngine;
@@ -7,7 +7,7 @@ using UWE;
 namespace Nautilus.Handlers;
 
 /// <summary>
-/// A handler for the WorldEntityDatabase of the game.
+/// A handler class for the <see cref="WorldEntityDatabase"/>. This class is essential for the game's Loot Distribution System to work properly.
 /// </summary>
 public static class WorldEntityDatabaseHandler
 {

--- a/Nautilus/Utility/AudioUtils.cs
+++ b/Nautilus/Utility/AudioUtils.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 namespace Nautilus.Utility;
 
 /// <summary>
-/// Utilities for audio and sound
+/// Utilities pertaining to the use and creation of custom <see cref="Sound"/> objects, alongside other audio-specific functionality. Also see the <see cref="Handlers.CustomSoundHandler"/>.
 /// </summary>
 public static partial class AudioUtils
 {

--- a/Nautilus/Utility/BasicText.cs
+++ b/Nautilus/Utility/BasicText.cs
@@ -1,8 +1,14 @@
-﻿using TMPro;
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
 namespace Nautilus.Utility;
+
+/* [this message was moved out of the XML docs because it was absurdly long and out of place]
+ * The idea of the defaults is that new modders don't have to bootstrap a bunch of irritating Unity stuff -- don't have to understand
+ * what a "Material" is or how to make one, don't have to know to initialize a font, or even a color. Can just start adding text and
+ * then can always custom and configure on further revision.
+*/
 
 /// <summary>
 /// <para>
@@ -10,18 +16,16 @@ namespace Nautilus.Utility;
 /// By default uses the same font/size/color as the "Press Any Button To Begin" message at the beginning of the game, and appears 
 /// centered about 1/3 down the screen, but all parameters can be reconfigured.
 /// </para>
-/// <para>
-/// The idea of the defaults is that new modders don't have to bootstrap a bunch of irritating Unity stuff -- don't have to understand
-/// what a "Material" is or how to make one, don't have to know to initialize a font, or even a color. Can just start adding text and
-/// then can always custom and configure on further revision.
-/// </para>
 /// </summary>
 /// <example>
 /// SIMPLE USAGE EXAMPLE:
+/// <code>
 /// BasicText message = new BasicText();
 /// message.ShowMessage("This Message Will Fade In 10 Seconds", 10);
+/// </code>
 /// 
 /// COMPLEX USAGE EXAMPLE:
+/// <code>
 /// BasicText message = new BasicText(TextAnchor.UpperLeft); // Note many other properties could also be set as constructor parameters
 /// message.setColor(Color.red); // Set Color
 /// message.setSize(20);         // Set Font Size
@@ -30,6 +34,7 @@ namespace Nautilus.Utility;
 /// message.ShowMessage("This message stays on screen until hidden"); // Display message; if fadeout seconds not specified, it just keeps showing
 /// ... // other things happen, time goes by
 /// message.Hide(); // Hides the message
+/// </code>
 /// </example>
 public class BasicText
 {

--- a/Nautilus/Utility/IOUtilities.cs
+++ b/Nautilus/Utility/IOUtilities.cs
@@ -1,9 +1,9 @@
-﻿using System.IO;
+using System.IO;
 
 namespace Nautilus.Utility;
 
 /// <summary>
-/// Utilities for files and paths
+/// Utilities for files and paths.
 /// </summary>
 public static class IOUtilities
 {

--- a/Nautilus/Utility/ItemStorageHelper.cs
+++ b/Nautilus/Utility/ItemStorageHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Nautilus.Utility;
 

--- a/Nautilus/Utility/MaterialUtils.cs
+++ b/Nautilus/Utility/MaterialUtils.cs
@@ -1,4 +1,4 @@
-﻿using Nautilus.Utility.MaterialModifiers;
+using Nautilus.Utility.MaterialModifiers;
 using UnityEngine;
 
 namespace Nautilus.Utility;
@@ -18,7 +18,7 @@ public static partial class MaterialUtils
     }
     
     /// <summary>
-    /// Contains references to various shaders.
+    /// Contains references to various Shaders.
     /// </summary>
     public static class Shaders
     {

--- a/Nautilus/Utility/SelfCheckingDictionary.cs
+++ b/Nautilus/Utility/SelfCheckingDictionary.cs
@@ -1,12 +1,12 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
 namespace Nautilus.Utility;
 
 /// <summary>
-/// This dictionary strtucture automatically checks for duplicate keys as they are being added to the collection.
-/// Duplicate entires are logged and removed from the final collection.
+/// This dictionary structure automatically checks for duplicate keys as they are being added to the collection.
+/// Duplicate entries are logged and removed from the final collection.
 /// </summary>
 /// <typeparam name="K">The Key Type</typeparam>
 /// <typeparam name="V">The Value Type</typeparam>

--- a/Nautilus/Utility/StorageHelperExtensions.cs
+++ b/Nautilus/Utility/StorageHelperExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Nautilus.Utility;
 


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed grammatical errors.
  - Shortened absurdly long docs.
  - Fixed weird inconsistencies in wording & punctuation between class docs.
  - Fixed the broken example in the BasicText class docs.
  - Added references to related classes when applicable.
  - Updated docs for classes that have had changes in purpose over time (e.g. PDAHandler).