### PR TITLE
Improve compatibility with SMLHelper by unpatching options and fixing exceptions

### DIFF
--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -42,6 +42,7 @@ public class Initializer : BaseUnityPlugin
         SpritePatcher.Patch(_harmony);
         KnownTechPatcher.Patch(_harmony);
         OptionsPanelPatcher.Patch(_harmony);
+        SMLHelperCompatibilityPatcher.Patch(_harmony);
         ItemsContainerPatcher.Patch(_harmony);
         PDALogPatcher.Patch(_harmony);
         PDAPatcher.Patch(_harmony);

--- a/Nautilus/Options/ModKeybindOption.cs
+++ b/Nautilus/Options/ModKeybindOption.cs
@@ -116,7 +116,7 @@ public class ModKeybindOption : ModOption<KeyCode, KeybindChangedEventArgs>
 
     internal class ModBindingTag: MonoBehaviour { };
 
-    private class BindingOptionAdjust: ModOptionAdjust
+    internal class BindingOptionAdjust: ModOptionAdjust
     {
         private const float spacing = 10f;
 

--- a/Nautilus/Options/ModSliderOption.cs
+++ b/Nautilus/Options/ModSliderOption.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Reflection;
 using BepInEx.Logging;
@@ -290,7 +290,7 @@ public class ModSliderOption : ModOption<float, SliderChangedEventArgs>
         }
     }
 
-    private class SliderOptionAdjust : ModOptionAdjust
+    internal class SliderOptionAdjust : ModOptionAdjust
     {
         private const string sliderBackground = "Slider/Slider/Background";
         private const float spacing_MainMenu = 30f;

--- a/Nautilus/Options/ModToggleOption.cs
+++ b/Nautilus/Options/ModToggleOption.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.Events;
@@ -63,7 +63,7 @@ public class ModToggleOption : ModOption<bool, ToggleChangedEventArgs>
         return new ModToggleOption(id, label, value, tooltip);
     }
 
-    private class ToggleOptionAdjust: ModOptionAdjust
+    internal class ToggleOptionAdjust: ModOptionAdjust
     {
         private const float spacing = 20f;
 

--- a/Nautilus/Patchers/OptionsPanelCompatibilityPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelCompatibilityPatcher.cs
@@ -1,0 +1,78 @@
+using HarmonyLib;
+using Nautilus.Utility;
+using System.Collections;
+using System.Reflection;
+using UnityEngine;
+using UWE;
+
+namespace Nautilus.Patchers;
+
+// Thanks SMLHelper... This disgusting code unpatches most options patches that were done by SMLHelper in order to force compatibility, and also fixes major errors
+internal class SMLHelperCompatibilityPatcher
+{
+    private const string SMLHarmonyInstance = "com.ahk1221.smlhelper";
+
+    internal static void Patch(Harmony harmony)
+    {
+        if (BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey("com.ahk1221.smlhelper"))
+        {
+            CoroutineHost.StartCoroutine(WaitOnSMLHelperForPatches(harmony));
+        }
+    }
+
+    private static IEnumerator WaitOnSMLHelperForPatches(Harmony harmony)
+    {
+        // This code is arbitrary but was taken from an older version of SMLHelper so that this patch applies only AFTER has been patched
+
+        var chainLoader = typeof(BepInEx.Bootstrap.Chainloader);
+
+        var _loaded = chainLoader.GetField("_loaded", BindingFlags.NonPublic | BindingFlags.Static);
+        while (!(bool) _loaded.GetValue(null))
+        {
+            yield return null;
+        }
+
+        yield return new WaitForSecondsRealtime(2);
+
+        // Waiting an extra frame is CRUCIAL!
+
+        yield return null;
+
+        UnpatchSMLHelperOptionsMethods(harmony);
+        FixSMLHelperRuntimeException(harmony);
+    }
+
+    private static void UnpatchSMLHelperOptionsMethods(Harmony harmony)
+    {
+        // Here, we unpatch SML's option panel patches to every method EXCEPT the postfix to uGUI_OptionsPanel.AddTabs
+
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.AddTab)), HarmonyPatchType.Postfix, SMLHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_Binding), nameof(uGUI_Binding.RefreshValue)), HarmonyPatchType.Prefix, SMLHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.AddHeading)), HarmonyPatchType.Prefix, SMLHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.OnEnable)), HarmonyPatchType.Postfix, SMLHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.SetVisibleTab)), HarmonyPatchType.Prefix, SMLHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.RemoveTabs)), HarmonyPatchType.Prefix, SMLHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.HighlightCurrentTab)), HarmonyPatchType.Postfix, SMLHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.SetVisibleTab)), HarmonyPatchType.Prefix, SMLHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.SetVisibleTab)), HarmonyPatchType.Postfix, SMLHarmonyInstance);
+    }
+
+    // Fix what should have been a compiler error (source can be seen here: https://github.com/SubnauticaModding/Nautilus/blob/f3d5de3e36b61a7f26291ef4725eadcb5c4de2a5/SMLHelper/Options/ModOptions.cs#L157)
+    private static void FixSMLHelperRuntimeException(Harmony harmony)
+    {
+        harmony.Patch(
+            AccessTools.Method(AccessTools.TypeByName("SMLHelper.V2.Options.ModOption.ModOptionAdjust"), "Awake"),
+            prefix: new HarmonyMethod(typeof(SMLHelperCompatibilityPatcher), nameof(ModOptionAdjustAwakePrefix)));
+    }
+
+    [HarmonyPrefix]
+    private static bool ModOptionAdjustAwakePrefix(object __instance)
+    {
+        var asMonoBehaviour = (MonoBehaviour) __instance;
+        // use the same logic we use in Nautilus's own version of the component
+        var isMainMenu = asMonoBehaviour.gameObject.GetComponentInParent<uGUI_MainMenu>() != null;
+        // use good old reflection to avoid having SMLHelper as a dependency
+        __instance.SetInstanceField("isMainMenu", isMainMenu);
+        return false; // SKIP ORIGINAL TO AVOID TYPE LOAD EXCEPTION
+    }
+}

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -25,10 +25,7 @@ internal class OptionsPanelPatcher
     {
         harmony.PatchAll(typeof(OptionsPanelPatcher));
         harmony.PatchAll(typeof(ScrollPosKeeper));
-        if (!BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey("com.ahk1221.smlhelper"))
-        {
-            harmony.PatchAll(typeof(ModOptionsHeadingsToggle));
-        }
+        harmony.PatchAll(typeof(ModOptionsHeadingsToggle));
     }
 
 

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -24,33 +24,9 @@ internal class OptionsPanelPatcher
 
     internal static void Patch(Harmony harmony)
     {
-        if (BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey("com.ahk1221.smlhelper"))
-        {
-            CoroutineHost.StartCoroutine(UnpatchSMLHelperPatches(harmony));
-        }
-
         harmony.PatchAll(typeof(OptionsPanelPatcher));
         harmony.PatchAll(typeof(ScrollPosKeeper));
         harmony.PatchAll(typeof(ModOptionsHeadingsToggle));
-    }
-
-    // unpatch options patches done by SMLHelper
-    internal static IEnumerator UnpatchSMLHelperPatches(Harmony harmony)
-    {
-        yield return new WaitForSeconds(15);
-
-        InternalLogger.Log("Unpatching SMLHelper options for compatibility", BepInEx.Logging.LogLevel.Info);
-        var smlHarmonyInstance = "com.ahk1221.smlhelper";
-        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.AddTab)), HarmonyPatchType.Postfix, smlHarmonyInstance);
-        harmony.Unpatch(AccessTools.Method(typeof(uGUI_Binding), nameof(uGUI_Binding.RefreshValue)), HarmonyPatchType.Prefix, smlHarmonyInstance);
-        //harmony.Unpatch(AccessTools.Method(typeof(uGUI_OptionsPanel), nameof(uGUI_OptionsPanel.AddTabs)), HarmonyPatchType.Postfix, smlHarmonyInstance);
-        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.AddHeading)), HarmonyPatchType.Prefix, smlHarmonyInstance);
-        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.OnEnable)), HarmonyPatchType.Postfix, smlHarmonyInstance);
-        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.SetVisibleTab)), HarmonyPatchType.Prefix, smlHarmonyInstance);
-        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.RemoveTabs)), HarmonyPatchType.Prefix, smlHarmonyInstance);
-        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.HighlightCurrentTab)), HarmonyPatchType.Postfix, smlHarmonyInstance);
-        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.SetVisibleTab)), HarmonyPatchType.Prefix, smlHarmonyInstance);
-        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.SetVisibleTab)), HarmonyPatchType.Postfix, smlHarmonyInstance);
     }
 
     // 'Mods' tab also added in QModManager, so we can't rely on 'modsTab' in AddTabs_Postfix

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -10,6 +10,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
+using UWE;
 
 namespace Nautilus.Patchers;
 
@@ -23,11 +24,34 @@ internal class OptionsPanelPatcher
 
     internal static void Patch(Harmony harmony)
     {
+        if (BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey("com.ahk1221.smlhelper"))
+        {
+            CoroutineHost.StartCoroutine(UnpatchSMLHelperPatches(harmony));
+        }
+
         harmony.PatchAll(typeof(OptionsPanelPatcher));
         harmony.PatchAll(typeof(ScrollPosKeeper));
         harmony.PatchAll(typeof(ModOptionsHeadingsToggle));
     }
 
+    // unpatch options patches done by SMLHelper
+    internal static IEnumerator UnpatchSMLHelperPatches(Harmony harmony)
+    {
+        yield return new WaitForSeconds(15);
+
+        InternalLogger.Log("Unpatching SMLHelper options for compatibility", BepInEx.Logging.LogLevel.Info);
+        var smlHarmonyInstance = "com.ahk1221.smlhelper";
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.AddTab)), HarmonyPatchType.Postfix, smlHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_Binding), nameof(uGUI_Binding.RefreshValue)), HarmonyPatchType.Prefix, smlHarmonyInstance);
+        //harmony.Unpatch(AccessTools.Method(typeof(uGUI_OptionsPanel), nameof(uGUI_OptionsPanel.AddTabs)), HarmonyPatchType.Postfix, smlHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.AddHeading)), HarmonyPatchType.Prefix, smlHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.OnEnable)), HarmonyPatchType.Postfix, smlHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.SetVisibleTab)), HarmonyPatchType.Prefix, smlHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.RemoveTabs)), HarmonyPatchType.Prefix, smlHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.HighlightCurrentTab)), HarmonyPatchType.Postfix, smlHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.SetVisibleTab)), HarmonyPatchType.Prefix, smlHarmonyInstance);
+        harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.SetVisibleTab)), HarmonyPatchType.Postfix, smlHarmonyInstance);
+    }
 
     // 'Mods' tab also added in QModManager, so we can't rely on 'modsTab' in AddTabs_Postfix
     [HarmonyPostfix]

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -10,7 +10,6 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
-using UWE;
 
 namespace Nautilus.Patchers;
 

--- a/Nautilus/Patchers/SMLHelperCompatibilityPatcher.cs
+++ b/Nautilus/Patchers/SMLHelperCompatibilityPatcher.cs
@@ -1,7 +1,6 @@
 using HarmonyLib;
 using Nautilus.Utility;
 using System;
-using System.Linq;
 using System.Collections;
 using System.Reflection;
 using UnityEngine;
@@ -10,7 +9,8 @@ using Nautilus.Options;
 
 namespace Nautilus.Patchers;
 
-// Thanks SMLHelper... This disgusting code unpatches most options patches that were done by SMLHelper in order to force compatibility, and also fixes major errors
+// Thanks SMLHelper... This disgusting code fixes many of the bugs caused by SMLHelper with patching, in order to force compatibility
+// This class can be SAFELY removed if we ever decide to make Nautilus incompatible with SMLHelper (which it already kinda is...)
 internal class SMLHelperCompatibilityPatcher
 {
     private const string SMLHarmonyInstance = "com.ahk1221.smlhelper"; // This string is both the harmony instance & plugin GUID
@@ -52,10 +52,12 @@ internal class SMLHelperCompatibilityPatcher
 
     private static void UnpatchSMLOptionsMethods(Harmony harmony)
     {
-        // Here, we unpatch SML's option panel patches to every method EXCEPT the postfix to uGUI_OptionsPanel.AddTabs
+        /* Here, we unpatch SML's option panel patches to every method EXCEPT the following:
+        * The postfix to uGUI_OptionsPanel.AddTabs
+        * The prefix to uGUI_Binding.RefreshValue
+        */
 
         harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.AddTab)), HarmonyPatchType.Postfix, SMLHarmonyInstance);
-        harmony.Unpatch(AccessTools.Method(typeof(uGUI_Binding), nameof(uGUI_Binding.RefreshValue)), HarmonyPatchType.Prefix, SMLHarmonyInstance);
         harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.AddHeading)), HarmonyPatchType.Prefix, SMLHarmonyInstance);
         harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.OnEnable)), HarmonyPatchType.Postfix, SMLHarmonyInstance);
         harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.SetVisibleTab)), HarmonyPatchType.Prefix, SMLHarmonyInstance);
@@ -67,7 +69,7 @@ internal class SMLHelperCompatibilityPatcher
 
     // Fix what should have been a compiler error (cause of error is this line: https://github.com/SubnauticaModding/Nautilus/blob/f3d5de3e36b61a7f26291ef4725eadcb5c4de2a5/SMLHelper/Options/ModOptions.cs#L157)
     // Here we just use Nautilus's version of the ModOptionAdjust components, instead of the old SMLHelper ones.
-    // We can't patch that single Awake line because it would provide a compiler error, meaning it's unpatchable.
+    // We can't patch that single Awake line because it references a missing class, and is therefore unpatchable.
     private static void FixSMLOptionsException(Harmony harmony)
     {
         var modOptionBaseClass = GetSMLType("SMLHelper.V2.Options.ModOption");

--- a/Nautilus/Patchers/SMLHelperCompatibilityPatcher.cs
+++ b/Nautilus/Patchers/SMLHelperCompatibilityPatcher.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using Nautilus.Utility;
+using System;
 using System.Collections;
 using System.Reflection;
 using UnityEngine;
@@ -39,7 +40,7 @@ internal class SMLHelperCompatibilityPatcher
         yield return null;
 
         UnpatchSMLHelperOptionsMethods(harmony);
-        FixSMLHelperRuntimeException(harmony);
+        FixSMLHelperOptionsException(harmony);
     }
 
     private static void UnpatchSMLHelperOptionsMethods(Harmony harmony)
@@ -58,10 +59,10 @@ internal class SMLHelperCompatibilityPatcher
     }
 
     // Fix what should have been a compiler error (source can be seen here: https://github.com/SubnauticaModding/Nautilus/blob/f3d5de3e36b61a7f26291ef4725eadcb5c4de2a5/SMLHelper/Options/ModOptions.cs#L157)
-    private static void FixSMLHelperRuntimeException(Harmony harmony)
+    private static void FixSMLHelperOptionsException(Harmony harmony)
     {
         harmony.Patch(
-            AccessTools.Method(AccessTools.TypeByName("SMLHelper.V2.Options.ModOption.ModOptionAdjust"), "Awake"),
+            AccessTools.Method(Type.GetType("SMLHelper.V2.Options.ModOption.ModOptionAdjust"), "Awake"),
             prefix: new HarmonyMethod(typeof(SMLHelperCompatibilityPatcher), nameof(ModOptionAdjustAwakePrefix)));
     }
 

--- a/Nautilus/Patchers/SMLHelperCompatibilityPatcher.cs
+++ b/Nautilus/Patchers/SMLHelperCompatibilityPatcher.cs
@@ -9,11 +9,11 @@ using Nautilus.Options;
 
 namespace Nautilus.Patchers;
 
-// Thanks SMLHelper... This disgusting code fixes many of the bugs caused by SMLHelper with patching, in order to force compatibility
+// Thanks SMLHelper... This disgusting code fixes many of the bugs caused by SMLHelper with patching, in order to force compatibility.
 // This class can be SAFELY removed if we ever decide to make Nautilus incompatible with SMLHelper (which it already kinda is...)
 internal class SMLHelperCompatibilityPatcher
 {
-    private const string SMLHarmonyInstance = "com.ahk1221.smlhelper"; // This string is both the harmony instance & plugin GUID
+    private const string SMLHarmonyInstance = "com.ahk1221.smlhelper"; // This string is both the harmony instance & plugin GUID.
     private const string SMLAssemblyName = "SMLHelper";
 
     private static Assembly _smlHelperAssembly;
@@ -28,7 +28,7 @@ internal class SMLHelperCompatibilityPatcher
 
     private static IEnumerator WaitOnSMLHelperForPatches(Harmony harmony)
     {
-        // This code is arbitrary but was taken from an older version of SMLHelper so that this patch applies only AFTER has been patched
+        // This code is arbitrary but was taken from an older version of SMLHelper so that this patch applies only AFTER has been patched.
 
         var chainLoader = typeof(BepInEx.Bootstrap.Chainloader);
 
@@ -40,7 +40,7 @@ internal class SMLHelperCompatibilityPatcher
 
         yield return new WaitForSecondsRealtime(2);
 
-        // Waiting an extra frame is CRUCIAL!
+        // Waiting an extra frame is CRUCIAL to avoid race conditions.
 
         yield return null;
 
@@ -53,8 +53,8 @@ internal class SMLHelperCompatibilityPatcher
     private static void UnpatchSMLOptionsMethods(Harmony harmony)
     {
         /* Here, we unpatch SML's option panel patches to every method EXCEPT the following:
-        * The postfix to uGUI_OptionsPanel.AddTabs
-        * The prefix to uGUI_Binding.RefreshValue
+        * The postfix to uGUI_OptionsPanel.AddTabs (needed for SML options to actually appear)
+        * The prefix to uGUI_Binding.RefreshValue (needed for keybinds)
         */
 
         harmony.Unpatch(AccessTools.Method(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.AddTab)), HarmonyPatchType.Postfix, SMLHarmonyInstance);
@@ -90,14 +90,14 @@ internal class SMLHelperCompatibilityPatcher
         }
     }
 
-    // This method swaps out the old (broken) ModOption.ModOptionAdjust components with the new Nautilus ones
+    // This method swaps out the old (broken) ModOption.ModOptionAdjust components with the new Nautilus ones.
     // __instance is of type SMLHelper.V2.Options.ModOption
     private static bool ChangeAdjusterComponentPrefix(object __instance, ref Type __result)
     {
         var typeName = __instance.GetType().Name;
         switch (typeName)
         {
-            // The cases are the SMLHelper option classes, and __result is set equal to the new Nautilus adjust types
+            // The cases are the SMLHelper option classes, and __result is set equal to the new Nautilus adjust types.
             case "ModToggleOption":
                 __result = typeof(ModToggleOption.ToggleOptionAdjust);
                 break;
@@ -136,7 +136,7 @@ internal class SMLHelperCompatibilityPatcher
         return assembly.GetType(typeName);
     }
 
-    // Works with types that have full names like SMLHelper.V2.Options.ModOption+ModOptionAdjust... IDK why the other method does not work as intended for subclasses
+    // Might be necessary for types that are subclasses like "SMLHelper.V2.Options.ModOption+ModOptionAdjust", notice the + symbol there
     private static Type GetSMLTypeByFullName(string typeName)
     {
         var assembly = GetSMLAssembly();


### PR DESCRIPTION
### Changes made in this pull request

  - Made all ModOptionAdjust classes internal rather than private
  - Added the SMLHelperCompatibilityPatcher class
    - Currently only used for fixing mod options bugs, but can be expanded
    - Fixes runtime exceptions by the ModOptionAdjust classes because SMLHelper is referencing a class that was removed from Subnautica. The fix is simply adding the Nautilus components rather than the old SMLHelper ones.
    - Unpatches SEVERAL SMLHelper options methods to ensure compatibility and that Nautilus applies the *newer* patches.
 
### Breaking changes

  - None