### PR TITLE
Custom audios not playing: CustomSoundHandler, CustomSoundPatcher and AudioUtils fix.

### DIFF
--- a/Nautilus/Handlers/CustomSoundHandler.cs
+++ b/Nautilus/Handlers/CustomSoundHandler.cs
@@ -19,11 +19,12 @@ public static class CustomSoundHandler
     /// <param name="id">The Id of your custom sound which is used when checking which sounds to play.</param>
     /// <param name="filePath">The file path on disk of the sound file to load.</param>
     /// <param name="busPath">The bus path to play the sound on.</param>
+    /// <param name="mode">The audio MODE of the sound.</param>
     /// <returns>the <see cref="Sound"/> loaded</returns>
-    public static Sound RegisterCustomSound(string id, string filePath, string busPath)
+    public static Sound RegisterCustomSound(string id, string filePath, string busPath, MODE mode = MODE.DEFAULT)
     {
         Bus bus = RuntimeManager.GetBus(busPath);
-        return RegisterCustomSound(id, filePath, bus);
+        return RegisterCustomSound(id, filePath, bus, mode);
     }
 
     /// <summary>
@@ -32,14 +33,15 @@ public static class CustomSoundHandler
     /// <param name="id">The Id of your custom sound which is used when checking which sounds to play.</param>
     /// <param name="filePath">The file path on disk of the sound file to load.</param>
     /// <param name="bus">The bus to play the sound on.</param>
+    /// <param name="mode">The audio MODE of the sound.</param>
     /// <returns>the <see cref="Sound"/> loaded</returns>
-    public static Sound RegisterCustomSound(string id, string filePath, Bus bus)
+    public static Sound RegisterCustomSound(string id, string filePath, Bus bus, MODE mode = MODE.DEFAULT)
     {
         if (bus.getChannelGroup(out _) != RESULT.OK)
         {
             bus.lockChannelGroup().CheckResult();
         }
-        Sound sound = AudioUtils.CreateSound(filePath);
+        Sound sound = AudioUtils.CreateSound(filePath, mode);
         CustomSoundPatcher.CustomSounds[id] = sound;
         CustomSoundPatcher.CustomSoundBuses[id] = bus;
         return sound;
@@ -51,11 +53,12 @@ public static class CustomSoundHandler
     /// <param name="id">The Id of your custom sound which is used when checking which sounds to play.</param>
     /// <param name="audio">The AudioClip to register.</param>
     /// <param name="busPath">The bus path to play the sound on.</param>
+    /// <param name="mode">The audio MODE of the sound.</param>
     /// <returns>the <see cref="Sound"/> loaded</returns>
-    public static Sound RegisterCustomSound(string id, AudioClip audio, string busPath)
+    public static Sound RegisterCustomSound(string id, AudioClip audio, string busPath, MODE mode = MODE.DEFAULT)
     {
         Bus bus = RuntimeManager.GetBus(busPath);
-        return RegisterCustomSound(id, audio, bus);
+        return RegisterCustomSound(id, audio, bus, mode);
     }
 
     /// <summary>
@@ -64,14 +67,15 @@ public static class CustomSoundHandler
     /// <param name="id">The Id of your custom sound which is used when checking which sounds to play.</param>
     /// <param name="audio">The AudioClip to register.</param>
     /// <param name="bus">The bus to play the sound on.</param>
+    /// <param name="mode">The audio MODE of the sound.</param>
     /// <returns>the <see cref="Sound"/> loaded</returns>
-    public static Sound RegisterCustomSound(string id, AudioClip audio, Bus bus)
+    public static Sound RegisterCustomSound(string id, AudioClip audio, Bus bus, MODE mode = MODE.DEFAULT)
     {
         if (bus.getChannelGroup(out _) != RESULT.OK)
         {
             bus.lockChannelGroup().CheckResult();
         }
-        Sound sound = AudioUtils.CreateSound(audio);
+        Sound sound = AudioUtils.CreateSound(audio, mode);
         CustomSoundPatcher.CustomSounds[id] = sound;
         CustomSoundPatcher.CustomSoundBuses[id] = bus;
         return sound;
@@ -119,7 +123,7 @@ public static class CustomSoundHandler
     /// Try to find and play a custom <see cref="Sound"/> that has been registered.
     /// </summary>
     /// <param name="id">The Id of the custom sound</param>
-    /// <param name="channel">the <see cref="Channel"/>the sound is playing on.</param>
+    /// <param name="channel">the <see cref="Channel"/> the sound is playing on.</param>
     public static bool TryPlayCustomSound(string id, out Channel channel)
     {
         channel = default;

--- a/Nautilus/Handlers/CustomSoundHandler.cs
+++ b/Nautilus/Handlers/CustomSoundHandler.cs
@@ -35,6 +35,10 @@ public static class CustomSoundHandler
     /// <returns>the <see cref="Sound"/> loaded</returns>
     public static Sound RegisterCustomSound(string id, string filePath, Bus bus)
     {
+        if (bus.getChannelGroup(out _) != RESULT.OK)
+        {
+            bus.lockChannelGroup().CheckResult();
+        }
         Sound sound = AudioUtils.CreateSound(filePath);
         CustomSoundPatcher.CustomSounds[id] = sound;
         CustomSoundPatcher.CustomSoundBuses[id] = bus;
@@ -63,6 +67,10 @@ public static class CustomSoundHandler
     /// <returns>the <see cref="Sound"/> loaded</returns>
     public static Sound RegisterCustomSound(string id, AudioClip audio, Bus bus)
     {
+        if (bus.getChannelGroup(out _) != RESULT.OK)
+        {
+            bus.lockChannelGroup().CheckResult();
+        }
         Sound sound = AudioUtils.CreateSound(audio);
         CustomSoundPatcher.CustomSounds[id] = sound;
         CustomSoundPatcher.CustomSoundBuses[id] = bus;
@@ -99,6 +107,10 @@ public static class CustomSoundHandler
     /// <param name="bus">The bus to play the sound on.</param>
     public static void RegisterCustomSound(string id, Sound sound, Bus bus)
     {
+        if (bus.getChannelGroup(out _) != RESULT.OK)
+        {
+            bus.lockChannelGroup().CheckResult();
+        }
         CustomSoundPatcher.CustomSounds[id] = sound;
         CustomSoundPatcher.CustomSoundBuses[id] = bus;
     }

--- a/Nautilus/Handlers/CustomSoundHandler.cs
+++ b/Nautilus/Handlers/CustomSoundHandler.cs
@@ -19,7 +19,8 @@ public static class CustomSoundHandler
     /// <param name="id">The Id of your custom sound which is used when checking which sounds to play.</param>
     /// <param name="filePath">The file path on disk of the sound file to load.</param>
     /// <param name="busPath">The bus path to play the sound on.</param>
-    /// <param name="mode">The audio MODE of the sound.</param>
+    /// <param name="mode">The audio MODE of the sound.
+    /// Standard values of this property can be found in the <see cref="AudioUtils"/> class (i.e. <see cref="AudioUtils.StandardSoundModes_3D"/>).</param>
     /// <returns>the <see cref="Sound"/> loaded</returns>
     public static Sound RegisterCustomSound(string id, string filePath, string busPath, MODE mode = MODE.DEFAULT)
     {
@@ -33,7 +34,8 @@ public static class CustomSoundHandler
     /// <param name="id">The Id of your custom sound which is used when checking which sounds to play.</param>
     /// <param name="filePath">The file path on disk of the sound file to load.</param>
     /// <param name="bus">The bus to play the sound on.</param>
-    /// <param name="mode">The audio MODE of the sound.</param>
+    /// <param name="mode">The audio MODE of the sound.
+    /// Standard values of this property can be found in the <see cref="AudioUtils"/> class (i.e. <see cref="AudioUtils.StandardSoundModes_3D"/>).</param>
     /// <returns>the <see cref="Sound"/> loaded</returns>
     public static Sound RegisterCustomSound(string id, string filePath, Bus bus, MODE mode = MODE.DEFAULT)
     {
@@ -53,7 +55,8 @@ public static class CustomSoundHandler
     /// <param name="id">The Id of your custom sound which is used when checking which sounds to play.</param>
     /// <param name="audio">The AudioClip to register.</param>
     /// <param name="busPath">The bus path to play the sound on.</param>
-    /// <param name="mode">The audio MODE of the sound.</param>
+    /// <param name="mode">The audio MODE of the sound.
+    /// Standard values of this property can be found in the <see cref="AudioUtils"/> class (i.e. <see cref="AudioUtils.StandardSoundModes_3D"/>).</param>
     /// <returns>the <see cref="Sound"/> loaded</returns>
     public static Sound RegisterCustomSound(string id, AudioClip audio, string busPath, MODE mode = MODE.DEFAULT)
     {
@@ -67,7 +70,8 @@ public static class CustomSoundHandler
     /// <param name="id">The Id of your custom sound which is used when checking which sounds to play.</param>
     /// <param name="audio">The AudioClip to register.</param>
     /// <param name="bus">The bus to play the sound on.</param>
-    /// <param name="mode">The audio MODE of the sound.</param>
+    /// <param name="mode">The audio MODE of the sound.
+    /// Standard values of this property can be found in the <see cref="AudioUtils"/> class (i.e. <see cref="AudioUtils.StandardSoundModes_3D"/>).</param>
     /// <returns>the <see cref="Sound"/> loaded</returns>
     public static Sound RegisterCustomSound(string id, AudioClip audio, Bus bus, MODE mode = MODE.DEFAULT)
     {

--- a/Nautilus/Handlers/PDAHandler.cs
+++ b/Nautilus/Handlers/PDAHandler.cs
@@ -180,7 +180,7 @@ public static class PDAHandler
     /// <param name="icon">The icon that will be used in the Log tab for this entry. if unassigned, it will use the default log entry icon.</param>
     public static void AddLogEntry(string key, string languageKey, AudioClip audioClip, Sprite icon = null)
     {
-        AddLogEntry(key, languageKey, CustomSoundHandler.RegisterCustomSound(key, audioClip, AudioUtils.BusPaths.PDAVoice), icon);
+        AddLogEntry(key, languageKey, CustomSoundHandler.RegisterCustomSound(key, audioClip, AudioUtils.BusPaths.PDAVoice, AudioUtils.StandardSoundModes_Stream), icon);
     }
 
     /// <summary>
@@ -192,7 +192,7 @@ public static class PDAHandler
     /// <param name="icon">The icon that will be used in the Log tab for this entry. if unassigned, it will use the default log entry icon.</param>
     public static void AddLogEntry(string key, string languageKey, string soundFilePath, Sprite icon = null)
     {
-        AddLogEntry(key, languageKey, CustomSoundHandler.RegisterCustomSound(key, soundFilePath, AudioUtils.BusPaths.PDAVoice), icon);
+        AddLogEntry(key, languageKey, CustomSoundHandler.RegisterCustomSound(key, soundFilePath, AudioUtils.BusPaths.PDAVoice, AudioUtils.StandardSoundModes_Stream), icon);
     }
 
     /// <summary>

--- a/Nautilus/Patchers/CustomSoundPatcher.cs
+++ b/Nautilus/Patchers/CustomSoundPatcher.cs
@@ -44,11 +44,6 @@ internal class CustomSoundPatcher
 
         InternalLogger.Debug($"FMODExtensions.GetLength(\"{path}\") executed. Checking if it's a custom sound...");
 
-        foreach(KeyValuePair<string, Sound> kvp in CustomSounds)
-        {
-            InternalLogger.Debug($"CustomSound: {kvp.Key}");
-        }
-
         if (!CustomSounds.ContainsKey(path))
             return true;
 

--- a/Nautilus/Patchers/CustomSoundPatcher.cs
+++ b/Nautilus/Patchers/CustomSoundPatcher.cs
@@ -451,7 +451,7 @@ internal class CustomSoundPatcher
                 return true;
             }
 #if BELOWZERO
-            if (SoundQueue.GetPlaybackState(__instance.eventInstance) is not PLAYBACK_STATE.STARTING or PLAYBACK_STATE.PLAYING)
+            if (SoundQueue.GetPlaybackState(__instance.eventInstance) is not (PLAYBACK_STATE.STARTING or PLAYBACK_STATE.PLAYING))
             {
                 return true;
             }
@@ -459,7 +459,7 @@ internal class CustomSoundPatcher
             if (!SoundQueue.GetIsStartingOrPlaying(__instance.eventInstance)) return true;
 #endif
 
-            ATTRIBUTES_3D attributes = Player.main.transform.To3DAttributes();
+        ATTRIBUTES_3D attributes = Player.main.transform.To3DAttributes();
             channel.set3DAttributes(ref attributes.position, ref attributes.velocity);
             channel.getPosition(out uint position, TIMEUNIT.MS);
             instanceCurrent.position = (int)position;

--- a/Nautilus/Patchers/VehicleUpgradesPatcher.cs
+++ b/Nautilus/Patchers/VehicleUpgradesPatcher.cs
@@ -395,7 +395,7 @@ internal class VehicleUpgradesPatcher
     // SEATRUCK
     // ON USE
     //
-    private static void DelegateUseCallback(SeaTruckUpgrades __instance, int slotID, TechType techType)
+    /*private static void DelegateUseCallback(SeaTruckUpgrades __instance, int slotID, TechType techType)
     {
         if (!SeatruckUpgradeModules.TryGetValue(techType, out var prefab))
             return;
@@ -428,7 +428,7 @@ internal class VehicleUpgradesPatcher
             );
 
         return matcher.InstructionEnumeration();
-    }
+    }*/
 
     //
     // SEATRUCK

--- a/Nautilus/Patchers/VehicleUpgradesPatcher.cs
+++ b/Nautilus/Patchers/VehicleUpgradesPatcher.cs
@@ -395,7 +395,7 @@ internal class VehicleUpgradesPatcher
     // SEATRUCK
     // ON USE
     //
-    /*private static void DelegateUseCallback(SeaTruckUpgrades __instance, int slotID, TechType techType)
+    private static void DelegateUseCallback(SeaTruckUpgrades __instance, int slotID, TechType techType)
     {
         if (!SeatruckUpgradeModules.TryGetValue(techType, out var prefab))
             return;
@@ -428,7 +428,7 @@ internal class VehicleUpgradesPatcher
             );
 
         return matcher.InstructionEnumeration();
-    }*/
+    }
 
     //
     // SEATRUCK

--- a/Nautilus/Utility/AudioUtils.cs
+++ b/Nautilus/Utility/AudioUtils.cs
@@ -17,15 +17,15 @@ public static partial class AudioUtils
     /// <summary>
     /// 3D sounds
     /// </summary>
-    public const MODE k3DOptiSoundModes = MODE.DEFAULT | MODE._3D | MODE.ACCURATETIME | MODE._3D_LINEARSQUAREROLLOFF;
+    public const MODE StandardSoundModes_3D = MODE.DEFAULT | MODE._3D | MODE.ACCURATETIME | MODE._3D_LINEARSQUAREROLLOFF;
     /// <summary>
     /// 2D sounds
     /// </summary>
-    public const MODE k2DOptiSoundModes = MODE.DEFAULT | MODE._2D | MODE.ACCURATETIME;
+    public const MODE StandardSoundModes_2D = MODE.DEFAULT | MODE._2D | MODE.ACCURATETIME;
     /// <summary>
-    /// For music, PDA and any 2D sounds that can have more than one instance at a time.
+    /// For music, PDA voices and any 2D sounds that can have more than one instance at a time.
     /// </summary>
-    public const MODE kStreamSoundModes = k2DOptiSoundModes | MODE.CREATESTREAM;
+    public const MODE StandardSoundModes_Stream = StandardSoundModes_2D | MODE.CREATESTREAM;
 
     private static FMOD.System FMOD_System => RuntimeManager.CoreSystem;
 

--- a/Nautilus/Utility/AudioUtils.cs
+++ b/Nautilus/Utility/AudioUtils.cs
@@ -14,6 +14,19 @@ namespace Nautilus.Utility;
 /// </summary>
 public static partial class AudioUtils
 {
+    /// <summary>
+    /// 3D sounds
+    /// </summary>
+    public const MODE k3DOptiSoundModes = MODE.DEFAULT | MODE._3D | MODE.ACCURATETIME | MODE._3D_LINEARSQUAREROLLOFF;
+    /// <summary>
+    /// 2D sounds
+    /// </summary>
+    public const MODE k2DOptiSoundModes = MODE.DEFAULT | MODE._2D | MODE.ACCURATETIME;
+    /// <summary>
+    /// For music, PDA and any 2D sounds that can have more than one instance at a time.
+    /// </summary>
+    public const MODE kStreamSoundModes = k2DOptiSoundModes | MODE.CREATESTREAM;
+
     private static FMOD.System FMOD_System => RuntimeManager.CoreSystem;
 
     /// <summary>

--- a/Nautilus/Utility/AudioUtils.cs
+++ b/Nautilus/Utility/AudioUtils.cs
@@ -72,6 +72,10 @@ public static partial class AudioUtils
     {
         channel = default;
         Bus bus = RuntimeManager.GetBus(busPath);
+        if (bus.getChannelGroup(out _) != RESULT.OK)
+        {
+            bus.lockChannelGroup().CheckResult();
+        }
         return bus.getChannelGroup(out ChannelGroup channelGroup) == RESULT.OK &&
                channelGroup.getPaused(out bool paused) == RESULT.OK &&
                FMOD_System.playSound(sound, channelGroup, paused, out channel) == RESULT.OK;
@@ -87,6 +91,10 @@ public static partial class AudioUtils
     public static bool TryPlaySound(Sound sound, Bus bus, out Channel channel)
     {
         channel = default;
+        if (bus.getChannelGroup(out _) != RESULT.OK)
+        {
+            bus.lockChannelGroup().CheckResult();
+        }
         return bus.getChannelGroup(out ChannelGroup channelGroup) == RESULT.OK &&
                channelGroup.getPaused(out bool paused) == RESULT.OK &&
                FMOD_System.playSound(sound, channelGroup, paused, out channel) == RESULT.OK;


### PR DESCRIPTION
Made with Metious ! Gigantic thanks to them for taking time to inspect FMOD bugs and find solutions because I was not smart enough to find it myself because of my unexperience with FMOD system :)

### Changes made in this pull request

  - CustomSoundHandler now checks the bus channels when a modder adds a new sound.
  - AudioUtils.TryPlaySound now also do a check for the buses. If the bus is, somehow, not locked, then the function will do it, however the sound will have to be replayed to work.
  - CustomSoundPatcher have been a little modified to fix the PlayBackState() check

### Breaking changes

  - CustomSoundHandler.RegisterCustomSound methods now have a `mode` parameter.