### PR TITLE
Add early logger for before main logger is initialized

### DIFF
--- a/Nautilus/Utility/InternalLogger.cs
+++ b/Nautilus/Utility/InternalLogger.cs
@@ -11,6 +11,7 @@ internal static class InternalLogger
 {
     internal static bool Initialized = false;
     private static ManualLogSource Logger { get; set; }
+    private static ManualLogSource EarlyLogger { get; } = BepInEx.Logging.Logger.CreateLogSource("Nautilus.EarlyLogger");
     private static FieldInfo ConfigConsoleDisplayedLevel { get; } = typeof(ConsoleLogListener).GetField("ConfigConsoleDisplayedLevel", BindingFlags.Static | BindingFlags.NonPublic);
     private static ConfigEntry<LogLevel> consoleLogLevel { get; } = ConfigConsoleDisplayedLevel.GetValue(null) as ConfigEntry<LogLevel>;
     private static FieldInfo ConfigDiskConsoleDisplayedLevel { get; } = typeof(Chainloader).GetField("ConfigDiskConsoleDisplayedLevel", BindingFlags.Static | BindingFlags.NonPublic);
@@ -120,7 +121,7 @@ internal static class InternalLogger
         {
             if(level >= LogLevel.Info || EnableDebugging)
             {
-                Console.WriteLine($"[Nautilus/{level}] {text}");
+                EarlyLogger.Log(level, text);
             }
 
             return;


### PR DESCRIPTION
### Changes made in this pull request

  - Added a `Nautilus.EarlyLogger` log source for before the main one is initialized? Idk it seems like a terrible idea.

### Breaking changes

  - None

May resolve #395.

![image](https://github.com/SubnauticaModding/Nautilus/assets/31892011/fc0732d4-ce1d-47eb-9765-3e7eab5f00a8)
