### PR TITLE
Correct LanguageLine value to string to properly use the Language key

### DIFF
--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_TechCategory.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_TechCategory.cs
@@ -21,7 +21,7 @@ public static partial class EnumExtensions
         if (!string.IsNullOrEmpty(displayName))
         {
             LanguageHandler.SetLanguageLine("TechCategory" + name, displayName, language);
-            uGUI_BlueprintsTab.techCategoryStrings.valueToString[category] = "TechCategory" + displayName;
+            uGUI_BlueprintsTab.techCategoryStrings.valueToString[category] = "TechCategory" + name;
             return builder;
         }
 


### PR DESCRIPTION
### Changes made in this pull request

  - Correct uGUI_BlueprintsTab.techCategoryStrings to properly use the Language key when registering a TechCategory