### PR TITLE
Fixed ambiguous method error for WithAnalysisTech

### DIFF
--- a/Nautilus/Assets/Gadgets/ScanningGadget.cs
+++ b/Nautilus/Assets/Gadgets/ScanningGadget.cs
@@ -318,7 +318,7 @@ public class ScanningGadget : Gadget
     /// <returns>A reference to this instance after the operation has completed.</returns>
     public ScanningGadget WithAnalysisTech(
         Sprite popupSprite, 
-        List<StoryGoal> storyGoalsToTrigger = null,
+        List<StoryGoal> storyGoalsToTrigger,
         FMODAsset unlockSound = null, 
         string unlockMessage = null
         )


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed an error you get when you try to use the `WithAnalysisTech` method without story goals. This issue started occurring when we added an overload without a story goals parameter, but kept the parameter as an optional parameter for the older one.