### PR TITLE
Change a singular check so that #397 works.

### DIFF
--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -221,7 +221,7 @@ public static class PDAHandler
 
         PDAEncyclopediaPatcher.CustomEntryData[entry.key] = entry;
         
-        if (uGUI.isMainLevel)
+        if(PDAEncyclopedia.initialized)
             PDAEncyclopediaPatcher.InitializePostfix();
     }
 


### PR DESCRIPTION
### Changes made in this pull request

- `if (uGUI.isMainLevel)` changed to `if(PDAEncyclopedia.initialized)`

### Breaking changes

- None (as far as I know)