### PR TITLE
Caching Proper Prefabs Fixes

### DIFF
--- a/Nautilus/Assets/CustomPrefab.cs
+++ b/Nautilus/Assets/CustomPrefab.cs
@@ -117,6 +117,9 @@ public class CustomPrefab : ICustomPrefab
     private readonly List<Action> _onRegister = new();
     private readonly List<Action> _onUnregister = new();
 
+    // Very simple way of preventing Unity from unloading asset bundle prefabs via Resources.UnloadUnusedAssets.
+    private GameObject _prefab;
+    
     private bool _registered;
 
     /// <inheritdoc/>
@@ -257,12 +260,17 @@ public class CustomPrefab : ICustomPrefab
     /// </summary>
     /// <param name="prefabTemplate">The prefab template object to set.</param>
     public void SetGameObject(PrefabTemplate prefabTemplate) => Prefab = prefabTemplate.GetPrefabAsync;
-    
+
     /// <summary>
     /// Sets a game object as the prefab of this custom prefab.
     /// </summary>
+    /// <remarks>Only use this overload on GameObjects that are loaded from asset bundles <b>without</b> instantiating them. For objects that could be destroyed on scene load, use <see cref="SetGameObject(System.Func{UnityEngine.GameObject})"/> instead.</remarks>
     /// <param name="prefab">The game object to set.</param>
-    public void SetGameObject(GameObject prefab) => Prefab = obj => SyncPrefab(obj, prefab);
+    public void SetGameObject(GameObject prefab)
+    {
+        _prefab = prefab;
+        Prefab = obj => SyncPrefab(obj, prefab);
+    }
     
     /// <summary>
     /// Sets a function as the game object constructor of this custom prefab. This is a synchronous version.

--- a/Nautilus/Assets/ModPrefabCache.cs
+++ b/Nautilus/Assets/ModPrefabCache.cs
@@ -1,5 +1,6 @@
 using Nautilus.Utility;
 using System.Collections.Generic;
+using Nautilus.Extensions;
 using UnityEngine;
 
 namespace Nautilus.Assets;
@@ -88,8 +89,16 @@ internal class ModPrefabCacheInstance : MonoBehaviour
 
     public void EnterPrefabIntoCache(GameObject prefab)
     {
-        prefab.transform.parent = _prefabRoot;
-        prefab.SetActive(true);
+        // Proper prefabs can never exist in the scene, so parenting them is dangerous and pointless. 
+        if (prefab.IsPrefab())
+        {
+            InternalLogger.Debug($"Game Object: {prefab} is a proper prefab. Skipping parenting for cache.");
+        }
+        else
+        {
+            prefab.transform.parent = _prefabRoot;
+            prefab.SetActive(true);
+        }
 
         var prefabIdentifier = prefab.GetComponent<PrefabIdentifier>();
 

--- a/Nautilus/Assets/PrefabTemplates/AssetBundleTemplate.cs
+++ b/Nautilus/Assets/PrefabTemplates/AssetBundleTemplate.cs
@@ -14,13 +14,14 @@ namespace Nautilus.Assets.PrefabTemplates;
 /// </summary>
 public class AssetBundleTemplate : PrefabTemplate
 {
+    private GameObject _prefab;
     private static Dictionary<Assembly, AssetBundle> _loadedBundles = new Dictionary<Assembly, AssetBundle>();
 
     /// <summary>
     /// Instantiates a new AssetBundleTemplate
     /// </summary>
     /// <param name="bundle">The AssetBundle to load the asset from</param>
-    /// <param name="prefabName">The name of the prefab gameobject to load from the bundle</param>
+    /// <param name="prefabName">The name of the prefab game object to load from the bundle</param>
     /// <param name="info">The prefab info to base this template off of.</param>
     public AssetBundleTemplate(AssetBundle bundle, string prefabName, PrefabInfo info) : base(info)
     {
@@ -53,8 +54,6 @@ public class AssetBundleTemplate : PrefabTemplate
 
         _prefab = bundle.LoadAsset<GameObject>(prefabName);
     }
-
-    private GameObject _prefab;
 
     /// <inheritdoc/>
     public override IEnumerator GetPrefabAsync(TaskResult<GameObject> gameObject)

--- a/Nautilus/Extensions/GameObjectExtensions.cs
+++ b/Nautilus/Extensions/GameObjectExtensions.cs
@@ -128,4 +128,14 @@ public static class GameObjectExtensions
     /// <param name="name">The name of the object that is being searched for.</param>
     /// <returns></returns>
     public static GameObject SearchChild(this GameObject gameObject, string name) => SearchChild(gameObject.transform, name).gameObject;
+
+    /// <summary>
+    /// Checks if this game object is a proper prefab. Proper prefabs are those that are made via the Unity Editor and are .prefab formatted.
+    /// </summary>
+    /// <param name="gameObject">The game object to check.</param>
+    /// <returns>True if this game object is a proper prefab, otherwise false.</returns>
+    public static bool IsPrefab(this GameObject gameObject)
+    {
+        return !gameObject.activeInHierarchy && gameObject.activeSelf;
+    }
 }

--- a/Nautilus/Extensions/GameObjectExtensions.cs
+++ b/Nautilus/Extensions/GameObjectExtensions.cs
@@ -136,6 +136,6 @@ public static class GameObjectExtensions
     /// <returns>True if this game object is a proper prefab, otherwise false.</returns>
     public static bool IsPrefab(this GameObject gameObject)
     {
-        return !gameObject.activeInHierarchy && gameObject.activeSelf;
+        return gameObject.transform.parent == null && !gameObject.activeInHierarchy && gameObject.activeSelf;
     }
 }


### PR DESCRIPTION
### Changes made in this pull request

  - Added `IsPrefab` extension method that checks if a game object is a proper prefab (those that have .prefab at the end)
  - Fixed `SetGameObject(GameObject)` overload never working
  - Fixed the prefab cache also parenting proper prefabs, resulting in unexpected behaviors.

I used the following code for testing:
```cs
var bundle = AssetBundle.LoadFromFile(Path.Combine(modFolder, "Assets", "projectancientsassets"));
var alphaPeeper = new CustomPrefab("AlphaPeeper", "Wtf", "Haha");
var obj = bundle.LoadAsset<GameObject>("AlphaPeeper1_Prefab");
obj.AddComponent<Printer>();
alphaPeeper.SetGameObject(obj);
alphaPeeper.Register();

class Printer : MonoBehaviour
{
  private void Start()
  {
    ErrorMessage.AddError("We do be spawned");
  }
}
```