### PR TITLE
Update ModCraftTreeLinkingNode.cs

### DIFF
--- a/Nautilus/Crafting/ModCraftTreeLinkingNode.cs
+++ b/Nautilus/Crafting/ModCraftTreeLinkingNode.cs
@@ -1,9 +1,7 @@
 ﻿using System.Collections.Generic;
 using Nautilus.Handlers;
-using Nautilus.Utility;
 using UnityEngine;
 using UnityEngine.Assertions;
-using static HandReticle;
 
 namespace Nautilus.Crafting;
 

--- a/Nautilus/Crafting/ModCraftTreeLinkingNode.cs
+++ b/Nautilus/Crafting/ModCraftTreeLinkingNode.cs
@@ -62,7 +62,7 @@ public abstract class ModCraftTreeLinkingNode : ModCraftTreeNode
     /// Creates a new tab node for the crafting tree and links it to the calling node.
     /// </summary>
     /// <remarks>
-    /// Please not that this method will NOT set the language lines for the node and you must do it yourself.
+    /// Please note that this method will NOT set the language lines for the node and you must do it yourself.
     /// </remarks>
     /// <param name="nameID">The name/ID of this node.</param>
     /// <returns>A new tab node linked to the root node and ready to use.</returns>

--- a/Nautilus/Crafting/ModCraftTreeLinkingNode.cs
+++ b/Nautilus/Crafting/ModCraftTreeLinkingNode.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using Nautilus.Handlers;
+using Nautilus.Utility;
 using UnityEngine;
 using UnityEngine.Assertions;
+using static HandReticle;
 
 namespace Nautilus.Crafting;
 
@@ -61,6 +63,9 @@ public abstract class ModCraftTreeLinkingNode : ModCraftTreeNode
     /// <summary>
     /// Creates a new tab node for the crafting tree and links it to the calling node.
     /// </summary>
+    /// <remarks>
+    /// Please not that this method will NOT set the language lines for the node and you must do it yourself.
+    /// </remarks>
     /// <param name="nameID">The name/ID of this node.</param>
     /// <returns>A new tab node linked to the root node and ready to use.</returns>
     public ModCraftTreeTab AddTabNode(string nameID)
@@ -175,7 +180,6 @@ public abstract class ModCraftTreeLinkingNode : ModCraftTreeNode
     {
         foreach (TechType tType in techTypes)
         {
-            Assert.AreNotEqual(TechType.None, tType, "Attempt to add TechType.None as a crafting node.");
             AddCraftingNode(tType);
         }
     }
@@ -190,12 +194,9 @@ public abstract class ModCraftTreeLinkingNode : ModCraftTreeNode
     /// </remarks>
     public void AddModdedCraftingNode(string moddedTechTypeName)
     {
-        if (EnumHandler.TryGetValue(moddedTechTypeName, out TechType techType))
-        {
-            ModCraftTreeCraft craftNode = new(techType);
-            craftNode.LinkToParent(this);
-
-            ChildNodes.Add(craftNode);
-        }
+        var techTypeFound = EnumHandler.TryGetValue(moddedTechTypeName, out TechType techType);
+        Assert.IsTrue(techTypeFound, $"Could not find {moddedTechTypeName} when trying to AddModdedCraftingNode!");
+        
+        AddCraftingNode(techType);
     }
 }


### PR DESCRIPTION
The only place I can find for tab nodes to be added without their language lines being set is when you only pass the ID and don't give it any display text at all.

Meaning that if your using that method you need to set the language lines yourself.

### Changes made in this pull request

  - Add info that ModCraftTreeLinkingNode.AddTabNode(string nameID) does not set language lines 
  - Add check if AddModdedCraftingNode(string moddedTechTypeName) fails to find the moddedTechType

### Breaking changes

  - People will need to make sure they check if a mod is present before just willy nilly adding craft nodes.