### PR TITLE
Default recipe item craft amount to one

### DIFF
--- a/Nautilus/Crafting/RecipeData.cs
+++ b/Nautilus/Crafting/RecipeData.cs
@@ -22,7 +22,7 @@ public class RecipeData
     /// The quantity of the item this recipe yields.
     /// </value>
     [JsonProperty]
-    public int craftAmount { get; set; }
+    public int craftAmount { get; set; } = 1;
 
     /// <summary>
     /// Gets the number of different ingredients for this recipe.


### PR DESCRIPTION
### Changes made in this pull request

  - Set default value of RecipeData.craftAmount to 1

### Breaking changes

  - None