### PR TITLE
ScanningGadget & KnownTech handling

### DIFF
--- a/Nautilus/Assets/Gadgets/CraftingGadget.cs
+++ b/Nautilus/Assets/Gadgets/CraftingGadget.cs
@@ -89,11 +89,8 @@ public class CraftingGadget : Gadget
         
         CraftDataHandler.SetRecipeData(prefab.Info.TechType, RecipeData);
         
-        if (FabricatorType == CraftTree.Type.None)
-        {
-            InternalLogger.Log($"Prefab '{prefab.Info.ClassID}' was not automatically registered into a crafting tree.");
-        }
-        else
+        
+        if (FabricatorType is not CraftTree.Type.None)
         {
             if (StepsToFabricatorTab == null || StepsToFabricatorTab.Length == 0)
             {
@@ -103,6 +100,11 @@ public class CraftingGadget : Gadget
             {
                 CraftTreeHandler.AddCraftingNode(FabricatorType, prefab.Info.TechType, StepsToFabricatorTab);
             }
+            
+        }
+        else if (!prefab.TryGetGadget(out ScanningGadget scanningGadget) || !scanningGadget.IsBuildable)
+        {
+            InternalLogger.Log($"Prefab '{prefab.Info.ClassID}' was not automatically registered into a crafting tree.");
         }
 
         if (CraftingTime >= 0f)

--- a/Nautilus/Assets/Gadgets/GadgetExtensions.cs
+++ b/Nautilus/Assets/Gadgets/GadgetExtensions.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Runtime.CompilerServices;
 using Nautilus.Crafting;
 using Nautilus.Handlers;
 using Nautilus.Json.Converters;

--- a/Nautilus/Assets/Gadgets/GadgetExtensions.cs
+++ b/Nautilus/Assets/Gadgets/GadgetExtensions.cs
@@ -55,11 +55,7 @@ public static class GadgetExtensions
             return null;
         }
 
-        if (!customPrefab.TryGetGadget(out CraftingGadget craftingGadget))
-            return customPrefab.AddGadget(new CraftingGadget(customPrefab, recipeData));
-
-        craftingGadget.RecipeData = recipeData;
-        return craftingGadget;
+        return SetRecipe(customPrefab, recipeData);
     }
 
     /// <summary>
@@ -76,6 +72,27 @@ public static class GadgetExtensions
 
         scanningGadget.RequiredForUnlock = requiredForUnlock;
         scanningGadget.FragmentsToScan = fragmentsToScan;
+        return scanningGadget;
+    }
+
+    /// <summary>
+    /// Makes this prefab a fragment.
+    /// </summary>
+    /// <param name="customPrefab">The fragment custom prefab.</param>
+    /// <param name="blueprint">The blueprint that gets unlocked once this item is scanned</param>
+    /// <param name="scanTime">The amount of seconds it takes to scan this item.</param>
+    /// <param name="fragmentsToScan">The amount of fragments required to be scanned before the blueprint is unlocked.</param>
+    /// <param name="encyKey">The encyclopedia key to unlock once the scanning is completed.</param>
+    /// <param name="destroyAfterScan">Should this object be destroyed after a successful scan?</param>
+    /// <param name="isFragment">If this is set to <see keyword="true"/>, the loot distribution will not bother spawning this fragment if the blueprint is already unlocked.<br/>
+    /// This is the default behaviour for almost all of the vanilla fragments.</param>
+    /// <returns>A reference to the created <see cref="ScanningGadget"/> to continue the scanning settings on.</returns>
+    public static ScanningGadget CreateFragment(this ICustomPrefab customPrefab, TechType blueprint, float scanTime, int fragmentsToScan = 1, string encyKey = null, bool destroyAfterScan = true, bool isFragment = true)
+    {
+        if (!customPrefab.TryGetGadget(out ScanningGadget scanningGadget))
+            scanningGadget = customPrefab.AddGadget(new ScanningGadget(customPrefab, TechType.None, fragmentsToScan));
+
+        scanningGadget.WithScannerEntry(blueprint, scanTime, isFragment, encyKey, destroyAfterScan);
         return scanningGadget;
     }
 

--- a/Nautilus/Assets/Gadgets/GadgetExtensions.cs
+++ b/Nautilus/Assets/Gadgets/GadgetExtensions.cs
@@ -167,7 +167,7 @@ public static class GadgetExtensions
     /// <summary>
     /// Sets this item as a vehicle upgrade module. Cyclops upgrades are not supported by this function.
     /// <para>If you're using this function, please do not use <see cref="SetEquipment(ICustomPrefab, EquipmentType)"/>,<br/>
-    /// it would interefere with this and possibly make the game crash or cause the mod to not work.</para>
+    /// it would interfere with this and possibly make the game crash or cause the mod to not work.</para>
     /// </summary>
     /// <param name="customPrefab">The custom prefab to set vehicle upgrade for.</param>
     /// <param name="equipmentType">The type of equipment slot this item can fit into. Preferably use something related to vehicles.</param>

--- a/Nautilus/Assets/Gadgets/ScanningGadget.cs
+++ b/Nautilus/Assets/Gadgets/ScanningGadget.cs
@@ -284,9 +284,7 @@ public class ScanningGadget : Gadget
         )
     {
         AnalysisTech ??= new KnownTech.AnalysisTech();
-        AnalysisTech.techType = RequiredForUnlock != TechType.None
-            ? RequiredForUnlock
-            : prefab.Info.TechType;
+        AnalysisTech.techType = prefab.Info.TechType;
         AnalysisTech.unlockTechTypes = RequiredForUnlock != TechType.None
             ? new() { prefab.Info.TechType }
             : new();
@@ -347,13 +345,13 @@ public class ScanningGadget : Gadget
             PDAHandler.AddCustomScannerEntry(ScannerEntryData);
         }
 
+        if (RequiredForUnlock != TechType.None)
+        {
+            KnownTechHandler.AddRequirementForUnlock(prefab.Info.TechType, RequiredForUnlock);
+        }
+
         if (CompoundTechsForUnlock is { Count: > 0 } || RequiredForUnlock != TechType.None)
         {
-            if (AnalysisTech is null && RequiredForUnlock != TechType.None)
-            {
-                KnownTechHandler.SetAnalysisTechEntry(RequiredForUnlock, new[] { prefab.Info.TechType }, KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage, KnownTechHandler.DefaultUnlockData.BlueprintUnlockSound);
-            }
-
             KnownTechPatcher.UnlockedAtStart.Remove(prefab.Info.TechType);
         }
 

--- a/Nautilus/Assets/Gadgets/ScanningGadget.cs
+++ b/Nautilus/Assets/Gadgets/ScanningGadget.cs
@@ -17,7 +17,12 @@ public class ScanningGadget : Gadget
     /// <summary>
     /// Classifies this item as buildable via the habitat builder.
     /// </summary>
-    public bool IsBuildable { get; set; }
+    public bool IsBuildable { get; private set; }
+    
+    /// <summary>
+    /// Marks this item as hard locked.
+    /// </summary>
+    public bool IsHardLocked { get; private set; }
 
     /// <summary>
     /// The blueprint that must first be scanned or picked up to unlocked this item.
@@ -192,6 +197,18 @@ public class ScanningGadget : Gadget
     }
 
     /// <summary>
+    /// Makes this item hard locked. Hard locked items are not unlocked by default even in creative and can't be unlocked using the `unlockall` command.
+    /// </summary>
+    /// <param name="isHardLocked">Should this item be hard locked?</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public ScanningGadget SetHardLocked(bool isHardLocked = true)
+    {
+        IsHardLocked = isHardLocked;
+
+        return this;
+    }
+
+    /// <summary>
     /// <para>Adds an encyclopedia entry for this item in the PDA. This method does not ask for display text, for that you must use the <see cref="LanguageHandler"/>.</para>
     /// <para>The encyclopedia entry's key will be set as the TechType string.</para>
     /// <para>The language keys for this ency are as as follows: "Ency_{TechType}" (title) and "EncyDesc_{TechType}" (description), i.e. "Ency_Peeper".</para>
@@ -362,6 +379,11 @@ public class ScanningGadget : Gadget
             (CompoundTechsForUnlock is null || CompoundTechsForUnlock.Count <= 0) && RequiredForUnlock == TechType.None && ScannerEntryData is null)
         {
             KnownTechPatcher.LockedWithNoUnlocks.Add(prefab.Info.TechType);
+        }
+
+        if (IsHardLocked)
+        {
+            KnownTechHandler.SetHardLocked(prefab.Info.TechType);
         }
     }
 }

--- a/Nautilus/Assets/Gadgets/ScanningGadget.cs
+++ b/Nautilus/Assets/Gadgets/ScanningGadget.cs
@@ -14,7 +14,10 @@ namespace Nautilus.Assets.Gadgets;
 /// </summary>
 public class ScanningGadget : Gadget
 {
-    private bool _isBuildable;
+    /// <summary>
+    /// Classifies this item as buildable via the habitat builder.
+    /// </summary>
+    public bool IsBuildable { get; set; }
 
     /// <summary>
     /// The blueprint that must first be scanned or picked up to unlocked this item.
@@ -184,7 +187,7 @@ public class ScanningGadget : Gadget
     /// <returns>A reference to this instance after the operation has completed.</returns>
     public ScanningGadget SetBuildable(bool isBuildable = true)
     {
-        _isBuildable = isBuildable;
+        IsBuildable = isBuildable;
         return this;
     }
 
@@ -320,7 +323,7 @@ public class ScanningGadget : Gadget
                 InternalLogger.Error($"Failed to add {prefab.Info.TechType.AsString()} to {GroupForPda}/{CategoryForPda} as it is not a registered combination.");
             }
             
-            if (_isBuildable)
+            if (IsBuildable)
                 CraftDataHandler.AddBuildable(prefab.Info.TechType);
         }
 

--- a/Nautilus/Assets/Gadgets/ScanningGadget.cs
+++ b/Nautilus/Assets/Gadgets/ScanningGadget.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Nautilus.Handlers;
@@ -213,6 +214,31 @@ public class ScanningGadget : Gadget
 
         return this;
     }
+    
+    /// <summary>
+    /// Adds additional info on how the Scanner tool should treat this item when scanning it.
+    /// </summary>
+    /// <param name="blueprint">The blueprint that gets unlocked once this item is scanned.</param>
+    /// <param name="scanTime">The amount of seconds it takes to scan this item.</param>
+    /// <param name="isFragment">Is this a fragment?</param>
+    /// <param name="encyKey">The encyclopedia key to unlock once the scanning is completed.</param>
+    /// <param name="destroyAfterScan">Should this object be destroyed after a successful scan?</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public ScanningGadget WithScannerEntry(TechType blueprint, float scanTime, bool isFragment = false, string encyKey = null, bool destroyAfterScan = false)
+    {
+        ScannerEntryData = new PDAScanner.EntryData
+        {
+            key = prefab.Info.TechType,
+            encyclopedia = encyKey,
+            scanTime = scanTime,
+            destroyAfterScan = destroyAfterScan,
+            isFragment = isFragment,
+            blueprint = blueprint,
+            totalFragments = FragmentsToScan,
+        };
+
+        return this;
+    }
 
     /// <summary>
     /// Adds additional info on how the Scanner tool should treat this item when scanning it.
@@ -222,6 +248,8 @@ public class ScanningGadget : Gadget
     /// <param name="encyKey">The encyclopedia key to unlock once the scanning is completed.</param>
     /// <param name="destroyAfterScan">Should this object be destroyed after a successful scan?</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <remarks>This overload overrides the PDAScanner entry data for the <see cref="RequiredForUnlock"/>'s entry.</remarks>
+    [Obsolete("Deprecated; Use WithScannerEntry(TechType, float, bool, string, bool) overload instead.")]
     public ScanningGadget WithScannerEntry(float scanTime, bool isFragment = false, string encyKey = null, bool destroyAfterScan = false)
     {
         ScannerEntryData = new PDAScanner.EntryData

--- a/Nautilus/Assets/Gadgets/ScanningGadget.cs
+++ b/Nautilus/Assets/Gadgets/ScanningGadget.cs
@@ -285,7 +285,29 @@ public class ScanningGadget : Gadget
 
         return this;
     }
+    
+    /// <summary>
+    /// Adds additional info on what should happen when this item is unlocked.
+    /// </summary>
+    /// <param name="popupSprite">The sprite that should popup on unlock.</param>
+    /// <param name="unlockSound">The sound that will be played on unlock.</param>
+    /// <param name="unlockMessage">Message which should be shown on unlock.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public ScanningGadget WithAnalysisTech(
+        Sprite popupSprite, 
+        FMODAsset unlockSound = null, 
+        string unlockMessage = null
+    )
+    {
+        return WithAnalysisTech(new KnownTech.AnalysisTech
+        {
+            unlockPopup = popupSprite,
+            unlockSound = unlockSound,
+            unlockMessage = unlockMessage
+        });
+    }
 
+#if SUBNAUTICA
     /// <summary>
     /// Adds additional info on what should happen when this item is unlocked.
     /// </summary>
@@ -296,24 +318,34 @@ public class ScanningGadget : Gadget
     /// <returns>A reference to this instance after the operation has completed.</returns>
     public ScanningGadget WithAnalysisTech(
         Sprite popupSprite, 
-#if SUBNAUTICA
         List<StoryGoal> storyGoalsToTrigger = null,
-#endif
         FMODAsset unlockSound = null, 
         string unlockMessage = null
         )
     {
-        AnalysisTech ??= new KnownTech.AnalysisTech();
+        return WithAnalysisTech(new KnownTech.AnalysisTech
+        {
+            unlockPopup = popupSprite,
+            storyGoals = storyGoalsToTrigger,
+            unlockSound = unlockSound,
+            unlockMessage = unlockMessage
+        });
+    }
+#endif
+
+    private ScanningGadget WithAnalysisTech(KnownTech.AnalysisTech analysisTech)
+    {
+        AnalysisTech = analysisTech;
         AnalysisTech.techType = prefab.Info.TechType;
         AnalysisTech.unlockTechTypes = RequiredForUnlock != TechType.None
             ? new() { prefab.Info.TechType }
             : new();
-        AnalysisTech.unlockPopup = popupSprite;
+        AnalysisTech.unlockPopup = analysisTech.unlockPopup;
 #if SUBNAUTICA
-        AnalysisTech.storyGoals = storyGoalsToTrigger ?? new();
+        AnalysisTech.storyGoals = analysisTech.storyGoals ?? new();
 #endif
-        AnalysisTech.unlockSound = unlockSound;
-        AnalysisTech.unlockMessage = unlockMessage ?? KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage;
+        AnalysisTech.unlockSound = analysisTech.unlockSound;
+        AnalysisTech.unlockMessage = analysisTech.unlockMessage ?? KnownTechHandler.DefaultUnlockData.BlueprintUnlockMessage;
 
         return this;
     }

--- a/Nautilus/Handlers/KnownTechHandler.cs
+++ b/Nautilus/Handlers/KnownTechHandler.cs
@@ -304,6 +304,7 @@ public static class KnownTechHandler
     /// </summary>
     /// <param name="targetTechType">Target <see cref="TechType"/> to remove the unlocks for.</param>
     /// <param name="techTypes">List of <see cref="TechType"/> to remove the targetTechType from.</param>
+    /// <seealso cref="RemoveAllCurrentAnalysisTechEntry"/>
     public static void RemoveAnalysisTechEntryFromSpecific(TechType targetTechType, List<TechType> techTypes)
     {
         RemoveAnalysisSpecific(targetTechType, techTypes);
@@ -311,9 +312,11 @@ public static class KnownTechHandler
 
     /// <summary>
     /// Allows you to remove all unlock entries from a <see cref="TechType"/> to be able to disable or change it to a new unlock.
-    /// ***Note: This is patch time specific so the LAST mod to call this on a techtype will be the only one to control what unlocks said type after its use.***
     /// </summary>
+    /// <remarks>The unlock entry for analysis techs for the specified <paramref name="targetTechType"/> will not be removed. I.E: This method will not remove self-unlocks.<br/>
+    /// To also target unlock entry removal for the specified tech type's analysis tech entry, use <see cref="RemoveAnalysisTechEntryFromSpecific"/> instead.</remarks>
     /// <param name="targetTechType">Target <see cref="TechType"/> to remove the unlocks for.</param>
+    /// <seealso cref="RemoveAnalysisTechEntry"/>
     public static void RemoveAllCurrentAnalysisTechEntry(TechType targetTechType)
     {
         RemoveAnalysisTechEntry(targetTechType);

--- a/Nautilus/Handlers/KnownTechHandler.cs
+++ b/Nautilus/Handlers/KnownTechHandler.cs
@@ -38,6 +38,20 @@ public static class KnownTechHandler
         Reinitialize();
     }
 
+    /// <summary>
+    /// Makes the specified tech type hard locked. Hard locking means that the tech type will not be unlocked via the unlockall command and will not be unlocked by default
+    /// in creative. 
+    /// </summary>
+    /// <remarks>Calling this method will remove the specified item from being unlocked at start.</remarks>
+    /// <param name="techType">The tech type to set as hard locked.</param>
+    /// <seealso cref="UnlockOnStart"/>
+    public static void SetHardLocked(TechType techType)
+    {
+        KnownTechPatcher.HardLocked.Add(techType);
+        KnownTechPatcher.UnlockedAtStart.Remove(techType);
+        Reinitialize();
+    }
+
     internal static void AddAnalysisTech(KnownTech.AnalysisTech analysisTech)
     {
         if (analysisTech.techType != TechType.None)

--- a/Nautilus/Handlers/KnownTechHandler.cs
+++ b/Nautilus/Handlers/KnownTechHandler.cs
@@ -12,13 +12,19 @@ namespace Nautilus.Handlers;
 /// </summary>
 public static class KnownTechHandler
 {
+    private static void Reinitialize()
+    {
+        KnownTechPatcher.Reinitialize();
+    }
+    
     /// <summary>
     /// Allows you to unlock a TechType on game start.
     /// </summary>
-    /// <param name="techType"></param>
+    /// <param name="techType">The TechType to unlock at start.</param>
     public static void UnlockOnStart(TechType techType)
     {
         KnownTechPatcher.UnlockedAtStart.Add(techType);
+        Reinitialize();
     }
 
     /// <summary>
@@ -29,6 +35,7 @@ public static class KnownTechHandler
     public static void AddRequirementForUnlock(TechType blueprint, TechType requirement)
     {
         KnownTechPatcher.BlueprintRequirements.GetOrAddNew(requirement).Add(blueprint);
+        Reinitialize();
     }
 
     internal static void AddAnalysisTech(KnownTech.AnalysisTech analysisTech)
@@ -59,10 +66,7 @@ public static class KnownTechHandler
             InternalLogger.Error("Cannot Add Unlock to TechType.None!");
         }
         
-        if (Player.main)
-        {
-            KnownTechPatcher.InitializePrefix(Player.main.pdaData);
-        }
+        Reinitialize();
     }
 
     internal static void AddAnalysisTech(
@@ -115,10 +119,7 @@ public static class KnownTechHandler
             KnownTechPatcher.CompoundTech.Add(techType, new KnownTech.CompoundTech() { techType = techType, dependencies = compoundTechsForUnlock });
         }
         
-        if (Player.main)
-        {
-            KnownTechPatcher.InitializePrefix(Player.main.pdaData);
-        }
+        Reinitialize();
     }
 
     internal static void RemoveAnalysisSpecific(TechType targetTechType, List<TechType> techTypes)
@@ -138,44 +139,32 @@ public static class KnownTechHandler
             }
         }
         
-        if (Player.main)
-        {
-            KnownTechPatcher.InitializePrefix(Player.main.pdaData);
-        }
+        Reinitialize();
     }
 
     internal static void RemoveAnalysisTechEntry(TechType targetTechType)
     {
         foreach (KnownTech.AnalysisTech tech in KnownTechPatcher.AnalysisTech.Values)
         {
-            if (tech.unlockTechTypes.Contains(targetTechType))
+            if (tech.unlockTechTypes.Remove(targetTechType))
             {
                 InternalLogger.Debug($"Removed {targetTechType.AsString()} from {tech.techType.AsString()} unlocks that was added by another mod!");
-                tech.unlockTechTypes.Remove(targetTechType);
             }
         }
 
-        if (KnownTechPatcher.CompoundTech.TryGetValue(targetTechType, out KnownTech.CompoundTech types))
+        if (KnownTechPatcher.CompoundTech.Remove(targetTechType))
         {
             InternalLogger.Debug($"Removed Compound Unlock for {targetTechType.AsString()} that was added by another mod!");
-            KnownTechPatcher.CompoundTech.Remove(targetTechType);
         }
 
-        if (KnownTechPatcher.UnlockedAtStart.Contains(targetTechType))
+        if (KnownTechPatcher.UnlockedAtStart.Remove(targetTechType))
         {
             InternalLogger.Debug($"Removed UnlockedAtStart for {targetTechType.AsString()} that was added by another mod!");
-            KnownTechPatcher.UnlockedAtStart.Remove(targetTechType);
         }
 
-        if (!KnownTechPatcher.RemovalTechs.Contains(targetTechType))
-        {
-            KnownTechPatcher.RemovalTechs.Add(targetTechType);
-        }
+        KnownTechPatcher.RemovalTechs.Add(targetTechType);
         
-        if (Player.main)
-        {
-            KnownTechPatcher.InitializePrefix(Player.main.pdaData);
-        }
+        Reinitialize();
     }
 
 

--- a/Nautilus/Handlers/KnownTechHandler.cs
+++ b/Nautilus/Handlers/KnownTechHandler.cs
@@ -46,8 +46,10 @@ public static class KnownTechHandler
             InternalLogger.Error("Cannot Add Unlock to TechType.None!");
         }
         
-        if (uGUI.isMainLevel)
-            KnownTechPatcher.InitializePostfix();
+        if (Player.main)
+        {
+            KnownTechPatcher.InitializePrefix(Player.main.pdaData);
+        }
     }
 
     internal static void AddAnalysisTech(
@@ -100,8 +102,10 @@ public static class KnownTechHandler
             KnownTechPatcher.CompoundTech.Add(techType, new KnownTech.CompoundTech() { techType = techType, dependencies = compoundTechsForUnlock });
         }
         
-        if (uGUI.isMainLevel)
-            KnownTechPatcher.InitializePostfix();
+        if (Player.main)
+        {
+            KnownTechPatcher.InitializePrefix(Player.main.pdaData);
+        }
     }
 
     internal static void RemoveAnalysisSpecific(TechType targetTechType, List<TechType> techTypes)
@@ -121,8 +125,10 @@ public static class KnownTechHandler
             }
         }
         
-        if (uGUI.isMainLevel)
-            KnownTechPatcher.InitializePostfix();
+        if (Player.main)
+        {
+            KnownTechPatcher.InitializePrefix(Player.main.pdaData);
+        }
     }
 
     internal static void RemoveAnalysisTechEntry(TechType targetTechType)
@@ -153,8 +159,10 @@ public static class KnownTechHandler
             KnownTechPatcher.RemovalTechs.Add(targetTechType);
         }
         
-        if (uGUI.isMainLevel)
-            KnownTechPatcher.InitializePostfix();
+        if (Player.main)
+        {
+            KnownTechPatcher.InitializePrefix(Player.main.pdaData);
+        }
     }
 
 

--- a/Nautilus/Handlers/KnownTechHandler.cs
+++ b/Nautilus/Handlers/KnownTechHandler.cs
@@ -21,6 +21,16 @@ public static class KnownTechHandler
         KnownTechPatcher.UnlockedAtStart.Add(techType);
     }
 
+    /// <summary>
+    /// Unlocks the <paramref name="blueprint"/> when the <paramref name="requirement"/> tech type is unlocked.
+    /// </summary>
+    /// <param name="blueprint">The blueprint to unlock.</param>
+    /// <param name="requirement">The tech type that will unlock the specified blueprint once unlocked.</param>
+    public static void AddRequirementForUnlock(TechType blueprint, TechType requirement)
+    {
+        KnownTechPatcher.BlueprintRequirements.GetOrAddNew(requirement).Add(blueprint);
+    }
+
     internal static void AddAnalysisTech(KnownTech.AnalysisTech analysisTech)
     {
         if (analysisTech.techType != TechType.None)

--- a/Nautilus/Handlers/KnownTechHandler.cs
+++ b/Nautilus/Handlers/KnownTechHandler.cs
@@ -27,17 +27,20 @@ public static class KnownTechHandler
         {
             if (KnownTechPatcher.AnalysisTech.TryGetValue(analysisTech.techType, out KnownTech.AnalysisTech existingEntry))
             {
-                existingEntry.unlockMessage = existingEntry.unlockMessage ?? analysisTech.unlockMessage;
-                existingEntry.unlockSound = existingEntry.unlockSound ?? analysisTech.unlockSound;
-                existingEntry.unlockPopup = existingEntry.unlockPopup ?? analysisTech.unlockPopup;
+                existingEntry.unlockMessage = analysisTech.unlockMessage ?? existingEntry.unlockMessage;
+                existingEntry.unlockSound = analysisTech.unlockSound ?? existingEntry.unlockSound;
+                existingEntry.unlockPopup = analysisTech.unlockPopup ?? existingEntry.unlockPopup;
                 existingEntry.unlockTechTypes.AddRange(analysisTech.unlockTechTypes);
+#if SUBNAUTICA
+                analysisTech.storyGoals ??= existingEntry.storyGoals ?? new();
+#endif
             }
             else
             {
 #if SUBNAUTICA
                 analysisTech.storyGoals ??= new();
 #endif
-                    
+                
                 KnownTechPatcher.AnalysisTech.Add(analysisTech.techType, analysisTech);
             }
         }

--- a/Nautilus/Patchers/KnownTechPatcher.cs
+++ b/Nautilus/Patchers/KnownTechPatcher.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using HarmonyLib;
-using Nautilus.Handlers;
-using Nautilus.Utility;
+﻿namespace Nautilus.Patchers;
 
-namespace Nautilus.Patchers;
+using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using Handlers;
+using Utility;
 
 internal class KnownTechPatcher
 {
@@ -31,16 +30,20 @@ internal class KnownTechPatcher
     internal static void Reinitialize()
     {
         // At this point the KnownTech stuff haven't been initialized yet, so no need to re-patch.
-        if (!Player.main)
+        if (!KnownTech.initialized)
         {
             return;
         }
 
-        var pdaData = Player.main.pdaData;
-        InitializePrefix(pdaData);
-        KnownTech.AddRange(pdaData.defaultTech, false);
+        var knownTech = KnownTech.knownTech;
+        var knownCompound = KnownTech.knownCompoundTech;
+        var pdaData = UnityEngine.Object.Instantiate(Player.main.pdaData);
+        KnownTech.Initialize(pdaData);
         KnownTech.compoundTech = KnownTech.ValidateCompoundTech(pdaData.compoundTech);
         KnownTech.analysisTech = KnownTech.ValidateAnalysisTech(pdaData.analysisTech);
+        KnownTech.knownTech.AddRange(knownTech);
+        knownCompound.ForEach(x => knownCompound.Add(x.Key, x.Value));
+        KnownTech.AddRange(pdaData.defaultTech, false);
     }
 
     private static void InitializePrefix(PDAData data)

--- a/Nautilus/Patchers/KnownTechPatcher.cs
+++ b/Nautilus/Patchers/KnownTechPatcher.cs
@@ -75,7 +75,7 @@ internal class KnownTechPatcher
             var index = data.analysisTech.FindIndex(tech => tech.techType == blueprintRequirements.Key);
             if (index == -1)
             {
-                InternalLogger.Error($"TechType '{blueprintRequirements.Key.AsString()}' does not have an analysis tech. Cancelling requirement addition.");
+                InternalLogger.Error($"TechType '{blueprintRequirements.Key.AsString()}' does not have an analysis tech. Cancelling requirement addition for TechTypes '{blueprintRequirements.Value.Join()}'.");
                 continue;
             }
             

--- a/Nautilus/Patchers/KnownTechPatcher.cs
+++ b/Nautilus/Patchers/KnownTechPatcher.cs
@@ -13,11 +13,11 @@ internal class KnownTechPatcher
 
     internal static HashSet<TechType> UnlockedAtStart = new();
     internal static HashSet<TechType> LockedWithNoUnlocks = new();
+    internal static HashSet<TechType> RemovalTechs = new();
     internal static IDictionary<TechType, KnownTech.AnalysisTech> AnalysisTech = new SelfCheckingDictionary<TechType, KnownTech.AnalysisTech>("AnalysisTech", AsStringFunction);
     internal static IDictionary<TechType, List<TechType>> BlueprintRequirements = new SelfCheckingDictionary<TechType, List<TechType>>("BlueprintRequirements", AsStringFunction);
     internal static IDictionary<TechType, KnownTech.CompoundTech> CompoundTech = new SelfCheckingDictionary<TechType, KnownTech.CompoundTech>("CompoundTech", AsStringFunction);
     internal static IDictionary<TechType, List<TechType>> RemoveFromSpecificTechs = new SelfCheckingDictionary<TechType, List<TechType>>("RemoveFromSpecificTechs", AsStringFunction);
-    internal static List<TechType> RemovalTechs = new();
 
     public static void Patch(Harmony harmony)
     {
@@ -91,6 +91,28 @@ internal class KnownTechPatcher
             {
                 InternalLogger.Debug($"Replacing compoundTech for {tech.techType}");
                 data.compoundTech[index] = tech;
+            }
+        }
+        
+        foreach (var analysisTech in data.analysisTech)
+        {
+            foreach (var removalTech in RemovalTechs)
+            {
+                if (analysisTech.unlockTechTypes.Remove(removalTech))
+                {
+                    InternalLogger.Debug($"RemovalTechs: Removed unlockTechType '{removalTech}' from '{analysisTech.techType}' AnalysisTech.");
+                }
+            }
+
+            if (RemoveFromSpecificTechs.TryGetValue(analysisTech.techType, out var techsToRemove))
+            {
+                foreach (var removalTech in techsToRemove)
+                {
+                    if (analysisTech.unlockTechTypes.Remove(removalTech))
+                    {
+                        InternalLogger.Debug($"RemoveFromSpecificTechs: Removed unlockTechType '{removalTech}' from '{analysisTech.techType}' AnalysisTech.");
+                    }
+                }
             }
         }
     }

--- a/Nautilus/Patchers/KnownTechPatcher.cs
+++ b/Nautilus/Patchers/KnownTechPatcher.cs
@@ -98,6 +98,11 @@ internal class KnownTechPatcher
         {
             foreach (var removalTech in RemovalTechs)
             {
+                if (analysisTech.techType == removalTech)
+                {
+                    continue;
+                }
+                
                 if (analysisTech.unlockTechTypes.Remove(removalTech))
                 {
                     InternalLogger.Debug($"RemovalTechs: Removed unlockTechType '{removalTech}' from '{analysisTech.techType}' AnalysisTech.");

--- a/Nautilus/Patchers/KnownTechPatcher.cs
+++ b/Nautilus/Patchers/KnownTechPatcher.cs
@@ -42,7 +42,7 @@ internal class KnownTechPatcher
         KnownTech.compoundTech = KnownTech.ValidateCompoundTech(pdaData.compoundTech);
         KnownTech.analysisTech = KnownTech.ValidateAnalysisTech(pdaData.analysisTech);
         KnownTech.knownTech.AddRange(knownTech);
-        knownCompound.ForEach(x => knownCompound.Add(x.Key, x.Value));
+        knownCompound.ForEach(x => KnownTech.knownCompoundTech.Add(x.Key, x.Value));
         KnownTech.AddRange(pdaData.defaultTech, false);
     }
 

--- a/Nautilus/Patchers/KnownTechPatcher.cs
+++ b/Nautilus/Patchers/KnownTechPatcher.cs
@@ -12,6 +12,7 @@ internal class KnownTechPatcher
 
     internal static HashSet<TechType> UnlockedAtStart = new();
     internal static HashSet<TechType> LockedWithNoUnlocks = new();
+    internal static HashSet<TechType> HardLocked = new();
     internal static HashSet<TechType> RemovalTechs = new();
     internal static IDictionary<TechType, KnownTech.AnalysisTech> AnalysisTech = new SelfCheckingDictionary<TechType, KnownTech.AnalysisTech>("AnalysisTech", AsStringFunction);
     internal static IDictionary<TechType, List<TechType>> BlueprintRequirements = new SelfCheckingDictionary<TechType, List<TechType>>("BlueprintRequirements", AsStringFunction);
@@ -129,5 +130,6 @@ internal class KnownTechPatcher
     {
         var filtered = CraftData.FilterAllowed(LockedWithNoUnlocks);
         __result.AddRange(filtered);
+        __result.RemoveRange(HardLocked);
     }
 }

--- a/Nautilus/Patchers/KnownTechPatcher.cs
+++ b/Nautilus/Patchers/KnownTechPatcher.cs
@@ -28,13 +28,23 @@ internal class KnownTechPatcher
             postfix: new HarmonyMethod(AccessTools.Method(typeof(KnownTechPatcher), nameof(GetAllUnlockablesPostfix))));
     }
 
-    internal static void InitializePrefix(PDAData data)
+    internal static void Reinitialize()
     {
-        if (KnownTech.initialized)
+        // At this point the KnownTech stuff haven't been initialized yet, so no need to re-patch.
+        if (!Player.main)
         {
             return;
         }
 
+        var pdaData = Player.main.pdaData;
+        InitializePrefix(pdaData);
+        KnownTech.AddRange(pdaData.defaultTech, false);
+        KnownTech.compoundTech = KnownTech.ValidateCompoundTech(pdaData.compoundTech);
+        KnownTech.analysisTech = KnownTech.ValidateAnalysisTech(pdaData.analysisTech);
+    }
+
+    private static void InitializePrefix(PDAData data)
+    {
         data.defaultTech.AddRange(UnlockedAtStart);
 
         foreach (var tech in AnalysisTech.Values)


### PR DESCRIPTION
### Changes made in this pull request

resolves #402 
fixes #466

  - Improved the `KnownTechPatcher` implementation; special thanks to @vlyon for the suggestion in #402 
  - Fixed AddAnalysisTech assignment being flipped, results in overwriting values never being implemented for existing entries
  - Added `AddRequirementForUnlock` method that just adds blueprints to a requirement tech type
  - Added a better `WithScannerEntry` overload for the `ScanningGadget` that doesn't override a techtype's scanner entry that it has no business in
  - `ScanningGadget` now always adds analysis tech to the current tech type, when the `WithAnalysisTech` method is called
  - Fixed log spams for buildables
  - Added hard-locking to make items not unlockable by default or by the `unlockall` command
  - Added a cross-game-friendly overload for `AnalysisTech`.

### Breaking changes

  - You can no longer set requirements for tech types that don't have an Analysis tech

### Deprecated methods
  - [ScanningGadget.WithScannerEntry](https://github.com/Metious/Nautilus/blob/95d47bb8423450bfd5f3b7b5a372abc849685af9/Nautilus/Assets/Gadgets/ScanningGadget.cs#L253)
  
### TODO:
- [x] Decide on how to implement the `KnownTechPatcher.RemovalTechs` efficiently