### PR TITLE
SpriteManager Race Conditions BZ

### DIFF
--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -51,6 +51,7 @@ public class Initializer : BaseUnityPlugin
         ConsoleCommandsPatcher.Patch(_harmony);
         LanguagePatcher.Patch(_harmony);
         PrefabDatabasePatcher.PostPatch(_harmony);
+        SpritePatcher.Patch(_harmony);
         KnownTechPatcher.Patch(_harmony);
         OptionsPanelPatcher.Patch(_harmony);
         SMLHelperCompatibilityPatcher.Patch(_harmony);

--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -1,12 +1,12 @@
 using System;
-using System.Collections.Generic;
 using BepInEx;
 using HarmonyLib;
 using Nautilus.Patchers;
 using Nautilus.Utility;
 using UnityEngine;
-using UnityEngine.ResourceManagement.AsyncOperations;
+#if BELOWZERO
 using UnityEngine.U2D;
+#endif
 
 namespace Nautilus;
 

--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Collections.Generic;
 using BepInEx;
 using HarmonyLib;
 using Nautilus.Patchers;
 using Nautilus.Utility;
 using UnityEngine;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.U2D;
 
 namespace Nautilus;
 
@@ -15,6 +18,16 @@ namespace Nautilus;
 public class Initializer : BaseUnityPlugin
 {
     private static readonly Harmony _harmony = new(PluginInfo.PLUGIN_GUID);
+
+#if BELOWZERO
+    static Initializer()
+    {
+        var handle = AddressablesUtility.LoadAllAsync<SpriteAtlas>("SpriteAtlases");
+        handle.Completed += SpriteManager.OnLoadedSpriteAtlases;
+        // Please dont use this method. I hate using it but we have no other choice.
+        _ = handle.WaitForCompletion();
+    }
+#endif
 
     /// <summary>
     /// WARNING: This method is for use only by BepInEx.
@@ -38,7 +51,6 @@ public class Initializer : BaseUnityPlugin
         ConsoleCommandsPatcher.Patch(_harmony);
         LanguagePatcher.Patch(_harmony);
         PrefabDatabasePatcher.PostPatch(_harmony);
-        SpritePatcher.Patch(_harmony);
         KnownTechPatcher.Patch(_harmony);
         OptionsPanelPatcher.Patch(_harmony);
         SMLHelperCompatibilityPatcher.Patch(_harmony);


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed an issue where the SpriteManager is initialized too late in BZ resulting in race conditions whenever you call the `SpriteManager.Get` method.

I've only tested the example mod and it works like a charm. However, further testing is needed.

**Requires testing**

