### PR TITLE
Allow controllers to use options menu

### DIFF
--- a/Nautilus/Options/Attributes/OptionsMenuBuilder.cs
+++ b/Nautilus/Options/Attributes/OptionsMenuBuilder.cs
@@ -245,7 +245,7 @@ internal class OptionsMenuBuilder<T> : ModOptions where T : ConfigFile, new()
     private void BuildModKeybindOption(string id, string label, MemberInfoMetadata<T> memberInfoMetadata)
     {
         KeyCode value = memberInfoMetadata.GetValue<KeyCode>(ConfigFileMetadata.Config);
-        if(!AddItem(ModKeybindOption.Create(id, label, GameInput.Device.Keyboard, value)))
+        if(!AddItem(ModKeybindOption.Create(id, label, GameInput.GetPrimaryDevice(), value)))
             InternalLogger.Warn($"Failed to add ModKeybindOption with id {id} to {Name}");
     }
 

--- a/Nautilus/Options/ModKeybindOption.cs
+++ b/Nautilus/Options/ModKeybindOption.cs
@@ -27,7 +27,7 @@ public class ModKeybindOption : ModOption<KeyCode, KeybindChangedEventArgs>
     /// <summary>
     /// The currently select input source device for the <see cref="ModKeybindOption"/>.
     /// </summary>
-    public GameInput.Device Device { get; }
+    public GameInput.Device Device { get; set; }
 
     /// <summary>
     /// The tooltip to show when hovering over the option.
@@ -38,6 +38,7 @@ public class ModKeybindOption : ModOption<KeyCode, KeybindChangedEventArgs>
     {
         Device = device;
         Tooltip = tooltip;
+        GameInput.OnPrimaryDeviceChanged += () => { Device = GameInput.GetPrimaryDevice(); };
     }
 
     /// <summary>
@@ -98,13 +99,14 @@ public class ModKeybindOption : ModOption<KeyCode, KeybindChangedEventArgs>
 
         // Update bindings
         binding.device = Device;
-        binding.value = KeyCodeUtils.KeyCodeToString(Value);
+        binding.value = KeyCodeUtils.GetDisplayTextForKeyCode(Value);
         binding.gameObject.EnsureComponent<ModBindingTag>();
         binding.bindingSet = GameInput.BindingSet.Primary;
         binding.bindCallback = new Action<GameInput.Device, GameInput.Button, GameInput.BindingSet, string>((_, _1, _2, s) =>
         {
-            binding.value = s;
-            OnChange(Id, KeyCodeUtils.StringToKeyCode(s));
+            var keyCode = KeyCodeUtils.StringToKeyCode(s);
+            binding.value = KeyCodeUtils.GetDisplayTextForKeyCode(keyCode);
+            OnChange(Id, keyCode);
             parentOptions.OnChange<KeyCode, KeybindChangedEventArgs>(Id, KeyCodeUtils.StringToKeyCode(s));
             binding.RefreshValue();
         });

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -167,14 +167,19 @@ internal class OptionsPanelPatcher
             headingPrefab.name = "OptionHeadingToggleable";
             headingPrefab.AddComponent<HeadingToggle>();
 
+            var option = headingPrefab.AddComponent<uGUI_OptionSelection>();
+            option.selectionBackground = Object.Instantiate(panel.toggleOptionPrefab.GetComponentInChildren<uGUI_OptionSelection>(true).selectionBackground);
+            option.selectionBackground.transform.SetParent(headingPrefab.transform);
+            option.hoverSound = AudioUtils.GetFmodAsset("event:/tools/pda/select");
+
             Transform captionTransform = headingPrefab.transform.Find("Caption");
             captionTransform.localPosition = new Vector3(45f, 0f, 0f);
-            captionTransform.gameObject.AddComponent<HeadingClickHandler>();
             captionTransform.gameObject.AddComponent<ContentSizeFitter>().horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
 
             GameObject button = Object.Instantiate(panel.choiceOptionPrefab.transform.Find("Choice/Background/NextButton").gameObject);
             button.name = "HeadingToggleButton";
             button.AddComponent<ToggleButtonClickHandler>();
+            Object.Destroy(button.GetComponent<Button>());
 
             RectTransform buttonTransform = button.transform as RectTransform;
             buttonTransform.SetParent(headingPrefab.transform);
@@ -187,7 +192,7 @@ internal class OptionsPanelPatcher
 
         #region components
         // main component for headings toggling
-        private class HeadingToggle: Selectable
+        private class HeadingToggle: Selectable, IPointerClickHandler
         {
             private HeadingState headingState = HeadingState.Expanded;
             private string headingName = null;
@@ -239,40 +244,39 @@ internal class OptionsPanelPatcher
 
                 StoredHeadingStates.store(headingName, state);
             }
+            
+            public void OnPointerClick(PointerEventData _)
+            {
+                var buttonHandler = GetComponentInChildren<ToggleButtonClickHandler>();
+                if (buttonHandler.isRotating)
+                    return;
+
+                headingState = headingState == HeadingState.Expanded ? HeadingState.Collapsed : HeadingState.Expanded;
+                StartCoroutine(buttonHandler.SetState(headingState));
+
+                SetState(headingState);
+            }
         }
 
-        // click handler for arrow button
-        private class ToggleButtonClickHandler: MonoBehaviour, IPointerClickHandler
+        // change handler for arrow button
+        private class ToggleButtonClickHandler: MonoBehaviour
         {
             private const float timeRotate = 0.1f;
-            private HeadingState headingState = HeadingState.Expanded;
-            private bool isRotating = false;
+            public bool isRotating = false;
 
             public void SetStateInstant(HeadingState state)
             {
-                headingState = state;
-                transform.localEulerAngles = new Vector3(0, 0, headingState == HeadingState.Expanded? -90: 0);
+                transform.localEulerAngles = new Vector3(0, 0, state == HeadingState.Expanded? -90: 0);
             }
 
-            public void OnPointerClick(PointerEventData _)
-            {
-                if (isRotating)
-                {
-                    return;
-                }
-
-                headingState = headingState == HeadingState.Expanded? HeadingState.Collapsed: HeadingState.Expanded;
-                StartCoroutine(SmoothRotate(headingState == HeadingState.Expanded? -90: 90));
-
-                GetComponentInParent<HeadingToggle>()?.SetState(headingState);
-            }
-
-            private IEnumerator SmoothRotate(float angles)
+            internal IEnumerator SetState(HeadingState state)
             {
                 isRotating = true;
 
+                float angle = state == HeadingState.Expanded ? -90 : 90;
+
                 Quaternion startRotation = transform.localRotation;
-                Quaternion endRotation = Quaternion.Euler(new Vector3(0f, 0f, angles)) * startRotation;
+                Quaternion endRotation = Quaternion.Euler(new Vector3(0f, 0f, angle)) * startRotation;
 
                 float timeStart = Time.realtimeSinceStartup; // Time.deltaTime works only in main menu
 
@@ -284,15 +288,6 @@ internal class OptionsPanelPatcher
 
                 transform.localRotation = endRotation;
                 isRotating = false;
-            }
-        }
-
-        // click handler for title, just redirects clicks to button click handler
-        private class HeadingClickHandler: MonoBehaviour, IPointerClickHandler
-        {
-            public void OnPointerClick(PointerEventData eventData)
-            {
-                transform.parent.GetComponentInChildren<ToggleButtonClickHandler>()?.OnPointerClick(eventData);
             }
         }
         #endregion

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -187,7 +187,7 @@ internal class OptionsPanelPatcher
 
         #region components
         // main component for headings toggling
-        private class HeadingToggle: MonoBehaviour
+        private class HeadingToggle: Selectable
         {
             private HeadingState headingState = HeadingState.Expanded;
             private string headingName = null;

--- a/Nautilus/Utility/KeyCodeUtils.cs
+++ b/Nautilus/Utility/KeyCodeUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using BepInEx.Logging;
 using UnityEngine;
 
@@ -67,6 +67,18 @@ public static class KeyCodeUtils
             default:
                 return keyCode.ToString();
         }
+    }
+
+    /// <summary>
+    /// Get the UI display text for KeyCode input using uGUI.buttonCharacters.
+    /// Supports most key inputs, including controller and mouse buttons.
+    /// </summary>
+    /// <param name="keyCode"></param>
+    /// <returns></returns>
+    public static string GetDisplayTextForKeyCode(KeyCode keyCode)
+    {
+        var bindingName = GameInput.GetKeyCodeAsInputName(keyCode);
+        return uGUI.GetDisplayTextForBinding(bindingName);
     }
 
     /// <summary>

--- a/Nautilus/Utility/KeyCodeUtils.cs
+++ b/Nautilus/Utility/KeyCodeUtils.cs
@@ -78,7 +78,10 @@ public static class KeyCodeUtils
     public static string GetDisplayTextForKeyCode(KeyCode keyCode)
     {
         var bindingName = GameInput.GetKeyCodeAsInputName(keyCode);
-        return uGUI.GetDisplayTextForBinding(bindingName);
+        // Translates button names for PS4 and Switch if they're in use
+        // ex) JoystickButtonA -> ControllerButtonPs4Cross
+        var mappedButtonNmaes = GameInput.GetInputName(bindingName);
+        return uGUI.GetDisplayTextForBinding(mappedButtonNmaes);
     }
 
     /// <summary>


### PR DESCRIPTION
1. GameInput is hardcoded to keyboard, changed to use primary device. This updates when the menu is opened. Maybe there's a better spot to attach the device changing so it works while the menu is open
2. Fixed when controller gets stuck on the HeadingToggle since it only has a click handler. Thanks @JKohlman for fixing the selected background and button toggle!
3. Added controller icons for the KeyBind input! this uses uGUI.buttonCharacters internally so theoretically it works with anything in that array


fixes #263, #289