### PR TITLE
ConstructableFlags Fixes

### DIFF
--- a/Nautilus/Utility/PrefabUtils.cs
+++ b/Nautilus/Utility/PrefabUtils.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -43,6 +44,11 @@ public enum ConstructableFlags
     /// Can be placed inside. Combines <see cref="Base"/> and <see cref="Submarine"/>.
     /// </summary>
     Inside = Base | Submarine,
+    
+    /// <summary>
+    /// Default placement flags. Includes <see cref="Ground"/> and <see cref="Inside"/>
+    /// </summary>
+    Default = Ground | Inside,
         
     /// <summary>
     /// Can be placed outside.
@@ -57,7 +63,7 @@ public enum ConstructableFlags
     /// <summary>
     /// The constructable can be rotated during placement.
     /// </summary>
-    Rotatable = 1 << 7
+    Rotatable = 1 << 7,
 }
 
 /// <summary>
@@ -125,6 +131,8 @@ public static class PrefabUtils
         constructable.allowedOnCeiling = constructableFlags.HasFlag(ConstructableFlags.Ceiling);
         constructable.allowedOnConstructables = constructableFlags.HasFlag(ConstructableFlags.AllowedOnConstructable);
         constructable.allowedOnWall = constructableFlags.HasFlag(ConstructableFlags.Wall);
+        constructable.allowedOnGround = constructableFlags.HasFlag(ConstructableFlags.Ground);
+        constructable.rotationEnabled = constructableFlags.HasFlag(ConstructableFlags.Rotatable);
 
         if (model != null)
             constructable.model = model;
@@ -143,7 +151,7 @@ public static class PrefabUtils
     /// <param name="maxY">
     /// <para>The relative y position of where the ghost effect ends, in global coordinates relative to the model's center, taking the <paramref name="posOffset"/> into account.</para>
     /// <para>Typically a positive value because the top of an object is above its center. You may need to adjust this at runtime with Subnautica Runtime Editor to get desired results.</para></param>
-    /// <param name="posOffset">The offset of the model when being crafted (in METERS). This is generally around zero, but the y value may be ajusted up or down a few millimeters to fix clipping/floating issues.</param>
+    /// <param name="posOffset">The offset of the model when being crafted (in METERS). This is generally around zero, but the y value may be adjusted up or down a few millimeters to fix clipping/floating issues.</param>
     /// <param name="scaleFactor">The relative scale of the model. Generally is 1x for most items.</param>
     /// <param name="eulerOffset">Rotational offset.</param>
     /// <returns>The added component.</returns>
@@ -229,8 +237,8 @@ public static class PrefabUtils
         em.storageRoot = childObjectIdentifier;
         em.defaultBattery = defaultBattery;
         em.compatibleBatteries = compatibleBatteries;
-        em.batteryModels = batteryModels ?? (new EnergyMixin.BatteryModels[0]);
-        em.controlledObjects = new GameObject[0];
+        em.batteryModels = batteryModels ?? Array.Empty<EnergyMixin.BatteryModels>();
+        em.controlledObjects = Array.Empty<GameObject>();
         em.soundPowerUp = _soundPowerUp;
         em.soundPowerDown = _soundPowerDown;
 

--- a/Nautilus/Utility/PrefabUtils.cs
+++ b/Nautilus/Utility/PrefabUtils.cs
@@ -131,7 +131,12 @@ public static class PrefabUtils
         constructable.allowedOnCeiling = constructableFlags.HasFlag(ConstructableFlags.Ceiling);
         constructable.allowedOnConstructables = constructableFlags.HasFlag(ConstructableFlags.AllowedOnConstructable);
         constructable.allowedOnWall = constructableFlags.HasFlag(ConstructableFlags.Wall);
-        constructable.allowedOnGround = constructableFlags.HasFlag(ConstructableFlags.Ground);
+        
+        // dirty workaround for when the Ground flag wasn't actually functional but prefabs that used it still were allowed on ground since this is enabled
+        // by default on the Constructable component. I hate how enum flags don't get highlighted in IDEs when they're not used/implemented which led
+        // to this issue in the first place.
+        constructable.allowedOnGround = constructableFlags == ConstructableFlags.None || constructableFlags.HasFlag(ConstructableFlags.Ground);
+        
         constructable.rotationEnabled = constructableFlags.HasFlag(ConstructableFlags.Rotatable);
 
         if (model != null)


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed `ConstructableFlags.Ground` and `ConstructableFlags.Rotatable` not being implemented
  - Added `ConstructableFlags.Default`, which are the default flags if you add a `Constructable` component to a game object (ground, base, and submarine combined).

### Breaking changes

Since now we actually implement the `ConstructableFlags.Ground`, prefabs that used to _not_ include that flag may malfunction. Even after the 3dd42cfaf15b7763f9f5378245e1b1013fd354c5 workaround, those prefabs that used to have additional flags but not the Ground flag wont get the free treatment anymore.

A bug that kind of became a feature at its finest.