### PR TITLE
Add DuplicateGadgetException for safety

### DIFF
--- a/Nautilus/Assets/CustomPrefab.cs
+++ b/Nautilus/Assets/CustomPrefab.cs
@@ -46,6 +46,7 @@ public interface ICustomPrefab
     /// <param name="gadget">The gadget to add</param>
     /// <typeparam name="TGadget">Type of the gadget.</typeparam>
     /// <returns>A reference to the added gadget.</returns>
+    /// <exception cref="DuplicateGadgetException">When a Gadget of the given type already exists.</exception>
     TGadget AddGadget<TGadget>(TGadget gadget) where TGadget : Gadget;
 
     /// <summary>
@@ -178,6 +179,8 @@ public class CustomPrefab : ICustomPrefab
     /// <inheritdoc/>
     public TGadget AddGadget<TGadget>(TGadget gadget) where TGadget : Gadget
     {
+        if (_gadgets.ContainsKey(gadget.GetType()))
+            throw new DuplicateGadgetException(string.IsNullOrEmpty(Info.ClassID) ? "Uninitialized" : Info.ClassID, gadget);
         _gadgets[gadget.GetType()] = gadget;
         return gadget;
     }

--- a/Nautilus/Assets/CustomPrefab.cs
+++ b/Nautilus/Assets/CustomPrefab.cs
@@ -41,7 +41,7 @@ public interface ICustomPrefab
     PrefabPostProcessorAsync OnPrefabPostProcess { get; }
     
     /// <summary>
-    /// Adds a gadget to this custom prefab.
+    /// Adds a gadget to this custom prefab. A prefab can only hold one Gadget of any given type.
     /// </summary>
     /// <param name="gadget">The gadget to add</param>
     /// <typeparam name="TGadget">Type of the gadget.</typeparam>

--- a/Nautilus/Assets/Gadgets/DuplicateGadgetException.cs
+++ b/Nautilus/Assets/Gadgets/DuplicateGadgetException.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Nautilus.Assets.Gadgets;
+
+/// <summary>
+/// The exception that is thrown when a <see cref="Gadget"/> is attempted to be added when an existing one of the same type already exists.
+/// </summary>
+public class DuplicateGadgetException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DuplicateGadgetException"/> class with default properties.
+    /// </summary>
+    /// <param name="classId">ClassID of the Prefab, otherwise should be labeled "Uninitialized". For debugging purposes.</param>
+    /// <param name="duplicateGadget">The Gadget that cannot be added.</param>
+    public DuplicateGadgetException(string classId, Gadget duplicateGadget) : base
+        ($"Cannot add Gadget of Type '{duplicateGadget.GetType()}' onto prefab of ClassID '{classId}' because a Gadget already exists on this prefab with the same type! Did you forget to call ICustomPrefab.RemoveGadget<TGadget>()?")
+    {
+
+    }
+}


### PR DESCRIPTION
### Changes made in this pull request

  - Add `DuplicateGadgetException` that is thrown when adding multiple gadgets of the same type without removing one beforehand.

Example of one exception in the log:
```
[Error  : Unity Log] DuplicateGadgetException: Cannot add Gadget of Type 'Nautilus.Assets.Gadgets.ScanningGadget' onto prefab of ClassID 'CopperClone' because a Gadget already exists on this prefab with the same type! Did you forget to call ICustomPrefab.RemoveGadget<TGadget>()?
Stack trace:
Nautilus.Assets.CustomPrefab.AddGadget[TGadget] (TGadget gadget) (at <2d6c53b33c57449cbcd48bf3b63cc3b1>:0)
Nautilus.Examples.CustomPrefabExamples.Awake () (at <136feb4898744685a66659a924b5e09c>:0)
UnityEngine.GameObject:AddComponent(Type)
BepInEx.Bootstrap.Chainloader:Start()
UnityEngine.Application:.cctor()
UWE.GameApplication:AppAwake()
```