### PR TITLE
Fix default TechGroup

### DIFF
--- a/Nautilus/Assets/Gadgets/ScanningGadget.cs
+++ b/Nautilus/Assets/Gadgets/ScanningGadget.cs
@@ -33,7 +33,7 @@ public class ScanningGadget : Gadget
     /// <summary>
     /// The main group in the PDA blueprints where this item appears.
     /// </summary>
-    public TechGroup GroupForPda { get; set; }
+    public TechGroup GroupForPda { get; set; } = TechGroup.Uncategorized;
     
     /// <summary>
     /// The category within the group in the PDA blueprints where this item appears.


### PR DESCRIPTION
### Changes made in this pull request

  - Fix: Correctly sets the default TechGroup to Uncategorized as for some reason Resources is actually the enums default and Uncategorized is last in the vanilla list.