### PR TITLE
Add Remove default unlock request system.

### DIFF
--- a/Nautilus/Handlers/KnownTechHandler.cs
+++ b/Nautilus/Handlers/KnownTechHandler.cs
@@ -337,6 +337,21 @@ public static class KnownTechHandler
     }
 
     /// <summary>
+    /// Allows you to remove a <see cref="TechType"/> from being unlocked by default.
+    /// </summary>
+    /// <param name="techType"></param>
+    public static void RemoveDefaultUnlock(TechType techType)
+    {
+        var modName = ReflectionHelper.CallingAssemblyByStackTrace().GetName().Name;
+        if (!KnownTechPatcher.DefaultRemovalTechs.TryGetValue(modName, out var techTypes))
+            techTypes = new List<TechType>();
+        techTypes.Add(techType);
+
+        KnownTechPatcher.DefaultRemovalTechs[modName] = techTypes;
+        Reinitialize();
+    }
+
+    /// <summary>
     /// References to generic unlock sounds and unlock messages for the Known Tech system, matching those used in the base game.
     /// </summary>
     public static class DefaultUnlockData

--- a/Nautilus/Patchers/KnownTechPatcher.cs
+++ b/Nautilus/Patchers/KnownTechPatcher.cs
@@ -14,6 +14,7 @@ internal class KnownTechPatcher
     internal static HashSet<TechType> LockedWithNoUnlocks = new();
     internal static HashSet<TechType> HardLocked = new();
     internal static HashSet<TechType> RemovalTechs = new();
+    internal static Dictionary<string, List<TechType>> DefaultRemovalTechs = new();
     internal static IDictionary<TechType, KnownTech.AnalysisTech> AnalysisTech = new SelfCheckingDictionary<TechType, KnownTech.AnalysisTech>("AnalysisTech", AsStringFunction);
     internal static IDictionary<TechType, List<TechType>> BlueprintRequirements = new SelfCheckingDictionary<TechType, List<TechType>>("BlueprintRequirements", AsStringFunction);
     internal static IDictionary<TechType, KnownTech.CompoundTech> CompoundTech = new SelfCheckingDictionary<TechType, KnownTech.CompoundTech>("CompoundTech", AsStringFunction);
@@ -49,7 +50,25 @@ internal class KnownTechPatcher
 
     private static void InitializePrefix(PDAData data)
     {
-        data.defaultTech.AddRange(UnlockedAtStart);
+        foreach (var unlockedTech in UnlockedAtStart)
+        {
+            if (!data.defaultTech.Contains(unlockedTech))
+            {
+                data.defaultTech.Add(unlockedTech);
+                InternalLogger.Debug($"Setting {unlockedTech.AsString()} to be unlocked at start.");
+            }
+        }
+
+        foreach (var removalTechsByMod in DefaultRemovalTechs)
+        {
+            foreach (var removalTech in removalTechsByMod.Value)
+            {
+                if (data.defaultTech.Remove(removalTech))
+                {
+                    InternalLogger.Debug($"{removalTechsByMod.Key} removed {removalTech.AsString()} from unlocking at start.");
+                }
+            }
+        }
 
         foreach (var tech in AnalysisTech.Values)
         {

--- a/Nautilus/Patchers/KnownTechPatcher.cs
+++ b/Nautilus/Patchers/KnownTechPatcher.cs
@@ -80,6 +80,7 @@ internal class KnownTechPatcher
                 continue;
             }
             
+            InternalLogger.Debug($"Adding TechTypes to be unlocked by {blueprintRequirements.Key}: {blueprintRequirements.Value.Join((techType) => techType.AsString())}");
             data.analysisTech[index].unlockTechTypes.AddRange(blueprintRequirements.Value);
         }
 


### PR DESCRIPTION
### Changes made in this pull request

  - [Add logging to show when adding unlocks to an AnalysisTech](https://github.com/SubnauticaModding/Nautilus/commit/729b2405acdef3becd4830629170288da450aac2)
  - [Create method to remove default unlocks.](https://github.com/SubnauticaModding/Nautilus/commit/b437ba87f8440f3d24879b013cd409e3a9a1f6c6)