### PR TITLE
Addressed missing/unimplimented options in BepInEx ConfigEntry extensions

### DIFF
--- a/Nautilus/Options/ConfigEntryExtensions.cs
+++ b/Nautilus/Options/ConfigEntryExtensions.cs
@@ -254,7 +254,7 @@ public static class ConfigEntryExtensions
         T[] viableValues = options?.ToArray<T>() ?? (T[])Enum.GetValues(typeof(T));
 
         ModChoiceOption<T> optionItem = ModChoiceOption<T>.Create($"{configEntry.Definition.Section}_{configEntry.Definition.Key}",
-            configEntry.Definition.Key, viableValues, (T)configEntry.DefaultValue ?? configEntry.Value ?? viableValues[0], tooltip: configEntry.Description.Description);
+            configEntry.Definition.Key, viableValues, configEntry.Value ?? (T)configEntry.DefaultValue ?? viableValues[0], tooltip: configEntry.Description.Description);
         optionItem.OnChanged += (_, e) =>
         {
             configEntry.Value = (T)Enum.Parse(typeof(T), e.Value.ToString());
@@ -281,7 +281,7 @@ public static class ConfigEntryExtensions
             throw new ArgumentException("Could not get values from ConfigEntry");
 
         optionItem = ModChoiceOption<T>.Create($"{configEntry.Definition.Section}_{configEntry.Definition.Key}",
-            configEntry.Definition.Key, options, (T)configEntry.DefaultValue ?? configEntry.Value ?? options[0], tooltip: configEntry.Description.Description);
+            configEntry.Definition.Key, options, configEntry.Value ?? (T) configEntry.DefaultValue ?? options[0], tooltip: configEntry.Description.Description);
 
         optionItem.OnChanged += (_, e) =>
         {

--- a/Nautilus/Options/ConfigEntryExtensions.cs
+++ b/Nautilus/Options/ConfigEntryExtensions.cs
@@ -233,7 +233,7 @@ public static class ConfigEntryExtensions
     public static ModKeybindOption ToModKeybindOption(this ConfigEntry<KeyCode> configEntry)
     {
         ModKeybindOption optionItem = ModKeybindOption.Create($"{configEntry.Definition.Section}_{configEntry.Definition.Key}",
-            configEntry.Definition.Key, GameInput.GetPrimaryDevice(), configEntry.Value, configEntry.Description.Description);
+            configEntry.Definition.Key, GameInput.GetPrimaryDevice(), configEntry.Value, tooltip: configEntry.Description.Description);
         optionItem.OnChanged += (_, e) =>
         {
             configEntry.Value = e.Value;
@@ -253,7 +253,7 @@ public static class ConfigEntryExtensions
         T[] viableValues = options?.ToArray<T>() ?? (T[])Enum.GetValues(typeof(T));
 
         ModChoiceOption<T> optionItem = ModChoiceOption<T>.Create($"{configEntry.Definition.Section}_{configEntry.Definition.Key}",
-            configEntry.Definition.Key, viableValues, configEntry.Value, configEntry.Description.Description);
+            configEntry.Definition.Key, viableValues, configEntry.Value, tooltip: configEntry.Description.Description);
         optionItem.OnChanged += (_, e) =>
         {
             configEntry.Value = (T)Enum.Parse(typeof(T), e.Value.ToString());
@@ -280,7 +280,7 @@ public static class ConfigEntryExtensions
             throw new ArgumentException("Could not get values from ConfigEntry");
 
         optionItem = ModChoiceOption<T>.Create($"{configEntry.Definition.Section}_{configEntry.Definition.Key}",
-            configEntry.Definition.Key, options, (T)configEntry.DefaultValue ?? options[0], configEntry.Description.Description);
+            configEntry.Definition.Key, options, (T)configEntry.DefaultValue ?? options[0], tooltip: configEntry.Description.Description);
 
         optionItem.OnChanged += (_, e) =>
         {

--- a/Nautilus/Options/ConfigEntryExtensions.cs
+++ b/Nautilus/Options/ConfigEntryExtensions.cs
@@ -214,7 +214,7 @@ public static class ConfigEntryExtensions
     /// <param name="configEntry">A bepinex config entry</param>
     /// <param name="basic">Whether to use the basic or advanced color picker</param>
     /// <returns><see cref="ModColorOption"/></returns>
-    public static ModColorOption ToModColorOptions(this ConfigEntry<Color> configEntry, bool basic = false)
+    public static ModColorOption ToModColorOption(this ConfigEntry<Color> configEntry, bool basic = false)
     {
         ModColorOption optionItem = ModColorOption.Create($"{configEntry.Definition.Section}_{configEntry.Definition.Key}",
             configEntry.Definition.Key, configEntry.Value, basic, tooltip: configEntry.Description.Description);

--- a/Nautilus/Options/ConfigEntryExtensions.cs
+++ b/Nautilus/Options/ConfigEntryExtensions.cs
@@ -217,7 +217,7 @@ public static class ConfigEntryExtensions
     public static ModColorOption ToModColorOption(this ConfigEntry<Color> configEntry, bool basic = false)
     {
         ModColorOption optionItem = ModColorOption.Create($"{configEntry.Definition.Section}_{configEntry.Definition.Key}",
-            configEntry.Definition.Key, configEntry.Value, basic, tooltip: configEntry.Description.Description);
+            configEntry.Definition.Key, configEntry.Value, advanced: !basic, tooltip: configEntry.Description.Description);
         optionItem.OnChanged += (_, e) =>
         {
             configEntry.Value = e.Value;

--- a/Nautilus/Options/ConfigEntryExtensions.cs
+++ b/Nautilus/Options/ConfigEntryExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using BepInEx.Configuration;
@@ -213,11 +213,11 @@ public static class ConfigEntryExtensions
     /// </summary>
     /// <param name="configEntry">A bepinex config entry</param>
     /// <param name="basic">Whether to use the basic or advanced color picker</param>
-    /// <returns><see cref="ModSliderOption"/></returns>
-    public static ModColorOption ToModSliderOptions(this ConfigEntry<Color> configEntry, bool basic = false)
+    /// <returns><see cref="ModColorOption"/></returns>
+    public static ModColorOption ToModColorOptions(this ConfigEntry<Color> configEntry, bool basic = false)
     {
         ModColorOption optionItem = ModColorOption.Create($"{configEntry.Definition.Section}_{configEntry.Definition.Key}",
-            configEntry.Definition.Key, configEntry.Value, basic);
+            configEntry.Definition.Key, configEntry.Value, basic, tooltip: configEntry.Description.Description);
         optionItem.OnChanged += (_, e) =>
         {
             configEntry.Value = e.Value;

--- a/Nautilus/Options/ConfigEntryExtensions.cs
+++ b/Nautilus/Options/ConfigEntryExtensions.cs
@@ -254,7 +254,7 @@ public static class ConfigEntryExtensions
         T[] viableValues = options?.ToArray<T>() ?? (T[])Enum.GetValues(typeof(T));
 
         ModChoiceOption<T> optionItem = ModChoiceOption<T>.Create($"{configEntry.Definition.Section}_{configEntry.Definition.Key}",
-            configEntry.Definition.Key, viableValues, configEntry.Value, tooltip: configEntry.Description.Description);
+            configEntry.Definition.Key, viableValues, (T)configEntry.DefaultValue ?? configEntry.Value ?? viableValues[0], tooltip: configEntry.Description.Description);
         optionItem.OnChanged += (_, e) =>
         {
             configEntry.Value = (T)Enum.Parse(typeof(T), e.Value.ToString());
@@ -281,7 +281,7 @@ public static class ConfigEntryExtensions
             throw new ArgumentException("Could not get values from ConfigEntry");
 
         optionItem = ModChoiceOption<T>.Create($"{configEntry.Definition.Section}_{configEntry.Definition.Key}",
-            configEntry.Definition.Key, options, (T)configEntry.DefaultValue ?? options[0], tooltip: configEntry.Description.Description);
+            configEntry.Definition.Key, options, (T)configEntry.DefaultValue ?? configEntry.Value ?? options[0], tooltip: configEntry.Description.Description);
 
         optionItem.OnChanged += (_, e) =>
         {

--- a/Nautilus/Options/ConfigEntryExtensions.cs
+++ b/Nautilus/Options/ConfigEntryExtensions.cs
@@ -233,7 +233,7 @@ public static class ConfigEntryExtensions
     public static ModKeybindOption ToModKeybindOption(this ConfigEntry<KeyCode> configEntry)
     {
         ModKeybindOption optionItem = ModKeybindOption.Create($"{configEntry.Definition.Section}_{configEntry.Definition.Key}",
-            configEntry.Definition.Key, GameInput.GetPrimaryDevice(), configEntry.Value);
+            configEntry.Definition.Key, GameInput.GetPrimaryDevice(), configEntry.Value, configEntry.Description.Description);
         optionItem.OnChanged += (_, e) =>
         {
             configEntry.Value = e.Value;

--- a/Nautilus/Options/ConfigEntryExtensions.cs
+++ b/Nautilus/Options/ConfigEntryExtensions.cs
@@ -213,6 +213,7 @@ public static class ConfigEntryExtensions
     /// </summary>
     /// <param name="configEntry">A bepinex config entry</param>
     /// <param name="basic">Whether to use the basic or advanced color picker</param>
+    /// <remarks>Does not support use of <see cref="AcceptableValueList{T}"/>.</remarks>
     /// <returns><see cref="ModColorOption"/></returns>
     public static ModColorOption ToModColorOption(this ConfigEntry<Color> configEntry, bool basic = false)
     {

--- a/Nautilus/Options/ConfigEntryExtensions.cs
+++ b/Nautilus/Options/ConfigEntryExtensions.cs
@@ -253,7 +253,7 @@ public static class ConfigEntryExtensions
         T[] viableValues = options?.ToArray<T>() ?? (T[])Enum.GetValues(typeof(T));
 
         ModChoiceOption<T> optionItem = ModChoiceOption<T>.Create($"{configEntry.Definition.Section}_{configEntry.Definition.Key}",
-            configEntry.Definition.Key, viableValues, configEntry.Value);
+            configEntry.Definition.Key, viableValues, configEntry.Value, configEntry.Description.Description);
         optionItem.OnChanged += (_, e) =>
         {
             configEntry.Value = (T)Enum.Parse(typeof(T), e.Value.ToString());
@@ -280,7 +280,7 @@ public static class ConfigEntryExtensions
             throw new ArgumentException("Could not get values from ConfigEntry");
 
         optionItem = ModChoiceOption<T>.Create($"{configEntry.Definition.Section}_{configEntry.Definition.Key}",
-            configEntry.Definition.Key, options, (T)configEntry.DefaultValue ?? options[0]);
+            configEntry.Definition.Key, options, (T)configEntry.DefaultValue ?? options[0], configEntry.Description.Description);
 
         optionItem.OnChanged += (_, e) =>
         {

--- a/Nautilus/Options/ModChoiceOption.cs
+++ b/Nautilus/Options/ModChoiceOption.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Nautilus.Options.Utility;
@@ -83,7 +83,10 @@ public class ModChoiceOption<T> : ModOption<T, ChoiceChangedEventArgs<T>>
         List<string> optionStrings = new List<string>();
         foreach(var option in options)
         {
-            optionStrings.Add(option.ToString());
+            if (option is Color color)
+                optionStrings.Add($"<color=#{ColorUtility.ToHtmlStringRGBA(color)}>{color}</color>");
+            else
+                optionStrings.Add(option.ToString());
         }
         OptionStrings = optionStrings.ToArray();
         Index = index;

--- a/Nautilus/Options/ModColorOption.cs
+++ b/Nautilus/Options/ModColorOption.cs
@@ -46,6 +46,9 @@ public class ModColorOption : ModOption<Color, ColorChangedEventArgs>
 
         GameObject colorPicker = panel.AddColorOption(tabIndex, Label, Value, callback);
 
+        // Add tooltip
+        colorPicker.transform.Find("Choice").gameObject.EnsureComponent<MenuTooltip>().key = Tooltip;
+
         if (Advanced)
         {
             UnityEngine.Object.Destroy(colorPicker.transform.Find("Choice/Background/ButtonLeft").gameObject);
@@ -58,7 +61,7 @@ public class ModColorOption : ModOption<Color, ColorChangedEventArgs>
                     OnChange(Id, color);
                     parentOptions.OnChange<Color, ColorChangedEventArgs>(Id, color);
                 }),
-                SliderLabelMode.Percent, "{0:F0}", tooltip: Tooltip);
+                SliderLabelMode.Percent, "{0:F0}", "The <color=\"red\">red</color> level of the color.");
 
             GameObject greenSlider = panel.AddSliderOption(tabIndex, "Green", Value.g, 0, 1, 0, 0.01f,
                 new UnityAction<float>((float value) => {
@@ -67,7 +70,7 @@ public class ModColorOption : ModOption<Color, ColorChangedEventArgs>
                     OnChange(Id, color);
                     parentOptions.OnChange<Color, ColorChangedEventArgs>(Id, color);
                 }),
-                SliderLabelMode.Percent, "{0:F0}", tooltip: Tooltip);
+                SliderLabelMode.Percent, "{0:F0}", "The <color=\"green\">green</color> level of the color.");
 
             GameObject blueSlider = panel.AddSliderOption(tabIndex, "Blue", Value.b, 0, 1, 0, 0.01f,
                 new UnityAction<float>((float value) => {
@@ -76,7 +79,7 @@ public class ModColorOption : ModOption<Color, ColorChangedEventArgs>
                     OnChange(Id, color);
                     parentOptions.OnChange<Color, ColorChangedEventArgs>(Id, color);
                 }),
-                SliderLabelMode.Percent, "{0:F0}", tooltip: Tooltip);
+                SliderLabelMode.Percent, "{0:F0}", "The <color=\"blue\">blue</color> level of the color.");
 
             GameObject alphaSlider = panel.AddSliderOption(tabIndex, "Alpha", Value.a, 0, 1, 1, 0.01f,
                 new UnityAction<float>((float value) => {
@@ -85,7 +88,7 @@ public class ModColorOption : ModOption<Color, ColorChangedEventArgs>
                     OnChange(Id, color);
                     parentOptions.OnChange<Color, ColorChangedEventArgs>(Id, color);
                 }),
-                SliderLabelMode.Percent, "{0:F0}", tooltip: Tooltip);
+                SliderLabelMode.Percent, "{0:F0}", "The opaqueness of the color. The lower the value the more transparent.");
         }
 
         OptionGameObject = colorPicker.transform.parent.gameObject;

--- a/Nautilus/Options/ModColorOption.cs
+++ b/Nautilus/Options/ModColorOption.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -28,6 +28,11 @@ public class ModColorOption : ModOption<Color, ColorChangedEventArgs>
     public bool Advanced { get; set; }
 
     /// <summary>
+    /// The tooltip to show when hovering over the option's items.
+    /// </summary>
+    public string Tooltip { get; }
+
+    /// <summary>
     /// The base method for adding an object to the options panel
     /// </summary>
     /// <param name="panel">The panel to add the option to.</param>
@@ -53,7 +58,7 @@ public class ModColorOption : ModOption<Color, ColorChangedEventArgs>
                     OnChange(Id, color);
                     parentOptions.OnChange<Color, ColorChangedEventArgs>(Id, color);
                 }),
-                SliderLabelMode.Percent, "{0:F0}");
+                SliderLabelMode.Percent, "{0:F0}", tooltip: Tooltip);
 
             GameObject greenSlider = panel.AddSliderOption(tabIndex, "Green", Value.g, 0, 1, 0, 0.01f,
                 new UnityAction<float>((float value) => {
@@ -62,7 +67,7 @@ public class ModColorOption : ModOption<Color, ColorChangedEventArgs>
                     OnChange(Id, color);
                     parentOptions.OnChange<Color, ColorChangedEventArgs>(Id, color);
                 }),
-                SliderLabelMode.Percent, "{0:F0}");
+                SliderLabelMode.Percent, "{0:F0}", tooltip: Tooltip);
 
             GameObject blueSlider = panel.AddSliderOption(tabIndex, "Blue", Value.b, 0, 1, 0, 0.01f,
                 new UnityAction<float>((float value) => {
@@ -71,7 +76,7 @@ public class ModColorOption : ModOption<Color, ColorChangedEventArgs>
                     OnChange(Id, color);
                     parentOptions.OnChange<Color, ColorChangedEventArgs>(Id, color);
                 }),
-                SliderLabelMode.Percent, "{0:F0}");
+                SliderLabelMode.Percent, "{0:F0}", tooltip: Tooltip);
 
             GameObject alphaSlider = panel.AddSliderOption(tabIndex, "Alpha", Value.a, 0, 1, 1, 0.01f,
                 new UnityAction<float>((float value) => {
@@ -80,16 +85,17 @@ public class ModColorOption : ModOption<Color, ColorChangedEventArgs>
                     OnChange(Id, color);
                     parentOptions.OnChange<Color, ColorChangedEventArgs>(Id, color);
                 }),
-                SliderLabelMode.Percent, "{0:F0}", tooltip: "Opaqueness. The lower the value the more transparent.");
+                SliderLabelMode.Percent, "{0:F0}", tooltip: Tooltip);
         }
 
         OptionGameObject = colorPicker.transform.parent.gameObject;
         base.AddToPanel(panel, tabIndex);
     }
 
-    private ModColorOption(string id, string label, Color value, bool advanced = false) : base(label, id, value)
+    private ModColorOption(string id, string label, Color value, bool advanced = false, string tooltip = null) : base(label, id, value)
     {
         Advanced = advanced;
+        Tooltip= tooltip;
     }
 
     /// <summary>
@@ -99,9 +105,10 @@ public class ModColorOption : ModOption<Color, ColorChangedEventArgs>
     /// <param name="label">The display text to use in the in-game menu.</param>
     /// <param name="value">The starting value.</param>
     /// <param name="advanced">Whether to use an advanced display.</param>
-    public static ModColorOption Create(string id, string label, Color value, bool advanced = false)
+    /// <param name="tooltip">The tooltip to show when hovering over the options.</param>
+    public static ModColorOption Create(string id, string label, Color value, bool advanced = false, string tooltip = null)
     {
-        return new ModColorOption(id, label, value, advanced);
+        return new ModColorOption(id, label, value, advanced, tooltip);
     }
 
     /// <summary>

--- a/Nautilus/Options/ModKeybindOption.cs
+++ b/Nautilus/Options/ModKeybindOption.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using Nautilus.Utility;
 using TMPro;
@@ -29,9 +29,15 @@ public class ModKeybindOption : ModOption<KeyCode, KeybindChangedEventArgs>
     /// </summary>
     public GameInput.Device Device { get; }
 
-    private ModKeybindOption(string id, string label, GameInput.Device device, KeyCode key) : base(label, id, key)
+    /// <summary>
+    /// The tooltip to show when hovering over the option.
+    /// </summary>
+    public string Tooltip { get; }
+
+    private ModKeybindOption(string id, string label, GameInput.Device device, KeyCode key, string tooltip) : base(label, id, key)
     {
         Device = device;
+        Tooltip = tooltip;
     }
 
     /// <summary>
@@ -41,9 +47,10 @@ public class ModKeybindOption : ModOption<KeyCode, KeybindChangedEventArgs>
     /// <param name="label">The display text to use in the in-game menu.</param>
     /// <param name="device">The device name.</param>
     /// <param name="key">The starting keybind value.</param>
-    public static ModKeybindOption Create(string id, string label, GameInput.Device device, KeyCode key)
+    /// /// <param name="tooltip">The tooltip to show when hovering over the option.</param>
+    public static ModKeybindOption Create(string id, string label, GameInput.Device device, KeyCode key, string tooltip = null)
     {
-        return new ModKeybindOption(id, label, device, key);
+        return new ModKeybindOption(id, label, device, key, tooltip);
     }
     /// <summary>
     /// Creates a new <see cref="ModKeybindOption"/> for handling an option that is a keybind.
@@ -52,9 +59,10 @@ public class ModKeybindOption : ModOption<KeyCode, KeybindChangedEventArgs>
     /// <param name="label">The display text to use in the in-game menu.</param>
     /// <param name="device">The device name.</param>
     /// <param name="key">The starting keybind value.</param>
-    public static ModKeybindOption Create(string id, string label, GameInput.Device device, string key)
+    /// /// <param name="tooltip">The tooltip to show when hovering over the option.</param>
+    public static ModKeybindOption Create(string id, string label, GameInput.Device device, string key, string tooltip = null)
     {
-        return Create(id, label, device, KeyCodeUtils.StringToKeyCode(key));
+        return Create(id, label, device, KeyCodeUtils.StringToKeyCode(key), tooltip);
     }
 
     /// <summary>
@@ -74,6 +82,10 @@ public class ModKeybindOption : ModOption<KeyCode, KeybindChangedEventArgs>
             OptionGameObject.GetComponentInChildren<TranslationLiveUpdate>().translationKey = Label;
             text.text = Language.main.Get(Label);
         }
+
+        // Add tooltip
+        MenuTooltip tooltip = OptionGameObject.EnsureComponent<MenuTooltip>();
+        tooltip.key = Tooltip;
 
         // Create bindings
         uGUI_Bindings bindings = OptionGameObject.GetComponentInChildren<uGUI_Bindings>();


### PR DESCRIPTION
### Breaking changes
- `ConfigEntry<Color>.ToModSliderOptions` renamed to `ConfigEntry<Color>.ToModColorOption` for better name accuracy

### Changes made in this pull request

  - Added tooltip to `ModKeybindOption`
  - Added tooltip option to `ConfigEntry<KeyCode>.ToModKeybindOption`
  - Added tooltips to `ModColorOption`
    - Static tooltips on each slider
    - Dynamic tooltip on the color display
  - Added tooltip option to `ConfigEntry<Color>.ToModColorOption`
  - Fixed bug where `ConfigEntry<Color>.ToModColorOption` used the wrong type (basic = true was using advanced)
  - Added tooltip option to `ConfigEntry<T>.ToModChoiceOption`
  - Fixed slight bug where `ConfigEntry<T>.ToModChoiceOption` relied on the DefaultValue then fell back to the first option in some cases. Now it tries Value, then DefaultValue, then the first option
  - Made ModChoiceOptions _**fancy**_ for Color

**Should resolve #317**.

Would appreciate feedback from @RamuneNeptune and @tinyhoot