### PR TITLE
Prefix SpriteManager.GetWithNoDefault to avoid potential issues with custom icons

### DIFF
--- a/Nautilus/Patchers/SpritePatcher.cs
+++ b/Nautilus/Patchers/SpritePatcher.cs
@@ -46,11 +46,13 @@ internal class SpritePatcher
 #elif BELOWZERO
             MethodInfo spriteManagerGet = AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.Get), new Type[] { typeof(SpriteManager.Group), typeof(string), typeof(Sprite) });
 #endif
+        MethodInfo spriteManagerGetWithNoDefault = AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.GetWithNoDefault), new Type[] { typeof(SpriteManager.Group), typeof(string) });
         MethodInfo spriteManagerGetBackground = AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.GetBackground), new Type[] { typeof(CraftData.BackgroundType) });
 
         HarmonyMethod patchCheck = new(AccessTools.Method(typeof(SpritePatcher), nameof(SpritePatcher.PatchCheck)));
         HarmonyMethod patchBackgrounds = new(AccessTools.Method(typeof(SpritePatcher), nameof(PatchBackgrounds)));
         harmony.Patch(spriteManagerGet, prefix: patchCheck);
+        harmony.Patch(spriteManagerGetWithNoDefault, prefix: patchCheck);
         harmony.Patch(spriteManagerGetBackground, prefix: patchBackgrounds);
     }
 

--- a/Nautilus/Patchers/SpritePatcher.cs
+++ b/Nautilus/Patchers/SpritePatcher.cs
@@ -43,16 +43,18 @@ internal class SpritePatcher
         PatchSprites();
 #if SUBNAUTICA
         MethodInfo spriteManagerGet = AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.Get), new Type[] { typeof(SpriteManager.Group), typeof(string) });
-#elif BELOWZERO
-            MethodInfo spriteManagerGet = AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.Get), new Type[] { typeof(SpriteManager.Group), typeof(string), typeof(Sprite) });
-#endif
         MethodInfo spriteManagerGetWithNoDefault = AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.GetWithNoDefault), new Type[] { typeof(SpriteManager.Group), typeof(string) });
+#elif BELOWZERO
+        MethodInfo spriteManagerGet = AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.Get), new Type[] { typeof(SpriteManager.Group), typeof(string), typeof(Sprite) });
+#endif
         MethodInfo spriteManagerGetBackground = AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.GetBackground), new Type[] { typeof(CraftData.BackgroundType) });
 
         HarmonyMethod patchCheck = new(AccessTools.Method(typeof(SpritePatcher), nameof(SpritePatcher.PatchCheck)));
         HarmonyMethod patchBackgrounds = new(AccessTools.Method(typeof(SpritePatcher), nameof(PatchBackgrounds)));
         harmony.Patch(spriteManagerGet, prefix: patchCheck);
+# if SUBNAUTICA
         harmony.Patch(spriteManagerGetWithNoDefault, prefix: patchCheck);
+#endif
         harmony.Patch(spriteManagerGetBackground, prefix: patchBackgrounds);
     }
 


### PR DESCRIPTION
### Changes made in this pull request

  - Added a check to initialize the SpriteManager before calling GetWithNoDefault, if necessary.
    - Only needed for SN1; GetWithNoDefault doesn't exist in BZ.

Should resolve #472. I did test that just now and the resource tracker seems to work perfectly fine for custom icons (even without the fix), but this catch feels proper anyway and might solve some rare race conditions?