### PR TITLE
Mark packages as development dependencies

### DIFF
--- a/Nautilus/Nautilus.csproj
+++ b/Nautilus/Nautilus.csproj
@@ -38,12 +38,12 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.0" />
+    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.0" PrivateAssets="all" />
     <PackageReference Include="UnityEngine.Modules" Version="2019.4.36" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
-    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.1.0" />
-    <PackageReference Include="PolySharp" Version="1.13.1" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.1.0" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.13.1" PrivateAssets="all" />
 
     <Publicize Include="Newtonsoft.Json" />
   </ItemGroup>


### PR DESCRIPTION
### Changes made in this pull request

- Set `BepInEx.AssemblyPublicizer`, `BepInEx.PluginInfoProps` and `PolySharp` as development dependencies, as they are not necessarily needed by downstream projects looking to install the NuGet package.