### PR TITLE
Prerelease suffix

### DIFF
--- a/Version.targets
+++ b/Version.targets
@@ -3,5 +3,6 @@
     <PropertyGroup>
         <!-- The assembly uses this version number. !-->
         <VersionPrefix>1.0.0</VersionPrefix>
+        <VersionSuffix>pre.7</VersionSuffix>
     </PropertyGroup>
 </Project>

--- a/Version.targets
+++ b/Version.targets
@@ -3,6 +3,6 @@
     <PropertyGroup>
         <!-- The assembly uses this version number. !-->
         <VersionPrefix>1.0.0</VersionPrefix>
-        <VersionSuffix>pre.7</VersionSuffix>
+        <VersionSuffix>pre.6</VersionSuffix>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Changes made in this pull request

  - `<VersionSuffix>pre.{version number}</VersionSuffix>` for nuget package/assembly during pre-release stage (remove later)