### PR TITLE
MarmosetUBER is initialized too late

### DIFF
--- a/Nautilus/Utility/MaterialUtils.cs
+++ b/Nautilus/Utility/MaterialUtils.cs
@@ -19,19 +19,12 @@ public static partial class MaterialUtils
 
     private static IEnumerator LoadReferences()
     {
-        yield return LoadMarmosetUBER();
 #if SUBNAUTICA
         yield return PatchInternal();
 #endif
         IsReady = true;
-    }
-
-    // Shader.Find("MarmosetUBER") returns the wrong shader, so we need to get it in this way:
-    private static IEnumerator LoadMarmosetUBER()
-    {
-        var titaniumTask = CraftData.GetPrefabForTechTypeAsync(TechType.Titanium);
-        yield return titaniumTask;
-        Shaders.MarmosetUBER = titaniumTask.GetResult().GetComponentInChildren<Renderer>(true).material.shader;
+        
+        yield break;
     }
 
     /// <summary>
@@ -53,16 +46,12 @@ public static partial class MaterialUtils
         {
             get
             {
+                // Shader.Find("MarmosetUBER") returns the wrong shader, so we need to get it in this way:
                 if (_marmosetUber == null)
                 {
-                    InternalLogger.Warn("Attempting to access the MaterialUtils.Shaders.MarmosetUBER property before it is ready! " +
-                        "Consider delaying your logic until Nautilus.Utility.MaterialUtils.IsReady equals true.");
+                    _marmosetUber = AddressablesUtility.LoadAsync<Shader>("Assets/Marmoset/Shader/Uber/MarmosetUber.shader").WaitForCompletion();
                 }
                 return _marmosetUber;
-            }
-            internal set
-            {
-                _marmosetUber = value;
             }
         }
 


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed an issue where the MarmosetUBER is initialized quite a bit late in the stack, resulting in possible race conditions.

I've tested this both in SN1 and BZ and it's working as expected.

Special thanks to UWE, especially Artyom for their insights and assistance in making this fix a possibility.