### PR TITLE
Always save command history when Nautilus is enabled

### DIFF
--- a/Nautilus/Patchers/ConsoleCommandsPatcher.cs
+++ b/Nautilus/Patchers/ConsoleCommandsPatcher.cs
@@ -120,6 +120,17 @@ internal static class ConsoleCommandsPatcher
     }
 
     /// <summary>
+    /// Forces history to always be saved in the command line, regardless of whether it was successful or not.
+    /// </summary>
+    /// <param name="__result"></param>
+    [HarmonyPatch(typeof(DevConsole), nameof(DevConsole.OnSubmit))]
+    [HarmonyPostfix]
+    private static void DevConsole_OnSubmit_Postfix(out bool __result)
+    {
+        __result = true;
+    }
+
+    /// <summary>
     /// Attempts to handle a user command.
     /// </summary>
     /// <param name="input">The command input.</param>


### PR DESCRIPTION
### Changes made in this pull request

  - Command history is now always saved even if the command entered was invalid.
  - Fixes compatibility issues with SMLHelper command history & allows for easier compensation after making minor typos.
 
Resolves #332.