### PR TITLE
Fix mod message holding not being disabled at game start

### DIFF
--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -3,6 +3,7 @@ using BepInEx;
 using HarmonyLib;
 using Nautilus.Patchers;
 using Nautilus.Utility;
+using Nautilus.Utility.ModMessages;
 using UnityEngine;
 #if BELOWZERO
 using UnityEngine.U2D;
@@ -76,5 +77,6 @@ public class Initializer : BaseUnityPlugin
         NewtonsoftJsonPatcher.Patch(_harmony);
         InventoryPatcher.Patch(_harmony);
         WaterParkPatcher.Patch(_harmony);
+        ModMessageSystem.Patch();
     }
 }

--- a/Nautilus/Utility/ModMessages/ModMessageSystem.cs
+++ b/Nautilus/Utility/ModMessages/ModMessageSystem.cs
@@ -7,7 +7,7 @@ namespace Nautilus.Utility.ModMessages;
 /// </summary>
 public static class ModMessageSystem
 {
-    static ModMessageSystem()
+    internal static void Patch()
     {
         SaveUtils.RegisterOnStartLoadingEvent(OnStartLoading);
     }


### PR DESCRIPTION
### Changes made in this pull request

  - Moved the start loading event registration later (from static constructor to plugin initialization) to address a race condition that resulted in the callback never being handled.
  - Now, mod messages can ONLY be held in the main menu before any save has been loaded.

### Breaking changes

  - This will break any mods that relied on holding mod messages at runtime (chances are no mods were affected).