### PR TITLE
SML Load Order Issues

### DIFF
--- a/Nautilus/Patchers/ConsoleCommandsPatcher.cs
+++ b/Nautilus/Patchers/ConsoleCommandsPatcher.cs
@@ -11,6 +11,7 @@ using UnityEngine;
 
 namespace Nautilus.Patchers;
 
+[HarmonyAfter(SMLHelperCompatibilityPatcher.SMLHarmonyInstance)]
 internal static class ConsoleCommandsPatcher
 {
     private static Dictionary<string, ConsoleCommand> ConsoleCommands = new();

--- a/Nautilus/Patchers/CraftDataPatcher.cs
+++ b/Nautilus/Patchers/CraftDataPatcher.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 
 namespace Nautilus.Patchers;
 
+[HarmonyAfter(SMLHelperCompatibilityPatcher.SMLHarmonyInstance)]
 internal partial class CraftDataPatcher
 {
     #region Internal Fields

--- a/Nautilus/Patchers/CraftTreePatcher.cs
+++ b/Nautilus/Patchers/CraftTreePatcher.cs
@@ -8,6 +8,7 @@ using Nautilus.Utility;
 
 namespace Nautilus.Patchers;
 
+[HarmonyAfter(SMLHelperCompatibilityPatcher.SMLHarmonyInstance)]
 internal class CraftTreePatcher
 {
     #region Internal Fields

--- a/Nautilus/Patchers/CustomSoundPatcher.cs
+++ b/Nautilus/Patchers/CustomSoundPatcher.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 
 namespace Nautilus.Patchers;
 
+[HarmonyAfter(SMLHelperCompatibilityPatcher.SMLHarmonyInstance)]
 internal class CustomSoundPatcher
 {
     internal static readonly SelfCheckingDictionary<string, Sound> CustomSounds = new("CustomSounds");

--- a/Nautilus/Patchers/EnumPatcher.cs
+++ b/Nautilus/Patchers/EnumPatcher.cs
@@ -7,6 +7,7 @@ using Nautilus.Utility;
 
 namespace Nautilus.Patchers;
 
+[HarmonyAfter(SMLHelperCompatibilityPatcher.SMLHarmonyInstance)]
 internal static class EnumPatcher
 {
     internal static void Patch(Harmony harmony)

--- a/Nautilus/Patchers/ItemActionPatcher.cs
+++ b/Nautilus/Patchers/ItemActionPatcher.cs
@@ -52,13 +52,13 @@ internal class ItemActionPatcher
         // See README.md for details.
 
         harmony.Patch(AccessTools.Method(typeof(uGUI_InventoryTab), nameof(uGUI_InventoryTab.OnPointerClick)), 
-            prefix: new HarmonyMethod(AccessTools.Method(typeof(ItemActionPatcher), nameof(ItemActionPatcher.OnPointerClick_Prefix))));
+            prefix: new HarmonyMethod(AccessTools.Method(typeof(ItemActionPatcher), nameof(OnPointerClick_Prefix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance}));
 
         harmony.Patch(AccessTools.Method(typeof(Inventory), nameof(Inventory.ExecuteItemAction),new Type[] { typeof(ItemAction), typeof(InventoryItem) }), 
-            prefix: new HarmonyMethod(AccessTools.Method(typeof(ItemActionPatcher), nameof(ItemActionPatcher.ExecuteItemAction_Prefix))));
+            prefix: new HarmonyMethod(AccessTools.Method(typeof(ItemActionPatcher), nameof(ExecuteItemAction_Prefix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance}));
 
         harmony.Patch(AccessTools.Method(typeof(TooltipFactory), nameof(TooltipFactory.ItemActions)), 
-            postfix: new HarmonyMethod(AccessTools.Method(typeof(ItemActionPatcher), nameof(ItemActionPatcher.ItemActions_Postfix))));
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(ItemActionPatcher), nameof(ItemActions_Postfix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance}));
 
         if (MiddleClickActions.Count > 0 && LeftClickActions.Count > 0)
         {

--- a/Nautilus/Patchers/ItemsContainerPatcher.cs
+++ b/Nautilus/Patchers/ItemsContainerPatcher.cs
@@ -10,17 +10,17 @@ internal static class ItemsContainerPatcher
     internal static void Patch(Harmony harmony)
     {
         harmony.Patch(AccessTools.Method(typeof(ItemsContainer), nameof(ItemsContainer.HasRoomFor), new Type[] { typeof(int), typeof(int) }),
-            prefix: new HarmonyMethod(AccessTools.Method(typeof(ItemsContainerPatcher), nameof(ItemsContainerPatcher.HasRoomFor_XY_Prefix))),
-            postfix: new HarmonyMethod(AccessTools.Method(typeof(ItemsContainerPatcher), nameof(ItemsContainerPatcher.HasRoomFor_Postfix))));
+            prefix: new HarmonyMethod(AccessTools.Method(typeof(ItemsContainerPatcher), nameof(HasRoomFor_XY_Prefix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance}),
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(ItemsContainerPatcher), nameof(HasRoomFor_Postfix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance}));
 
         harmony.Patch(AccessTools.Method(typeof(ItemsContainer), nameof(ItemsContainer.NotifyAddItem)),
-            postfix: new HarmonyMethod(AccessTools.Method(typeof(ItemsContainerPatcher), nameof(ItemsContainerPatcher.NotifyChangeItem_Postfix))));
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(ItemsContainerPatcher), nameof(NotifyChangeItem_Postfix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance}));
 
         harmony.Patch(AccessTools.Method(typeof(ItemsContainer), nameof(ItemsContainer.NotifyRemoveItem)),
-            postfix: new HarmonyMethod(AccessTools.Method(typeof(ItemsContainerPatcher), nameof(ItemsContainerPatcher.NotifyChangeItem_Postfix))));
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(ItemsContainerPatcher), nameof(NotifyChangeItem_Postfix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance}));
 
         harmony.Patch(AccessTools.Method(typeof(ItemsContainer), nameof(ItemsContainer.NotifyResize)),
-            postfix: new HarmonyMethod(AccessTools.Method(typeof(ItemsContainerPatcher), nameof(ItemsContainerPatcher.NotifyChangeItem_Postfix))));
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(ItemsContainerPatcher), nameof(NotifyChangeItem_Postfix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance}));
 
         InternalLogger.Log($"ItemsContainerPatcher is done.", LogLevel.Debug);
     }

--- a/Nautilus/Patchers/LanguagePatcher.cs
+++ b/Nautilus/Patchers/LanguagePatcher.cs
@@ -81,9 +81,9 @@ internal static class LanguagePatcher
 
     internal static void Patch(Harmony harmony)
     {
-        HarmonyMethod repatchCheckMethod = new(AccessTools.Method(typeof(LanguagePatcher), nameof(RepatchCheck)));
-        HarmonyMethod insertLinesMethod = new(AccessTools.Method(typeof(LanguagePatcher), nameof(InsertCustomLines)));
-        HarmonyMethod loadLanguagesMethod = new(AccessTools.Method(typeof(LanguagePatcher), nameof(LoadLanguageFilePrefix)));
+        HarmonyMethod repatchCheckMethod = new(AccessTools.Method(typeof(LanguagePatcher), nameof(RepatchCheck)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance});
+        HarmonyMethod insertLinesMethod = new(AccessTools.Method(typeof(LanguagePatcher), nameof(InsertCustomLines)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance});
+        HarmonyMethod loadLanguagesMethod = new(AccessTools.Method(typeof(LanguagePatcher), nameof(LoadLanguageFilePrefix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance});
 
         harmony.Patch(AccessTools.Method(typeof(Language), nameof(Language.ParseMetaData)), prefix: insertLinesMethod);
         harmony.Patch(AccessTools.Method(typeof(Language), nameof(Language.GetKeysFor)), prefix: insertLinesMethod);

--- a/Nautilus/Patchers/LargeWorldStreamerPatcher.cs
+++ b/Nautilus/Patchers/LargeWorldStreamerPatcher.cs
@@ -17,7 +17,7 @@ internal class LargeWorldStreamerPatcher
     internal static void Patch(Harmony harmony)
     {
         System.Reflection.MethodInfo initializeOrig = AccessTools.Method(typeof(LargeWorldStreamer), nameof(LargeWorldStreamer.Initialize));
-        HarmonyMethod initPostfix = new(AccessTools.Method(typeof(LargeWorldStreamerPatcher), nameof(InitializePostfix)));
+        HarmonyMethod initPostfix = new(AccessTools.Method(typeof(LargeWorldStreamerPatcher), nameof(InitializePostfix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance});
         harmony.Patch(initializeOrig, postfix: initPostfix);
     }
 

--- a/Nautilus/Patchers/LootDistributionPatcher.cs
+++ b/Nautilus/Patchers/LootDistributionPatcher.cs
@@ -12,7 +12,7 @@ internal class LootDistributionPatcher
     internal static void Patch(Harmony harmony)
     {
         harmony.Patch(AccessTools.Method(typeof(LootDistributionData), nameof(LootDistributionData.Initialize)),
-            postfix: new HarmonyMethod(AccessTools.Method(typeof(LootDistributionPatcher), nameof(LootDistributionPatcher.InitializePostfix))));
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(LootDistributionPatcher), nameof(InitializePostfix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance}));
 
         InternalLogger.Log("LootDistributionPatcher is done.", LogLevel.Debug);
     }

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -34,6 +34,7 @@ internal class OptionsPanelPatcher
     // 'Mods' tab also added in QModManager, so we can't rely on 'modsTab' in AddTabs_Postfix
     [HarmonyPostfix]
     [HarmonyPatch(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.AddTab))]
+    [HarmonyAfter(SMLHelperCompatibilityPatcher.SMLHarmonyInstance)]
     internal static void AddTab_Postfix(uGUI_TabbedControlsPanel __instance, string label, int __result)
     {
         if(__instance is not uGUI_OptionsPanel)
@@ -47,6 +48,7 @@ internal class OptionsPanelPatcher
 
     [HarmonyPrefix]
     [HarmonyPatch(typeof(uGUI_Binding), nameof(uGUI_Binding.RefreshValue))]
+    [HarmonyAfter(SMLHelperCompatibilityPatcher.SMLHarmonyInstance)]
     internal static bool RefreshValue_Prefix(uGUI_Binding __instance)
     {
         if (__instance.gameObject.GetComponent<ModBindingTag>() is null)
@@ -61,6 +63,7 @@ internal class OptionsPanelPatcher
 
     [HarmonyPostfix]
     [HarmonyPatch(typeof(uGUI_OptionsPanel), nameof(uGUI_OptionsPanel.AddTabs))]
+    [HarmonyAfter(SMLHelperCompatibilityPatcher.SMLHarmonyInstance)]
     internal static void AddTabs_Postfix(uGUI_OptionsPanel __instance)
     {
         uGUI_OptionsPanel optionsPanel = __instance;

--- a/Nautilus/Patchers/PDAEncyclopediaPatcher.cs
+++ b/Nautilus/Patchers/PDAEncyclopediaPatcher.cs
@@ -11,7 +11,7 @@ internal class PDAEncyclopediaPatcher
     internal static void Patch(Harmony harmony)
     {
         harmony.Patch(AccessTools.Method(typeof(PDAEncyclopedia), nameof(PDAEncyclopedia.Initialize)),
-            postfix: new HarmonyMethod(AccessTools.Method(typeof(PDAEncyclopediaPatcher), nameof(PDAEncyclopediaPatcher.InitializePostfix))));
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(PDAEncyclopediaPatcher), nameof(InitializePostfix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance}));
     }
 
     internal static void InitializePostfix()

--- a/Nautilus/Patchers/PDAEncyclopediaTabPatcher.cs
+++ b/Nautilus/Patchers/PDAEncyclopediaTabPatcher.cs
@@ -11,6 +11,7 @@ internal class PDAEncyclopediaTabPatcher
     }
     [HarmonyPatch(typeof(uGUI_EncyclopediaTab))]
     [HarmonyPatch(nameof(uGUI_EncyclopediaTab.Awake))]
+    [HarmonyAfter(SMLHelperCompatibilityPatcher.SMLHarmonyInstance)]
     [HarmonyPostfix]
     internal static void EncyTabAwakePostfix(uGUI_EncyclopediaTab __instance)
     {

--- a/Nautilus/Patchers/PDALogPatcher.cs
+++ b/Nautilus/Patchers/PDALogPatcher.cs
@@ -10,7 +10,7 @@ internal class PDALogPatcher
     internal static void Patch(Harmony harmony)
     {
         harmony.Patch(AccessTools.Method(typeof(PDALog), nameof(PDALog.Initialize)), 
-            postfix: new HarmonyMethod(AccessTools.Method(typeof(PDALogPatcher), nameof(InitializePostfix))));
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(PDALogPatcher), nameof(InitializePostfix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance}));
     }
 
     internal static void InitializePostfix()

--- a/Nautilus/Patchers/PdaPatcher.cs
+++ b/Nautilus/Patchers/PdaPatcher.cs
@@ -18,7 +18,7 @@ internal class PDAPatcher
     internal static void Patch(Harmony harmony)
     {
         harmony.Patch(AccessTools.Method(typeof(PDAScanner), nameof(PDAScanner.Initialize)),
-            postfix: new HarmonyMethod(AccessTools.Method(typeof(PDAPatcher), nameof(PDAPatcher.InitializePostfix))));
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(PDAPatcher), nameof(PDAPatcher.InitializePostfix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance}));
 
         InternalLogger.Log($"PDAPatcher is done.", LogLevel.Debug);
     }

--- a/Nautilus/Patchers/PrefabDatabasePatcher.cs
+++ b/Nautilus/Patchers/PrefabDatabasePatcher.cs
@@ -17,6 +17,7 @@ internal static class PrefabDatabasePatcher
     {
         [HarmonyPostfix]
         [HarmonyPatch(typeof(PrefabDatabase), nameof(PrefabDatabase.LoadPrefabDatabase))]
+        [HarmonyAfter(SMLHelperCompatibilityPatcher.SMLHarmonyInstance)]
         internal static void LoadPrefabDatabase_Postfix()
         {
             foreach (var prefab in PrefabHandler.Prefabs)
@@ -28,6 +29,7 @@ internal static class PrefabDatabasePatcher
 
     [HarmonyPrefix]
     [HarmonyPatch(typeof(PrefabDatabase), nameof(PrefabDatabase.TryGetPrefabFilename))]
+    [HarmonyAfter(SMLHelperCompatibilityPatcher.SMLHarmonyInstance)]
     internal static bool TryGetPrefabFilename_Prefix(string classId, ref string filename, ref bool __result)
     {
         if (!PrefabHandler.Prefabs.TryGetInfoForClassId(classId, out PrefabInfo prefabInfo))
@@ -42,6 +44,7 @@ internal static class PrefabDatabasePatcher
 
     [HarmonyPrefix]
     [HarmonyPatch(typeof(DeferredSpawner.AddressablesTask), nameof(DeferredSpawner.AddressablesTask.SpawnAsync))]
+    [HarmonyAfter(SMLHelperCompatibilityPatcher.SMLHarmonyInstance)]
     internal static bool DeferredSpawner_AddressablesTask_Spawn_Prefix(DeferredSpawner.AddressablesTask __instance, ref IEnumerator __result)
     {
         if (!PrefabHandler.Prefabs.TryGetInfoForFileName(__instance.key, out PrefabInfo prefabInfo))
@@ -90,6 +93,7 @@ internal static class PrefabDatabasePatcher
 
     [HarmonyPrefix]
     [HarmonyPatch(typeof(PrefabDatabase), nameof(PrefabDatabase.GetPrefabAsync))]
+    [HarmonyAfter(SMLHelperCompatibilityPatcher.SMLHarmonyInstance)]
     internal static bool GetPrefabAsync_Prefix(ref IPrefabRequest __result, string classId)
     {
         __result ??= GetModPrefabAsync(classId);
@@ -101,6 +105,7 @@ internal static class PrefabDatabasePatcher
     { 
         typeof(string), typeof(IOut<GameObject>), typeof(Transform), typeof(Vector3), typeof(Quaternion), typeof(bool)
     })]
+    [HarmonyAfter(SMLHelperCompatibilityPatcher.SMLHarmonyInstance)]
     internal static bool InstantiateAsync_Prefix(ref IEnumerator __result,string key, IOut<GameObject> result, Transform parent, Vector3 position, Quaternion rotation, bool awake)
     {
         if (!PrefabHandler.Prefabs.TryGetInfoForFileName(key, out var prefabInfo) && !PrefabHandler.Prefabs.TryGetInfoForClassId(key, out prefabInfo))

--- a/Nautilus/Patchers/SpritePatcher.cs
+++ b/Nautilus/Patchers/SpritePatcher.cs
@@ -48,8 +48,8 @@ internal class SpritePatcher
 #endif
         MethodInfo spriteManagerGetBackground = AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.GetBackground), new Type[] { typeof(CraftData.BackgroundType) });
 
-        HarmonyMethod patchCheck = new(AccessTools.Method(typeof(SpritePatcher), nameof(SpritePatcher.PatchCheck)));
-        HarmonyMethod patchBackgrounds = new(AccessTools.Method(typeof(SpritePatcher), nameof(PatchBackgrounds)));
+        HarmonyMethod patchCheck = new(AccessTools.Method(typeof(SpritePatcher), nameof(SpritePatcher.PatchCheck)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance});
+        HarmonyMethod patchBackgrounds = new(AccessTools.Method(typeof(SpritePatcher), nameof(PatchBackgrounds)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance});
         harmony.Patch(spriteManagerGet, prefix: patchCheck);
         harmony.Patch(spriteManagerGetBackground, prefix: patchBackgrounds);
     }

--- a/Nautilus/Patchers/WorldEntityDatabasePatcher.cs
+++ b/Nautilus/Patchers/WorldEntityDatabasePatcher.cs
@@ -12,7 +12,7 @@ internal class WorldEntityDatabasePatcher
     internal static void Patch(Harmony harmony)
     {
         harmony.Patch(AccessTools.Method(typeof(WorldEntityDatabase), nameof(WorldEntityDatabase.TryGetInfo)),
-            prefix: new HarmonyMethod(AccessTools.Method(typeof(WorldEntityDatabasePatcher), nameof(WorldEntityDatabasePatcher.Prefix))));
+            prefix: new HarmonyMethod(AccessTools.Method(typeof(WorldEntityDatabasePatcher), nameof(WorldEntityDatabasePatcher.Prefix)), after: new []{SMLHelperCompatibilityPatcher.SMLHarmonyInstance}));
     }
 
     private static bool Prefix(string classId, ref WorldEntityInfo info, ref bool __result)


### PR DESCRIPTION
### Changes made in this pull request

  - All patches now get executed _after_ SML patches. This is necessary because in the case of clashing (which exists and especially noticeable for craft trees (fabricators)), Nautilus still has the last word and never gets hidden by SML.

This is a big change and does make having both SML and Nautilus installed at the same time a worse experience for SML mods, but Nautilus is now always in favor.

I'm aware that I didn't include some patches in this PR, and those were only postfixes and new features. Both of those aren't possible to clash.

**Please test this PR thoroughly**

A price to pay, but hopefully a worthwhile one.

### Breaking changes

  - Nautilus is now the big boss instead of previously SML.