### PR TITLE
Improve add custom scanner entry

### DIFF
--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -93,7 +93,7 @@ public static class PDAHandler
     /// <param name="blueprint">The <paramref name="blueprint"/> that is unlocked when <paramref name="key"/> is scanned. In case of fragments, this is the actual <see cref="TechType"/> that unlocks when all fragments are scanned. Can be <see cref="TechType.None"/>.</param>
     /// <param name="isFragment">Whether the <paramref name="key"/> is a fragment or not.</param>
     /// <param name="totalFragmentsRequired">The total amount of objects of <paramref name="key"/> that need to be scanned to unlock the <paramref name="blueprint"/> and <paramref name="encyclopediaKey"/>.</param>
-    /// <param name="scanTime">The amount of time it takes to finish one scan. In seconds.</param>
+    /// <param name="scanTime">The amount of time in seconds it takes to scan this object.</param>
     /// <param name="destroyAfterScan">Whether the object should be destroyed after the scan is finished.</param>
     /// <param name="encyclopediaKey">The key of the encyclopedia entry that is unlocked when all the fragments are scanned.</param>
     public static void AddCustomScannerEntry(TechType key, TechType blueprint, bool isFragment, int totalFragmentsRequired, float scanTime = 2f, bool destroyAfterScan = true, string encyclopediaKey = null)
@@ -114,7 +114,7 @@ public static class PDAHandler
     /// Registers a custom <see cref="PDAScanner.EntryData"/>. This simplified overload is for prefabs that do not have fragments.
     /// </summary>
     /// <param name="key">The scanned object's <see cref="TechType"/>. In the case of fragments, the fragment <see cref="TechType"/> is the key.</param>
-    /// <param name="scanTime">The amount of time it takes to finish one scan. In seconds.</param>
+    /// <param name="scanTime">The amount of time in seconds it takes to scan this object.</param>
     /// <param name="destroyAfterScan">Whether the object should be destroyed after the scan is finished.</param>
     /// <param name="encyclopediaKey">The key of the encyclopedia entry that is unlocked when <paramref name="key"/> is scanned.</param>
     public static void AddCustomScannerEntry(TechType key, float scanTime = 2f, bool destroyAfterScan = false, string encyclopediaKey = null)

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -90,7 +90,7 @@ public static class PDAHandler
     /// Registers a custom <see cref="PDAScanner.EntryData"/>.
     /// </summary>
     /// <param name="key">The scanned object's <see cref="TechType"/>. In the case of fragments, the fragment <see cref="TechType"/> is the key.</param>
-    /// <param name="blueprint">The <paramref name="blueprint"/> when unlocked when scanned. In case of fragments, this is the actual <see cref="TechType"/> that unlocks when all fragments are scanned.</param>
+    /// <param name="blueprint">The <paramref name="blueprint"/> that is unlocked when <paramref name="key"/> is scanned. In case of fragments, this is the actual <see cref="TechType"/> that unlocks when all fragments are scanned. Can be <see cref="TechType.None"/>.</param>
     /// <param name="isFragment">Whether the <paramref name="key"/> is a fragment or not.</param>
     /// <param name="totalFragmentsRequired">The total amount of objects of <paramref name="key"/> that need to be scanned to unlock the <paramref name="blueprint"/> and <paramref name="encyclopediaKey"/>.</param>
     /// <param name="scanTime">The amount of time it takes to finish one scan. In seconds.</param>

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -95,8 +95,8 @@ public static class PDAHandler
     /// <param name="totalFragmentsRequired">The total amount of objects of <paramref name="key"/> that need to be scanned to unlock the <paramref name="blueprint"/> and <paramref name="encyclopediaKey"/>.</param>
     /// <param name="scanTime">The amount of time it takes to finish one scan. In seconds.</param>
     /// <param name="destroyAfterScan">Whether the object should be destroyed after the scan is finished.</param>
-    /// <param name="encyclopediaKey">The key to the encyclopedia entry.</param>
-    public static void AddCustomScannerEntry(TechType key, TechType blueprint, bool isFragment, string encyclopediaKey, int totalFragmentsRequired = 2, float scanTime = 2f, bool destroyAfterScan = true)
+    /// <param name="encyclopediaKey">The key of the encyclopedia entry.</param>
+    public static void AddCustomScannerEntry(TechType key, TechType blueprint, bool isFragment, string encyclopediaKey = null, int totalFragmentsRequired = 2, float scanTime = 2f, bool destroyAfterScan = true)
     {
         AddCustomScannerEntry(new PDAScanner.EntryData()
         {

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -96,7 +96,7 @@ public static class PDAHandler
     /// <param name="scanTime">The amount of time it takes to finish one scan. In seconds.</param>
     /// <param name="destroyAfterScan">Whether the object should be destroyed after the scan is finished.</param>
     /// <param name="encyclopediaKey">The key of the encyclopedia entry.</param>
-    public static void AddCustomScannerEntry(TechType key, TechType blueprint, bool isFragment, string encyclopediaKey = null, int totalFragmentsRequired = 2, float scanTime = 2f, bool destroyAfterScan = true)
+    public static void AddCustomScannerEntry(TechType key, TechType blueprint, bool isFragment, int totalFragmentsRequired, string encyclopediaKey = null, float scanTime = 2f, bool destroyAfterScan = true)
     {
         AddCustomScannerEntry(new PDAScanner.EntryData()
         {

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -98,7 +98,6 @@ public static class PDAHandler
     /// <param name="encyclopediaKey">The key to the encyclopedia entry.</param>
     public static void AddCustomScannerEntry(TechType key, TechType blueprint, bool isFragment, string encyclopediaKey, int totalFragmentsRequired = 2, float scanTime = 2f, bool destroyAfterScan = true)
     {
-        if (encyclopediaKey == null) encyclopediaKey = string.Empty;
         AddCustomScannerEntry(new PDAScanner.EntryData()
         {
             key = key,
@@ -107,7 +106,7 @@ public static class PDAHandler
             totalFragments = totalFragmentsRequired,
             scanTime = scanTime,
             destroyAfterScan = destroyAfterScan,
-            encyclopedia = encyclopediaKey
+            encyclopedia = encyclopediaKey ?? string.Empty
         });
     }
 

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -89,7 +89,7 @@ public static class PDAHandler
     /// <summary>
     /// Registers a custom <see cref="PDAScanner.EntryData"/>.
     /// </summary>
-    /// <param name="key">The scanned object's <see cref="TechType"/>. In case of fragments, the fragment <see cref="TechType"/> is the key.</param>
+    /// <param name="key">The scanned object's <see cref="TechType"/>. In the case of fragments, the fragment <see cref="TechType"/> is the key.</param>
     /// <param name="blueprint">The <paramref name="blueprint"/> when unlocked when scanned. In case of fragments, this is the actual <see cref="TechType"/> that unlocks when all fragments are scanned.</param>
     /// <param name="isFragment">Whether the <paramref name="key"/> is a fragment or not.</param>
     /// <param name="totalFragmentsRequired">The total amount of objects of <paramref name="key"/> that need to be scanned to unlock the <paramref name="blueprint"/> and <paramref name="encyclopediaKey"/>.</param>

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -95,7 +95,7 @@ public static class PDAHandler
     /// <param name="totalFragmentsRequired">The total amount of objects of <paramref name="key"/> that need to be scanned to unlock the <paramref name="blueprint"/> and <paramref name="encyclopediaKey"/>.</param>
     /// <param name="scanTime">The amount of time it takes to finish one scan. In seconds.</param>
     /// <param name="destroyAfterScan">Whether the object should be destroyed after the scan is finished.</param>
-    /// <param name="encyclopediaKey">The key of the encyclopedia entry.</param>
+    /// <param name="encyclopediaKey">The key of the encyclopedia entry that is unlocked when all the fragments are scanned.</param>
     public static void AddCustomScannerEntry(TechType key, TechType blueprint, bool isFragment, int totalFragmentsRequired, float scanTime = 2f, bool destroyAfterScan = true, string encyclopediaKey = null)
     {
         AddCustomScannerEntry(new PDAScanner.EntryData()
@@ -108,6 +108,18 @@ public static class PDAHandler
             destroyAfterScan = destroyAfterScan,
             encyclopedia = encyclopediaKey ?? string.Empty
         });
+    }
+
+    /// <summary>
+    /// Registers a custom <see cref="PDAScanner.EntryData"/>. This simplified overload is for prefabs that do not have fragments.
+    /// </summary>
+    /// <param name="key">The scanned object's <see cref="TechType"/>. In the case of fragments, the fragment <see cref="TechType"/> is the key.</param>
+    /// <param name="scanTime">The amount of time it takes to finish one scan. In seconds.</param>
+    /// <param name="destroyAfterScan">Whether the object should be destroyed after the scan is finished.</param>
+    /// <param name="encyclopediaKey">The key of the encyclopedia entry that is unlocked when <paramref name="key"/> is scanned.</param>
+    public static void AddCustomScannerEntry(TechType key, float scanTime = 2f, bool destroyAfterScan = false, string encyclopediaKey = null)
+    {
+        AddCustomScannerEntry(key, TechType.None, false, 1, scanTime, destroyAfterScan, encyclopediaKey);
     }
 
     /// <summary>

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -96,7 +96,7 @@ public static class PDAHandler
     /// <param name="scanTime">The amount of time it takes to finish one scan. In seconds.</param>
     /// <param name="destroyAfterScan">Whether the object should be destroyed after the scan is finished.</param>
     /// <param name="encyclopediaKey">The key of the encyclopedia entry.</param>
-    public static void AddCustomScannerEntry(TechType key, TechType blueprint, bool isFragment, int totalFragmentsRequired, string encyclopediaKey = null, float scanTime = 2f, bool destroyAfterScan = true)
+    public static void AddCustomScannerEntry(TechType key, TechType blueprint, bool isFragment, int totalFragmentsRequired, float scanTime = 2f, bool destroyAfterScan = true, string encyclopediaKey = null)
     {
         AddCustomScannerEntry(new PDAScanner.EntryData()
         {

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -87,7 +87,7 @@ public static class PDAHandler
     }
 
     /// <summary>
-    /// Adds in a custom <see cref="PDAScanner.EntryData"/>.
+    /// Registers a custom <see cref="PDAScanner.EntryData"/>.
     /// </summary>
     /// <param name="key">The scanned object's <see cref="TechType"/>. In case of fragments, the fragment <see cref="TechType"/> is the key.</param>
     /// <param name="blueprint">The <paramref name="blueprint"/> when unlocked when scanned. In case of fragments, this is the actual <see cref="TechType"/> that unlocks when all fragments are scanned.</param>


### PR DESCRIPTION
### Changes made in this pull request

  - More logical parameters (and default values) in AddCustomScannerEntry
    - 2 fragments is no longer the default... where the hell did 2 come from? It's just so arbitrary.
  - New AddCustomScannerEntry overload for prefabs that don't use fragments.
  - Fixed PAINFUL grammatical errors.

### Breaking changes

  - AddCustomScannerEntry parameters were reordered