### PR TITLE
Remove custom tech type be unlocked by default

### DIFF
--- a/Nautilus/Assets/PrefabInfo.cs
+++ b/Nautilus/Assets/PrefabInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using Nautilus.Handlers;
 using Nautilus.Utility;
 using UnityEngine;
@@ -51,7 +51,7 @@ public record struct PrefabInfo(string ClassID, string PrefabFileName, TechType 
     /// <param name="unlockAtStart">Whether this tech type should be unlocked on game start or not. Default to <see langword="true"/>.</param>
     /// <param name="techTypeOwner">The assembly that owns the created tech type. The name of this assembly will be shown in the PDA.</param>
     /// <returns>An instance of the constructed <see cref="PrefabInfo"/>.</returns>
-    public static PrefabInfo WithTechType(string classId, string displayName, string description, string language = "English", bool unlockAtStart = true, Assembly techTypeOwner = null)
+    public static PrefabInfo WithTechType(string classId, string displayName, string description, string language = "English", bool unlockAtStart = false, Assembly techTypeOwner = null)
     {
         techTypeOwner ??= Assembly.GetCallingAssembly();
         techTypeOwner = techTypeOwner == Assembly.GetExecutingAssembly()

--- a/Nautilus/Assets/PrefabInfo.cs
+++ b/Nautilus/Assets/PrefabInfo.cs
@@ -27,7 +27,7 @@ public record struct PrefabInfo(string ClassID, string PrefabFileName, TechType 
     /// <seealso cref="LanguageHandler.SetLanguageLine"/>
     /// <seealso cref="LanguageHandler.RegisterLocalizationFolder"/>
     /// <seealso cref="LanguageHandler.RegisterLocalization"/>
-    public static PrefabInfo WithTechType(string classId, bool unlockAtStart = true, Assembly techTypeOwner = null)
+    public static PrefabInfo WithTechType(string classId, bool unlockAtStart = false, Assembly techTypeOwner = null)
     {
         techTypeOwner ??= Assembly.GetCallingAssembly();
         techTypeOwner = techTypeOwner == Assembly.GetExecutingAssembly()

--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_TechType.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_TechType.cs
@@ -16,7 +16,7 @@ public static partial class EnumExtensions
     /// <param name="language">The language for this entry. Defaults to English.</param>
     /// <param name="unlockAtStart">Whether this instance should be unlocked on game start or not.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
-    public static EnumBuilder<TechType> WithPdaInfo(this EnumBuilder<TechType> builder, string displayName, string tooltip, string language = "English", bool unlockAtStart = true)
+    public static EnumBuilder<TechType> WithPdaInfo(this EnumBuilder<TechType> builder, string displayName, string tooltip, string language = "English", bool unlockAtStart = false)
     {
         TechType techType = builder;
         var name = techType.ToString();


### PR DESCRIPTION
### Changes made in this pull request

  - Instead of making the unlockedAtStart parameter in the [PrefabInfo.WithTechType](https://github.com/SubnauticaModding/Nautilus/blob/master/Nautilus/Assets/PrefabInfo.cs#L54) and [EnumExtensions.WithPdaInfo](https://github.com/SubnauticaModding/Nautilus/blob/master/Nautilus/Handlers/Enums/Extensions/EnumExtensions_TechType.cs#L19) set to true by default, it should be false.

### Breaking changes

  - Unless people specify that things are unlocked they will not be.