### PR TITLE
New WithTechType overload and explicit cast from Enum to EnumBuilder<Enum>

### DIFF
--- a/Nautilus/Assets/PrefabInfo.cs
+++ b/Nautilus/Assets/PrefabInfo.cs
@@ -16,6 +16,34 @@ public record struct PrefabInfo(string ClassID, string PrefabFileName, TechType 
     /// <summary>
     /// Constructs a new <see cref="PrefabInfo"/> instance with automatically set <see cref="PrefabFileName"/> and <see cref="TechType"/>.
     /// </summary>
+    /// <remarks>This overload does not do anything about the language side of this prefab (DisplayName and Description) and assumes that the entries were already added.<br/>
+    /// For the DisplayName, the language line must be "{ClassID}".<br/>
+    /// For the Description, the language line must be "Tooltip_{ClassID}" instead.</remarks>
+    /// <param name="classId">The class identifier used for the <see cref="PrefabIdentifier"/> component whenever applicable.</param>
+    /// <param name="unlockAtStart">Whether this tech type should be unlocked on game start or not. Default to <see langword="true"/>.</param>
+    /// <param name="techTypeOwner">The assembly that owns the created tech type. The name of this assembly will be shown in the PDA.</param>
+    /// <returns>An instance of the constructed <see cref="PrefabInfo"/>.</returns>
+    /// <seealso cref="WithTechType(string, string, string, string, bool, System.Reflection.Assembly)"/>
+    /// <seealso cref="LanguageHandler.SetLanguageLine"/>
+    /// <seealso cref="LanguageHandler.RegisterLocalizationFolder"/>
+    /// <seealso cref="LanguageHandler.RegisterLocalization"/>
+    public static PrefabInfo WithTechType(string classId, bool unlockAtStart = true, Assembly techTypeOwner = null)
+    {
+        techTypeOwner ??= Assembly.GetCallingAssembly();
+        techTypeOwner = techTypeOwner == Assembly.GetExecutingAssembly()
+            ? ReflectionHelper.CallingAssemblyByStackTrace()
+            : techTypeOwner;
+        return new PrefabInfo
+        (
+            classId, 
+            classId + "Prefab",
+            EnumHandler.AddEntry<TechType>(classId, techTypeOwner).WithPdaInfo(null, null, unlockAtStart: unlockAtStart)
+        );
+    }
+    
+    /// <summary>
+    /// Constructs a new <see cref="PrefabInfo"/> instance with automatically set <see cref="PrefabFileName"/> and <see cref="TechType"/>.
+    /// </summary>
     /// <param name="classId">The class identifier used for the <see cref="PrefabIdentifier"/> component whenever applicable.</param>
     /// <param name="displayName">The display name of this Tech Type, can be anything. If null or empty, this will use the language line "{enumName}" instead.</param>
     /// <param name="description">The tooltip displayed when hovered in the PDA, can be anything. If null or empty, this will use the language line "Tooltip_{enumName}" instead.</param>

--- a/Nautilus/Handlers/Enums/EnumBuilder.cs
+++ b/Nautilus/Handlers/Enums/EnumBuilder.cs
@@ -31,11 +31,26 @@ public sealed class EnumBuilder<TEnum> where TEnum : Enum
     /// <summary>
     /// Converts an EnumBuilder to its corresponding enum object. 
     /// </summary>
-    /// <param name="enumBuilder">The Enum Builder</param>
+    /// <param name="enumBuilder">The Enum Builder.</param>
     /// <returns>The enum object equivalent to this instance.</returns>
     public static implicit operator TEnum(EnumBuilder<TEnum> enumBuilder)
     {
         return enumBuilder.Value;
+    }
+
+    /// <summary>
+    /// Converts an Enum object to EnumBuilder.
+    /// </summary>
+    /// <param name="enum">The Enum object.</param>
+    /// <returns>The constructed enum builder for the specified enum object.</returns>
+    public static explicit operator EnumBuilder<TEnum>(TEnum @enum)
+    {
+        var enumBuilder = new EnumBuilder<TEnum>
+        {
+            _enumValue = @enum
+        };
+
+        return enumBuilder;
     }
 
     /// <summary>


### PR DESCRIPTION
### Changes made in this pull request

  - Added a `PrefabInfo.WithTechType` overload that doesn't take a display name and a description. Especially useful for tech types that have the language entries set elsewhere (E.G: localizations)
  - Added an explicit casting operator from Enum to EnumBuilder<Enum>. Can be used to cast a vanilla enum to EnumBuilder, then use the extension methods we provide for each one of them.