### PR TITLE
Use the correct MarmosetUBER shader (Decals are fixed!)

### DIFF
--- a/Nautilus/Utility/MaterialUtils_Subnautica.cs
+++ b/Nautilus/Utility/MaterialUtils_Subnautica.cs
@@ -7,14 +7,14 @@ namespace Nautilus.Utility;
 
 public static partial class MaterialUtils
 {
-    private static void PatchInternal()
+    private static IEnumerator PatchInternal()
     {
-        CoroutineHost.StartCoroutine(LoadIonCubeMaterial());
-        CoroutineHost.StartCoroutine(LoadPrecursorGlassAndFogMaterial());
-        CoroutineHost.StartCoroutine(LoadStasisFieldMaterial());
-        CoroutineHost.StartCoroutine(LoadAirWaterBarrierMaterial());
-        CoroutineHost.StartCoroutine(LoadForcefieldMaterial());
-        CoroutineHost.StartCoroutine(LoadGhostMaterial());
+        yield return CoroutineHost.StartCoroutine(LoadIonCubeMaterial());
+        yield return CoroutineHost.StartCoroutine(LoadPrecursorGlassAndFogMaterial());
+        yield return CoroutineHost.StartCoroutine(LoadStasisFieldMaterial());
+        yield return CoroutineHost.StartCoroutine(LoadAirWaterBarrierMaterial());
+        yield return CoroutineHost.StartCoroutine(LoadForcefieldMaterial());
+        yield return CoroutineHost.StartCoroutine(LoadGhostMaterial());
     }
 
     /// <summary>


### PR DESCRIPTION
### Changes made in this pull request

  - The MarmosetUBER shader is now obtained from the Titanium prefab.
    - We were using an old version of the MarmosetUBER shader because that is what `Shader.Find("MarmosetUBER")` was returning.

### Breaking changes

  - Mods that apply shaders to prefabs at patch time will now need to use a coroutine and wait for `MaterialUtils.IsReady` to be true.