### PR TITLE
StoryGoal actions receive the name of the unlocked goal

### DIFF
--- a/Nautilus/Handlers/StoryGoalHandler.cs
+++ b/Nautilus/Handlers/StoryGoalHandler.cs
@@ -137,10 +137,19 @@ public static class StoryGoalHandler
     /// Registers a given <see cref="Action"/> to be performed when its associated goal is completed.
     /// </summary>
     /// <param name="key">The key of the goal that triggers the <paramref name="customEventCallback"/>.</param>
-    /// <param name="customEventCallback">The method that is called when the associated goal is completed. The name of the goal will be passed as a parameter.</param>
+    /// <param name="customEventCallback">The method that is called when the associated goal is completed.</param>
     public static void RegisterCustomEvent(string key, Action customEventCallback)
     {
         CustomStoryGoalManager.StoryGoalCustomEvents.GetOrAddNew(key).Add(customEventCallback);
+    }
+
+    /// <summary>
+    /// Registers a given <see cref="Action"/> to be performed when a goal is completed.
+    /// </summary>
+    /// <param name="customEventCallback">The method that is called when any goal is completed. The name of the goal will be passed as a parameter.</param>
+    public static void RegisterCustomEvent(Action<string> customEventCallback)
+    {
+        CustomStoryGoalManager.StoryGoalCustomKeyHandlerEvents.Add(customEventCallback);
     }
 
     /// <summary>
@@ -154,5 +163,14 @@ public static class StoryGoalHandler
         {
             callbacks.Remove(customEventCallback);
         }
+    }
+    
+    /// <summary>
+    /// Unregisters a custom event.
+    /// </summary>
+    /// <param name="customEventCallback">The method to unregister.</param>
+    public static void UnregisterCustomEvent(Action<string> customEventCallback)
+    {
+        CustomStoryGoalManager.StoryGoalCustomKeyHandlerEvents.Remove(customEventCallback);
     }
 }

--- a/Nautilus/Handlers/StoryGoalHandler.cs
+++ b/Nautilus/Handlers/StoryGoalHandler.cs
@@ -138,7 +138,7 @@ public static class StoryGoalHandler
     /// </summary>
     /// <param name="key">The key of the goal that triggers the <paramref name="customEventCallback"/>.</param>
     /// <param name="customEventCallback">The method that is called when the associated goal is completed. The name of the goal will be passed as a parameter.</param>
-    public static void RegisterCustomEvent(string key, Action customEventCallback)
+    public static void RegisterCustomEvent(string key, Action<string> customEventCallback)
     {
         CustomStoryGoalManager.StoryGoalCustomEvents.GetOrAddNew(key).Add(customEventCallback);
     }
@@ -148,7 +148,7 @@ public static class StoryGoalHandler
     /// </summary>
     /// <param name="key">The key of the goal that triggers the <paramref name="customEventCallback"/>.</param>
     /// <param name="customEventCallback">The method to unregister.</param>
-    public static void UnregisterCustomEvent(string key, Action customEventCallback)
+    public static void UnregisterCustomEvent(string key, Action<string> customEventCallback)
     {
         if (CustomStoryGoalManager.StoryGoalCustomEvents.TryGetValue(key, out var callbacks) && callbacks is { })
         {

--- a/Nautilus/Handlers/StoryGoalHandler.cs
+++ b/Nautilus/Handlers/StoryGoalHandler.cs
@@ -138,7 +138,7 @@ public static class StoryGoalHandler
     /// </summary>
     /// <param name="key">The key of the goal that triggers the <paramref name="customEventCallback"/>.</param>
     /// <param name="customEventCallback">The method that is called when the associated goal is completed. The name of the goal will be passed as a parameter.</param>
-    public static void RegisterCustomEvent(string key, Action<string> customEventCallback)
+    public static void RegisterCustomEvent(string key, Action customEventCallback)
     {
         CustomStoryGoalManager.StoryGoalCustomEvents.GetOrAddNew(key).Add(customEventCallback);
     }
@@ -148,7 +148,7 @@ public static class StoryGoalHandler
     /// </summary>
     /// <param name="key">The key of the goal that triggers the <paramref name="customEventCallback"/>.</param>
     /// <param name="customEventCallback">The method to unregister.</param>
-    public static void UnregisterCustomEvent(string key, Action<string> customEventCallback)
+    public static void UnregisterCustomEvent(string key, Action customEventCallback)
     {
         if (CustomStoryGoalManager.StoryGoalCustomEvents.TryGetValue(key, out var callbacks) && callbacks is { })
         {

--- a/Nautilus/MonoBehaviours/CustomStoryGoalManager.cs
+++ b/Nautilus/MonoBehaviours/CustomStoryGoalManager.cs
@@ -10,6 +10,7 @@ internal class CustomStoryGoalManager : MonoBehaviour, IStoryGoalListener
     public static CustomStoryGoalManager Instance { get; private set; }
     
     internal static readonly Dictionary<string, List<Action>> StoryGoalCustomEvents = new();
+    internal static readonly List<Action<string>> StoryGoalCustomKeyHandlerEvents = new();
 
     private ItemGoalTracker _itemGoalTracker;
     private BiomeGoalTracker _biomeGoalTracker;
@@ -70,6 +71,7 @@ internal class CustomStoryGoalManager : MonoBehaviour, IStoryGoalListener
             if (key == customEvent.Key)
                 customEvent.Value.ForEach(x => x?.Invoke());
         }
+        StoryGoalCustomKeyHandlerEvents.ForEach(x => x?.Invoke(key));
     }
     
 #if BELOWZERO

--- a/Nautilus/MonoBehaviours/CustomStoryGoalManager.cs
+++ b/Nautilus/MonoBehaviours/CustomStoryGoalManager.cs
@@ -9,7 +9,7 @@ internal class CustomStoryGoalManager : MonoBehaviour, IStoryGoalListener
 {
     public static CustomStoryGoalManager Instance { get; private set; }
     
-    internal static readonly Dictionary<string, List<Action>> StoryGoalCustomEvents = new();
+    internal static readonly Dictionary<string, List<Action<string>>> StoryGoalCustomEvents = new();
 
     private ItemGoalTracker _itemGoalTracker;
     private BiomeGoalTracker _biomeGoalTracker;
@@ -68,7 +68,7 @@ internal class CustomStoryGoalManager : MonoBehaviour, IStoryGoalListener
         foreach (var customEvent in StoryGoalCustomEvents)
         {
             if (key == customEvent.Key)
-                customEvent.Value.ForEach(x => x?.Invoke());
+                customEvent.Value.ForEach(x => x?.Invoke(key));
         }
     }
     

--- a/Nautilus/MonoBehaviours/CustomStoryGoalManager.cs
+++ b/Nautilus/MonoBehaviours/CustomStoryGoalManager.cs
@@ -9,7 +9,7 @@ internal class CustomStoryGoalManager : MonoBehaviour, IStoryGoalListener
 {
     public static CustomStoryGoalManager Instance { get; private set; }
     
-    internal static readonly Dictionary<string, List<Action<string>>> StoryGoalCustomEvents = new();
+    internal static readonly Dictionary<string, List<Action>> StoryGoalCustomEvents = new();
 
     private ItemGoalTracker _itemGoalTracker;
     private BiomeGoalTracker _biomeGoalTracker;
@@ -68,7 +68,7 @@ internal class CustomStoryGoalManager : MonoBehaviour, IStoryGoalListener
         foreach (var customEvent in StoryGoalCustomEvents)
         {
             if (key == customEvent.Key)
-                customEvent.Value.ForEach(x => x?.Invoke(key));
+                customEvent.Value.ForEach(x => x?.Invoke());
         }
     }
     


### PR DESCRIPTION
### Changes made in this pull request

  - Custom events for StoryGoals behave as the documentation claims and now receive the name of the calling goal as an argument. Fix for #475 

### Breaking changes

  - None