### PR TITLE
Fix SaveDataCache loading issues (no longer loads after everything else)

### DIFF
--- a/Nautilus/Handlers/SaveDataHandler.cs
+++ b/Nautilus/Handlers/SaveDataHandler.cs
@@ -1,4 +1,4 @@
-﻿using Nautilus.Json;
+using Nautilus.Json;
 using Nautilus.Utility;
 
 namespace Nautilus.Handlers;
@@ -18,7 +18,7 @@ public static class SaveDataHandler
     {
         T cache = new();
 
-        SaveUtils.RegisterOnLoadEvent(() => cache.Load());
+        SaveUtils.RegisterOnStartLoadingEvent(() => cache.Load());
         SaveUtils.RegisterOnSaveEvent(() => cache.Save());
 
         return cache;

--- a/Nautilus/Patchers/SaveUtilsPatcher.cs
+++ b/Nautilus/Patchers/SaveUtilsPatcher.cs
@@ -12,7 +12,8 @@ internal class SaveUtilsPatcher
     private static readonly List<Action> oneTimeUseOnQuitEvents = new();
 
     internal static Action OnSaveEvents;
-    internal static Action OnLoadEvents;
+    internal static Action OnFinishLoadingEvents;
+    internal static Action OnStartLoadingEvents;
     internal static Action OnQuitEvents;
 
     public static void Patch(Harmony harmony)
@@ -57,12 +58,14 @@ internal class SaveUtilsPatcher
 
     internal static IEnumerator InvokeLoadEvents(IEnumerator enumerator)
     {
+        OnStartLoadingEvents?.Invoke();
+
         while (enumerator.MoveNext())
         {
             yield return enumerator.Current;
         }
 
-        OnLoadEvents?.Invoke();
+        OnFinishLoadingEvents?.Invoke();
 
         if (oneTimeUseOnLoadEvents.Count > 0)
         {

--- a/Nautilus/Utility/SaveUtils.cs
+++ b/Nautilus/Utility/SaveUtils.cs
@@ -29,7 +29,7 @@ public static class SaveUtils
     /// This is only invoked after the game (including most objects around the player) has FULLY loaded. For an earlier alternative, see <see cref="RegisterOnStartLoadingEvent"/>.
     /// </summary>
     /// <param name="onLoadAction">The method to invoke. This action will not be invoked a second time.</param>
-    public static void RegisterOnFinishLoadEvent(Action onLoadAction)
+    public static void RegisterOnFinishLoadingEvent(Action onLoadAction)
     {
         SaveUtilsPatcher.OnFinishLoadingEvents += onLoadAction;
     }
@@ -63,13 +63,23 @@ public static class SaveUtils
     }
 
     /// <summary>
-    /// Removes a method previously added through <see cref="RegisterOnFinishLoadEvent(Action)"/> so it is no longer invoked when loading the game.<para/>
+    /// Removes a method previously added through <see cref="RegisterOnFinishLoadingEvent(Action)"/> so it is no longer invoked when loading the game.<para/>
     /// If you plan on using this, do not register an anonymous method.
     /// </summary>
     /// <param name="onLoadAction">The method invoked.</param>
-    public static void UnregisterOnLoadEvent(Action onLoadAction)
+    public static void UnregisterOnFinishLoadingEvent(Action onLoadAction)
     {
         SaveUtilsPatcher.OnFinishLoadingEvents -= onLoadAction;
+    }
+
+    /// <summary>
+    /// Removes a method previously added through <see cref="RegisterOnStartLoadingEvent(Action)"/> so it is no longer invoked when loading the game.<para/>
+    /// If you plan on using this, do not register an anonymous method.
+    /// </summary>
+    /// <param name="onLoadAction">The method invoked.</param>
+    public static void UnregisterOnStartLoadingEvent(Action onLoadAction)
+    {
+        SaveUtilsPatcher.OnStartLoadingEvents -= onLoadAction;
     }
 
     /// <summary>

--- a/Nautilus/Utility/SaveUtils.cs
+++ b/Nautilus/Utility/SaveUtils.cs
@@ -28,10 +28,10 @@ public static class SaveUtils
     /// Registers a simple <see cref="Action"/> method to invoke the <c>first time</c> the player loads a saved game via the in game menu.
     /// This is only invoked after the game (including most objects around the player) has FULLY loaded. For an earlier alternative, see <see cref="RegisterOnStartLoadingEvent"/>.
     /// </summary>
-    /// <param name="onLoadAction">The method to invoke. This action will not be invoked a second time.</param>
-    public static void RegisterOnFinishLoadingEvent(Action onLoadAction)
+    /// <param name="onFinishLoadingAction">The method to invoke. This action will not be invoked a second time.</param>
+    public static void RegisterOnFinishLoadingEvent(Action onFinishLoadingAction)
     {
-        SaveUtilsPatcher.OnFinishLoadingEvents += onLoadAction;
+        SaveUtilsPatcher.OnFinishLoadingEvents += onFinishLoadingAction;
     }
 
     /// <summary>

--- a/Nautilus/Utility/SaveUtils.cs
+++ b/Nautilus/Utility/SaveUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Nautilus.Patchers;
 
 namespace Nautilus.Utility;
@@ -26,11 +26,21 @@ public static class SaveUtils
 
     /// <summary>
     /// Registers a simple <see cref="Action"/> method to invoke the <c>first time</c> the player loads a saved game via the in game menu.
+    /// This is only invoked after the game (including most objects around the player) has FULLY loaded. For an earlier alternative, see <see cref="RegisterOnStartLoadingEvent"/>.
     /// </summary>
     /// <param name="onLoadAction">The method to invoke. This action will not be invoked a second time.</param>
-    public static void RegisterOnLoadEvent(Action onLoadAction)
+    public static void RegisterOnFinishLoadEvent(Action onLoadAction)
     {
-        SaveUtilsPatcher.OnLoadEvents += onLoadAction;
+        SaveUtilsPatcher.OnFinishLoadingEvents += onLoadAction;
+    }
+
+    /// <summary>
+    /// Registers a simple <see cref="Action"/> method to invoke immediately after the <c>first time</c> the player loads a saved game via the in game menu.
+    /// </summary>
+    /// <param name="onStartLoadingAction">The method to invoke. This action will not be invoked a second time.</param>
+    public static void RegisterOnStartLoadingEvent(Action onStartLoadingAction)
+    {
+        SaveUtilsPatcher.OnStartLoadingEvents += onStartLoadingAction;
     }
 
     /// <summary>
@@ -53,13 +63,13 @@ public static class SaveUtils
     }
 
     /// <summary>
-    /// Removes a method previously added through <see cref="RegisterOnLoadEvent(Action)"/> so it is no longer invoked when loading the game.<para/>
+    /// Removes a method previously added through <see cref="RegisterOnFinishLoadEvent(Action)"/> so it is no longer invoked when loading the game.<para/>
     /// If you plan on using this, do not register an anonymous method.
     /// </summary>
     /// <param name="onLoadAction">The method invoked.</param>
     public static void UnregisterOnLoadEvent(Action onLoadAction)
     {
-        SaveUtilsPatcher.OnLoadEvents -= onLoadAction;
+        SaveUtilsPatcher.OnFinishLoadingEvents -= onLoadAction;
     }
 
     /// <summary>


### PR DESCRIPTION
### Changes made in this pull request

- FIXED issue where SaveDataCache was essentially useless without modifications...
  - The SaveDataCache now loads BEFORE the game is loaded, not AFTER it finishes loading.
- Added `RegisterOnStartLoadingEvent`.
- Renamed `RegisterOnLoadEvent` to `RegisterOnFinishLoadingEvent`.

### Breaking changes

  - Renamed `RegisterOnLoadEvent` to `RegisterOnFinishLoadingEvent`.