### PR TITLE
Fix Mod Options again.

### DIFF
--- a/Nautilus/Options/Attributes/OptionsMenuBuilder.cs
+++ b/Nautilus/Options/Attributes/OptionsMenuBuilder.cs
@@ -103,7 +103,7 @@ internal class OptionsMenuBuilder<T> : ModOptions where T : ConfigFile, new()
         if (ConfigFileMetadata.MenuAttribute.LoadOn.HasFlag(MenuAttribute.LoadEvents.MenuOpened))
         {
             ConfigFileMetadata.Config.Load();
-            foreach(var option in options)
+            foreach(var option in new List<OptionItem>(Options))
             {
                 RemoveItem(option.Id);
             }

--- a/Nautilus/Options/ModOptions.cs
+++ b/Nautilus/Options/ModOptions.cs
@@ -63,13 +63,14 @@ public abstract class ModOptions
 
     internal void AddOptionsToPanel(uGUI_TabbedControlsPanel panel, int modsTabIndex)
     {
-        /*
-         * Since Subnautica runs on a very old CLR, iterating on a list that is changed in the loop throws an exception.
-         * To prevent the mistake of calling RemoveItem or AddItem while iterating on the Options property, we pass a copy of
-         * The Options property.
-         */ 
-        var options = Options.ToList();
-        BuildModOptions(panel, modsTabIndex, options);
+        try
+        {
+            BuildModOptions(panel, modsTabIndex, Options);
+        }
+        catch(Exception ex)
+        {
+            InternalLogger.Error($"{Name} Failed to BuildModOptions with exception: \n {ex}");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION


### Changes made in this pull request

  - Add try catch to AddOptionsToPanel to catch when a mod breaks the BuildModOptions in their override.
  - Fix the BuildModOptions for ConfigFile options menu's that used the LoadEvents.MenuOpened flag