### PR TITLE
Don't patch option tab headers if SMLHelper exists

### DIFF
--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -25,7 +25,10 @@ internal class OptionsPanelPatcher
     {
         harmony.PatchAll(typeof(OptionsPanelPatcher));
         harmony.PatchAll(typeof(ScrollPosKeeper));
-        harmony.PatchAll(typeof(ModOptionsHeadingsToggle));
+        if (!BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey("com.ahk1221.smlhelper"))
+        {
+            harmony.PatchAll(typeof(ModOptionsHeadingsToggle));
+        }
     }
 
 


### PR DESCRIPTION
### Changes made in this pull request

Addresses https://github.com/SubnauticaModding/Nautilus/issues/314

  - Check if SMLHelper exists and if so don't patch the same thing twice