### PR TITLE
Fix AnalysisTech unlock message & sound

### DIFF
--- a/Nautilus/Assets/Gadgets/ScanningGadget.cs
+++ b/Nautilus/Assets/Gadgets/ScanningGadget.cs
@@ -13,7 +13,8 @@ namespace Nautilus.Assets.Gadgets;
 /// </summary>
 public class ScanningGadget : Gadget
 {
-    private const string DefaultUnlockMessage = "NotficationBlueprintUnlocked";
+    private const string DefaultPickupMessage = "NotificationBlueprintPickup";
+    private const string DefaultUnlockMessage = "NotificationBlueprintUnlocked";
 
     private bool _isBuildable;
 
@@ -177,7 +178,7 @@ public class ScanningGadget : Gadget
         List<StoryGoal> storyGoalsToTrigger = null,
 #endif
         FMODAsset unlockSound = null, 
-        string unlockMessage = "NotificationBlueprintUnlocked"
+        string unlockMessage = null
         )
     {
         AnalysisTech ??= new KnownTech.AnalysisTech();
@@ -192,9 +193,7 @@ public class ScanningGadget : Gadget
         AnalysisTech.storyGoals = storyGoalsToTrigger ?? new();
 #endif
         AnalysisTech.unlockSound = unlockSound;
-        AnalysisTech.unlockMessage = unlockMessage == DefaultUnlockMessage
-            ? unlockMessage
-            : $"{prefab.Info.TechType.AsString()}_DiscoverMessage";
+        AnalysisTech.unlockMessage = unlockMessage ?? (RequiredForUnlock == TechType.None ? DefaultUnlockMessage : DefaultPickupMessage);
 
         return this;
     }
@@ -246,11 +245,11 @@ public class ScanningGadget : Gadget
             PDAHandler.AddCustomScannerEntry(ScannerEntryData);
         }
 
-        if (CompoundTechsForUnlock is { Count: > 0 } || RequiredForUnlock is not TechType.None)
+        if (CompoundTechsForUnlock is { Count: > 0 } || RequiredForUnlock != TechType.None)
         {
             if (AnalysisTech is null)
             {
-                KnownTechHandler.SetAnalysisTechEntry(RequiredForUnlock, new[] { prefab.Info.TechType }, DefaultUnlockMessage);
+                KnownTechHandler.SetAnalysisTechEntry(RequiredForUnlock, new[] { prefab.Info.TechType }, RequiredForUnlock == TechType.None ? DefaultUnlockMessage : DefaultPickupMessage);
             }
 
             KnownTechPatcher.UnlockedAtStart.Remove(prefab.Info.TechType);

--- a/Nautilus/Assets/Gadgets/ScanningGadget.cs
+++ b/Nautilus/Assets/Gadgets/ScanningGadget.cs
@@ -13,9 +13,6 @@ namespace Nautilus.Assets.Gadgets;
 /// </summary>
 public class ScanningGadget : Gadget
 {
-    private const string DefaultPickupMessage = KnownTechHandler.DefaultUnlockData.BlueprintPickupMessage;
-    private const string DefaultUnlockMessage = KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage;
-
     private bool _isBuildable;
 
     /// <summary>
@@ -193,7 +190,7 @@ public class ScanningGadget : Gadget
         AnalysisTech.storyGoals = storyGoalsToTrigger ?? new();
 #endif
         AnalysisTech.unlockSound = unlockSound;
-        AnalysisTech.unlockMessage = unlockMessage ?? (RequiredForUnlock == TechType.None ? DefaultUnlockMessage : DefaultPickupMessage);
+        AnalysisTech.unlockMessage = unlockMessage ?? (RequiredForUnlock == TechType.None ? KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage : KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage);
 
         return this;
     }
@@ -249,7 +246,7 @@ public class ScanningGadget : Gadget
         {
             if (AnalysisTech is null)
             {
-                KnownTechHandler.SetAnalysisTechEntry(RequiredForUnlock, new[] { prefab.Info.TechType }, RequiredForUnlock == TechType.None ? DefaultUnlockMessage : DefaultPickupMessage);
+                KnownTechHandler.SetAnalysisTechEntry(RequiredForUnlock, new[] { prefab.Info.TechType }, RequiredForUnlock == TechType.None ? KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage : KnownTechHandler.DefaultUnlockData.BlueprintPickupMessage);;
             }
 
             KnownTechPatcher.UnlockedAtStart.Remove(prefab.Info.TechType);

--- a/Nautilus/Assets/Gadgets/ScanningGadget.cs
+++ b/Nautilus/Assets/Gadgets/ScanningGadget.cs
@@ -13,8 +13,8 @@ namespace Nautilus.Assets.Gadgets;
 /// </summary>
 public class ScanningGadget : Gadget
 {
-    private const string DefaultPickupMessage = "NotificationBlueprintPickup";
-    private const string DefaultUnlockMessage = "NotificationBlueprintUnlocked";
+    private const string DefaultPickupMessage = KnownTechHandler.DefaultUnlockData.BlueprintPickupMessage;
+    private const string DefaultUnlockMessage = KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage;
 
     private bool _isBuildable;
 

--- a/Nautilus/Assets/Gadgets/ScanningGadget.cs
+++ b/Nautilus/Assets/Gadgets/ScanningGadget.cs
@@ -246,7 +246,7 @@ public class ScanningGadget : Gadget
         {
             if (AnalysisTech is null)
             {
-                KnownTechHandler.SetAnalysisTechEntry(RequiredForUnlock, new[] { prefab.Info.TechType }, KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage);
+                KnownTechHandler.SetAnalysisTechEntry(RequiredForUnlock, new[] { prefab.Info.TechType }, KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage, KnownTechHandler.DefaultUnlockData.BlueprintUnlockSound);
             }
 
             KnownTechPatcher.UnlockedAtStart.Remove(prefab.Info.TechType);

--- a/Nautilus/Assets/Gadgets/ScanningGadget.cs
+++ b/Nautilus/Assets/Gadgets/ScanningGadget.cs
@@ -190,7 +190,7 @@ public class ScanningGadget : Gadget
         AnalysisTech.storyGoals = storyGoalsToTrigger ?? new();
 #endif
         AnalysisTech.unlockSound = unlockSound;
-        AnalysisTech.unlockMessage = unlockMessage ?? (RequiredForUnlock == TechType.None ? KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage : KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage);
+        AnalysisTech.unlockMessage = unlockMessage ?? KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage;
 
         return this;
     }
@@ -246,7 +246,7 @@ public class ScanningGadget : Gadget
         {
             if (AnalysisTech is null)
             {
-                KnownTechHandler.SetAnalysisTechEntry(RequiredForUnlock, new[] { prefab.Info.TechType }, RequiredForUnlock == TechType.None ? KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage : KnownTechHandler.DefaultUnlockData.BlueprintPickupMessage);;
+                KnownTechHandler.SetAnalysisTechEntry(RequiredForUnlock, new[] { prefab.Info.TechType }, KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage);
             }
 
             KnownTechPatcher.UnlockedAtStart.Remove(prefab.Info.TechType);

--- a/Nautilus/Handlers/KnownTechHandler.cs
+++ b/Nautilus/Handlers/KnownTechHandler.cs
@@ -315,16 +315,16 @@ public static class KnownTechHandler
     public static class DefaultUnlockData
     {
         /// <summary>Message on unlocking new creatures; "NEW LIFEFORM DISCOVERED"</summary>
-        public static string NewCreatureDiscoveredMessage { get; } = "NotificationCreatureDiscovered";
+        public const string NewCreatureDiscoveredMessage = "NotificationCreatureDiscovered";
         
         /// <summary>Sound on unlocking new creatures; "NEW LIFEFORM DISCOVERED"</summary>
         public static FMODAsset NewCreatureDiscoveredSound { get; } = AudioUtils.GetFmodAsset("event:/player/new_creature");
 
         /// <summary>Message on unlocking new blueprints from picking up items; "NEW BLUEPRINT SYNTHESIZED FROM ALIEN RESOURCE"</summary>
-        public static string BlueprintPickupMessage { get; } = "NotificationBlueprintPickup";
+        public const string BlueprintPickupMessage = "NotificationBlueprintPickup";
 
         /// <summary>Message on unlocking new blueprints from scanning; "NEW BLUEPRINT SYNTHESIZED"</summary>
-        public static string BlueprintUnlockMessage { get; } = "NotificationBlueprintUnlocked";
+        public const string BlueprintUnlockMessage = "NotificationBlueprintUnlocked";
         
         /// <summary>Sound on unlocking new blueprints from scanning or picking up items; "NEW BLUEPRINT SYNTHESIZED"</summary>
         public static FMODAsset BlueprintUnlockSound { get; } = AudioUtils.GetFmodAsset("event:/tools/scanner/new_blueprint");

--- a/Nautilus/Patchers/KnownTechPatcher.cs
+++ b/Nautilus/Patchers/KnownTechPatcher.cs
@@ -61,7 +61,7 @@ internal class KnownTechPatcher
             
         foreach (KnownTech.AnalysisTech tech in analysisTech)
         {
-            if (UnlockSound == null && tech.unlockSound != null && tech.techType == TechType.Lead)
+            if (UnlockSound == null && tech.unlockSound != null && tech.techType == TechType.CreepvinePiece)
             {
                 UnlockSound = tech.unlockSound;
             }


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed spelling in `DefaultUnlockMessage`
  - Added `DefaultPickupMessage`, which is used when `RequiredForUnlock == TechType.None`
  - Fixed missing `unlockSound`
