### PR TITLE
Loot distribution dependency on the prefab database

### DIFF
--- a/Nautilus/Handlers/LootDistributionHandler.cs
+++ b/Nautilus/Handlers/LootDistributionHandler.cs
@@ -95,6 +95,8 @@ public static class LootDistributionHandler
     /// <param name="biomeDistribution">The <see cref="LootDistributionData.BiomeData"/> dictating how the prefab should spawn in the world.</param>
     public static void AddLootDistributionData(string classId, params LootDistributionData.BiomeData[] biomeDistribution)
     {
+        CraftData.PreparePrefabIDCache();
+        
         if (!PrefabDatabase.TryGetPrefabFilename(classId, out var filename))
         {
             InternalLogger.Error($"Could not find prefab file path for class ID '{classId}'. Cancelling loot distribution addition.");
@@ -112,6 +114,8 @@ public static class LootDistributionHandler
     /// <param name="biomeDistribution">The <see cref="LootDistributionData.BiomeData"/> dictating how the prefab should spawn in the world.</param>
     public static void AddLootDistributionData(string classId, WorldEntityInfo info, params LootDistributionData.BiomeData[] biomeDistribution)
     {
+        CraftData.PreparePrefabIDCache();
+        
         if (!PrefabDatabase.TryGetPrefabFilename(classId, out var filename))
         {
             InternalLogger.Error($"Could not find prefab file path for class ID '{classId}'. Cancelling loot distribution addition.");


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed an issue where sometimes if you try to add loot distribution before the prefab database is loaded, it wont get registered.