### PR TITLE
Fixed Choice options not saving for ConfigFile instances

### DIFF
--- a/Nautilus/Options/Attributes/ConfigFileMetadata.cs
+++ b/Nautilus/Options/Attributes/ConfigFileMetadata.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -364,7 +364,7 @@ internal class ConfigFileMetadata<T> where T : ConfigFile, new()
     /// </summary>
     /// <param name="sender">The sender of the original choice changed event.</param>
     /// <param name="e">The <see cref="ChoiceChangedEventArgs{T}"/> for the choice changed event.</param>
-    public void HandleChoiceChanged(object sender, ChoiceChangedEventArgs<T> e)
+    public void HandleChoiceChanged<Any>(object sender, ChoiceChangedEventArgs<Any> e)
     {
         if (TryGetMetadata(e.Id, out ModOptionAttributeMetadata<T> modOptionMetadata))
         {

--- a/Nautilus/Options/Attributes/OptionsMenuBuilder.cs
+++ b/Nautilus/Options/Attributes/OptionsMenuBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -69,30 +69,27 @@ internal class OptionsMenuBuilder<T> : ModOptions where T : ConfigFile, new()
 
     private void RouteEventHandler(object sender, EventArgs e)
     {
-        switch (e)
+        if (e is ButtonClickedEventArgs buttonClickedEventArgs)
+            ConfigFileMetadata.HandleButtonClick(sender, buttonClickedEventArgs);
+        else if (e.GetType().IsGenericType && e.GetType().GetGenericTypeDefinition() == typeof(ChoiceChangedEventArgs<>))
         {
-            case ButtonClickedEventArgs buttonClickedEventArgs:
-                ConfigFileMetadata.HandleButtonClick(sender, buttonClickedEventArgs);
-                break;
-            case ChoiceChangedEventArgs<T> choiceChangedEventArgs:
-                ConfigFileMetadata.HandleChoiceChanged(sender, choiceChangedEventArgs);
-                break;
-            case ColorChangedEventArgs colorChangedEventArgs:
-                ConfigFileMetadata.HandleColorChanged(sender, colorChangedEventArgs);
-                break;
-            case KeybindChangedEventArgs keybindChangedEventArgs:
-                ConfigFileMetadata.HandleKeybindChanged(sender, keybindChangedEventArgs);
-                break;
-            case SliderChangedEventArgs sliderChangedEventArgs:
-                ConfigFileMetadata.HandleSliderChanged(sender, sliderChangedEventArgs);
-                break;
-            case ToggleChangedEventArgs toggleChangedEventArgs:
-                ConfigFileMetadata.HandleToggleChanged(sender, toggleChangedEventArgs);
-                break;
-            case GameObjectCreatedEventArgs gameObjectCreatedEventArgs:
-                ConfigFileMetadata.HandleGameObjectCreated(sender, gameObjectCreatedEventArgs);
-                break;
+            var genericParam = e.GetType().GetGenericArguments()[0];
+            var genericType = typeof(ChoiceChangedEventArgs<>).MakeGenericType(genericParam);
+            var typedEvent = Convert.ChangeType(e, genericType);
+            var methodInfo = ConfigFileMetadata.GetType().GetMethod(nameof(ConfigFileMetadata.HandleChoiceChanged));
+            var typedMethod = methodInfo.MakeGenericMethod(genericParam);
+            typedMethod.Invoke(ConfigFileMetadata, new object[] { sender, typedEvent });
         }
+        else if (e is ColorChangedEventArgs colorChangedEventArgs)
+            ConfigFileMetadata.HandleColorChanged(sender, colorChangedEventArgs);
+        else if (e is KeybindChangedEventArgs keybindChangedEventArgs)
+            ConfigFileMetadata.HandleKeybindChanged(sender, keybindChangedEventArgs);
+        else if (e is SliderChangedEventArgs sliderChangedEventArgs)
+            ConfigFileMetadata.HandleSliderChanged(sender, sliderChangedEventArgs);
+        else if (e is ToggleChangedEventArgs toggleChangedEventArgs)
+            ConfigFileMetadata.HandleToggleChanged(sender, toggleChangedEventArgs);
+        else if (e is GameObjectCreatedEventArgs gameObjectCreatedEventArgs)
+            ConfigFileMetadata.HandleGameObjectCreated(sender, gameObjectCreatedEventArgs);
     }
 
     #region Build ModOptions Menu


### PR DESCRIPTION
### Breaking changes
- None

### Changes made in this pull request

  - Fixed `ConfigFileMetadata.HandleChoiceChanged` to properly take any `ChoiceChangedEventArgs<>` type rather than a `<T>` which is defined at the class level elsewhere
  - Fixed event routing not recognizing `ChoiceChangedEventArgs` since the generic type param 

**Should resolve #316** if I'm understanding the issue correctly.

### PLEASE TEST, I finished this at 1AM and need to sleep

Would appreciate feedback from @MrJumpscare