### PR TITLE
AddCustomScannerEntry documentation

### DIFF
--- a/Nautilus/Documentation/tutorials/databank-entries.md
+++ b/Nautilus/Documentation/tutorials/databank-entries.md
@@ -252,6 +252,16 @@ PDA entries are not unlocked by default, but there are various ways to add them 
 | `PDAEncyclopedia.AddAndPlaySound(string key)` | Adds the entry with the given `key`, shows a notification, and plays the correct sound (if defined) for this entry. |
 | `PDAEncyclopedia.Add(string key, bool verbose)` | Adds the entry with the given `key`, and shows a notification if `verbose` is true. |
 
+### Example for unlocking with PDAHandler.AddCustomScannerEntry:
+```csharp
+// Register encyclopedia entry like usual:
+PDAHandler.AddEncyclopediaEntry("ArcticReaperEncy", "Lifeforms/Fauna/Leviathans", "Arctic Reaper", "A reaper leviathan that lives in a colder climate.");
+
+// Use PDAHandler.AddCustomScannerEntry to make it unlockable.
+// This code unlocks the encyclopedia entry when a prefab with a TechType of ArcticReaperTechType is scanned.
+PDAHandler.AddCustomScannerEntry(ArcticReaperTechType, 4, false, "ArcticReaperEncy");
+```
+
 ### Example for unlocking with Story Goals:
 
 ```csharp

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -232,6 +232,9 @@ public static class PDAHandler
     /// <param name="path"><para>Path to this entry in the databank.</para>
     /// <para>To find examples of this string, open "Subnautica_Data\StreamingAssets\SNUnmanagedData\LanguageFiles\English.json" and search for "EncyPath".
     /// Remember to omit the "EncyPath_" prefix from these language keys. An example of a proper value is: "Lifeforms/Fauna/Leviathans".</para>
+    /// <para>A list of all Databank paths can also be found in
+    /// <see href="https://subnauticamodding.github.io/Nautilus/tutorials/databank-entries.html#creating-an-entry-path">this section</see>
+    /// of Nautilus's documentation.</para>
     /// </param>
     /// <param name="title">Displayed title of the PDA entry in English. If set to null, you must implement your own translations. Language key is 'Ency_{<paramref name="key"/>}'.</param>
     /// <param name="desc">Displayed description of the PDA entry in English. If set to null, you must implement your own translations. Language key is 'EncyDesc_{<paramref name="key"/>}'.</param>


### PR DESCRIPTION
### Changes made in this pull request

  - Improved documentation of AddCustomScannerEntry in the Nautilus documentation site
  - Linked Nautilus docs in AddEncyclopediaEntry's XML docs for the `path` parameter

### Breaking changes

  - None