### PR TITLE
ApplySNShaders improvements: No specular settings applied by default, fix log spam, add comments 

### DIFF
--- a/Nautilus/Utility/MaterialUtils.cs
+++ b/Nautilus/Utility/MaterialUtils.cs
@@ -210,16 +210,15 @@ public static partial class MaterialUtils
         if (specularTexture != null)
         {
             material.SetTexture(ShaderPropertyID._SpecTex, specularTexture);
+            material.SetFloat("_SpecInt", specularIntensity);
+            material.SetFloat("_Shininess", shininess);
+            material.EnableKeyword("_ZWRITE_ON");
+            material.EnableKeyword("MARMO_SPECMAP");
+            material.SetColor(ShaderPropertyID._SpecColor, new Color(1f, 1f, 1f, 1f));
+            material.SetFloat("_Fresnel", 0.24f);
+            material.SetVector("_SpecTex_ST", new Vector4(1.0f, 1.0f, 0.0f, 0.0f));
         }
-        material.SetFloat("_SpecInt", specularIntensity);
-        material.SetFloat("_Shininess", shininess);
-        material.EnableKeyword("_ZWRITE_ON");
-        material.EnableKeyword("MARMO_SPECMAP");
-        material.enableInstancing = true;
-        material.globalIlluminationFlags = MaterialGlobalIlluminationFlags.EmissiveIsBlack | MaterialGlobalIlluminationFlags.RealtimeEmissive;
-        material.SetColor(ShaderPropertyID._SpecColor, new Color(1f, 1f, 1f, 1f));
-        material.SetFloat("_Fresnel", 0.24f);
-        material.SetVector("_SpecTex_ST", new Vector4(1.0f, 1.0f, 0.0f, 0.0f));
+        
         if (material.IsKeywordEnabled("_EMISSION"))
         {
             material.EnableKeyword("MARMO_EMISSION");
@@ -234,6 +233,9 @@ public static partial class MaterialUtils
         {
             material.EnableKeyword("MARMO_NORMALMAP");
         }
+        
+        material.enableInstancing = true;
+        material.globalIlluminationFlags = MaterialGlobalIlluminationFlags.EmissiveIsBlack | MaterialGlobalIlluminationFlags.RealtimeEmissive;
 
         switch (materialType)
         {

--- a/Nautilus/Utility/MaterialUtils.cs
+++ b/Nautilus/Utility/MaterialUtils.cs
@@ -200,13 +200,19 @@ public static partial class MaterialUtils
     /// <param name="materialType">Controls various settings including alpha clipping and transparency.</param>
     public static void ApplyUBERShader(Material material, float shininess, float specularIntensity, float glowStrength, MaterialType materialType)
     {
+        // Grab existing references to textures & colors using property names from the standard shader
         var specularTexture = material.HasProperty(ShaderPropertyID._SpecGlossMap) ? material.GetTexture(ShaderPropertyID._SpecGlossMap) : null;
         var emissionTexture = material.HasProperty(_emissionMap) ? material.GetTexture(_emissionMap) : null;
         var emissionColor = material.HasProperty(ShaderPropertyID._EmissionColor) ? material.GetColor(ShaderPropertyID._EmissionColor) : Color.black;
+
+        // Change the shader to MarmosetUBER
         material.shader = Shaders.MarmosetUBER;
 
+        // Disable keywords that were added by Unity
         material.DisableKeyword("_SPECGLOSSMAP");
         material.DisableKeyword("_NORMALMAP");
+
+        // Apply specular settings if there is a specular texture (otherwise it will appear bright white)
         if (specularTexture != null)
         {
             material.SetTexture(ShaderPropertyID._SpecTex, specularTexture);
@@ -218,7 +224,8 @@ public static partial class MaterialUtils
             material.SetFloat("_Fresnel", 0.24f);
             material.SetVector("_SpecTex_ST", new Vector4(1.0f, 1.0f, 0.0f, 0.0f));
         }
-        
+
+        // Apply emission if it was enabled in the standard shader
         if (material.IsKeywordEnabled("_EMISSION"))
         {
             material.EnableKeyword("MARMO_EMISSION");
@@ -229,6 +236,7 @@ public static partial class MaterialUtils
             material.SetFloat(ShaderPropertyID._GlowStrengthNight, glowStrength);
         }
 
+        // Apply normal map if it was applied in the standard shader
         if (material.GetTexture("_BumpMap"))
         {
             material.EnableKeyword("MARMO_NORMALMAP");

--- a/Nautilus/Utility/MaterialUtils.cs
+++ b/Nautilus/Utility/MaterialUtils.cs
@@ -202,7 +202,7 @@ public static partial class MaterialUtils
     {
         var specularTexture = material.HasProperty(ShaderPropertyID._SpecGlossMap) ? material.GetTexture(ShaderPropertyID._SpecGlossMap) : null;
         var emissionTexture = material.HasProperty(_emissionMap) ? material.GetTexture(_emissionMap) : null;
-        var emissionColor = material.GetColor(ShaderPropertyID._EmissionColor);
+        var emissionColor = material.HasProperty(ShaderPropertyID._EmissionColor) ? material.GetColor(ShaderPropertyID._EmissionColor) : Color.black;
         material.shader = Shaders.MarmosetUBER;
 
         material.DisableKeyword("_SPECGLOSSMAP");


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed a bug where specular settings were always applied even if there are no spec textures resulting in unwanted results.
  - Fixed log spam occurring because the _EmissionColor property was expected to always exist.