### PR TITLE
Story Goal patching should not be SN1 specific

### DIFF
--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -57,8 +57,6 @@ public class Initializer : BaseUnityPlugin
         EatablePatcher.Patch(_harmony);
         MaterialUtils.Patch();
         FontReferencesPatcher.Patch(_harmony);
-#if SUBNAUTICA
         StoryGoalPatcher.Patch(_harmony); // TO-DO: Story goal handling for Below Zero
-#endif
     }
 }


### PR DESCRIPTION
### Changes made in this pull request

  - The call to `StoryGoalPatcher.Patch(...)` no longer applies only on the SN1 build

### Breaking changes

  - None