### PR TITLE
Rename documentation pages

### DIFF
--- a/Nautilus/Documentation/tutorials/overview.md
+++ b/Nautilus/Documentation/tutorials/overview.md
@@ -5,7 +5,7 @@ This section covers step-by-step tutorials on how to get some of the useful feat
 ## Sections
 
 ### Adding Content
-* [Spawns](spawns.md)  
+* [Spawning objects in the world](spawns.md)  
 * [Custom Console Commands](console-commands.md)
 * [Story Goals](story-goals.md)
 * [Databank Entries](databank-entries.md)

--- a/Nautilus/Documentation/tutorials/overview.md
+++ b/Nautilus/Documentation/tutorials/overview.md
@@ -6,18 +6,18 @@ This section covers step-by-step tutorials on how to get some of the useful feat
 
 ### Adding Content
 * [Spawning objects in the world](spawns.md)  
-* [Custom Console Commands](console-commands.md)
-* [Story Goals](story-goals.md)
-* [Databank Entries](databank-entries.md)
+* [Custom console commands](console-commands.md)
+* [Story goals](story-goals.md)
+* [Databank entries](databank-entries.md)
 * TODO: [Audio (FMOD)](https://www.youtube.com/watch?v=dQw4w9WgXcQ)
 
 
 ### Editing Content
-* [Background Type](background-type.md)
-* [Equipment Type](equipment-type.md)
-* [Crafting Recipes](crafting-recipes.md)
+* [Background type](background-type.md)
+* [Equipment type](equipment-type.md)
+* [Crafting recipes](crafting-recipes.md)
 
 
 ### Utilities
 * [Localization](localization.md)
-* [In-Game Options](options.md)
+* [In-Game options](options.md)

--- a/Nautilus/Documentation/tutorials/toc.yml
+++ b/Nautilus/Documentation/tutorials/toc.yml
@@ -5,27 +5,27 @@
   items:
     - name: Spawning objects in the world
       href: spawns.md
-    - name: Custom Console Commands
+    - name: Custom console commands
       href: console-commands.md
-    - name: Story Goals
+    - name: Story goals
       href: story-goals.md
-    - name: Databank Entries
+    - name: Databank entries
       href: databank-entries.md
     
 - name: Editing Content
   items:
-    - name: Background Type
+    - name: Background type
       href: background-type.md
-    - name: Equipment Type
+    - name: Equipment type
       href: equipment-type.md
-    - name: Crafting Recipes
+    - name: Crafting recipes
       href: crafting-recipes.md
   
 - name: Utilities
   items:
     - name: Localization
       href: localization.md
-    - name: In-Game Options
+    - name: In-Game options
       href: options.md
   
     

--- a/Nautilus/Documentation/tutorials/toc.yml
+++ b/Nautilus/Documentation/tutorials/toc.yml
@@ -3,7 +3,7 @@
   
 - name: Adding Content
   items:
-    - name: Spawns
+    - name: Spawning objects in the world
       href: spawns.md
     - name: Custom Console Commands
       href: console-commands.md


### PR DESCRIPTION
### Changes made in this pull request

  - More consistent capitalization & disallow one-word titles
  - Looks more "cozy" now

Before and after pics shown below:
![image](https://github.com/SubnauticaModding/Nautilus/assets/31892011/1d1be326-1203-4943-886a-509796424c36)
![image](https://github.com/SubnauticaModding/Nautilus/assets/31892011/0914fb54-197a-492a-9301-d35be302fa4d)
