### PR TITLE
Allow nullables and params arrays in console commands

### DIFF
--- a/Nautilus/Commands/Parameter.cs
+++ b/Nautilus/Commands/Parameter.cs
@@ -1,15 +1,21 @@
-﻿
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
+using Nautilus.Extensions;
 
 namespace Nautilus.Commands;
 
 internal struct Parameter
 {
-    private static Dictionary<Type, Func<string, object>> TypeConverters = new()
+    [Flags]
+    public enum ValidationError
+    {
+        Valid = 0,
+        UnsupportedType = 1,
+        ArrayNotParams = 2,
+    }
+    private static Dictionary<Type, Func<string, object>> _typeConverters = new()
     {
         [typeof(string)] = (s) => s,
         [typeof(bool)] = (s) => bool.Parse(s),
@@ -18,23 +24,47 @@ internal struct Parameter
         [typeof(double)] = (s) => double.Parse(s, CultureInfo.InvariantCulture.NumberFormat)
     };
 
-    public static IEnumerable<Type> SupportedTypes => TypeConverters.Keys;
+    public static IEnumerable<Type> SupportedTypes => _typeConverters.Keys;
 
     public Type ParameterType { get; }
+    public Type UnderlyingValueType { get; }
     public bool IsOptional { get; }
     public string Name { get; }
-    public bool IsValidParameterType { get; }
+    public ValidationError ValidState { get; }
 
     public Parameter(ParameterInfo parameter)
     {
         ParameterType = parameter.ParameterType;
-        IsOptional = parameter.IsOptional;
+        UnderlyingValueType = ParameterType.GetUnderlyingType();
+        IsOptional = parameter.IsOptional || ParameterType.IsArray;
         Name = parameter.Name;
-        IsValidParameterType = SupportedTypes.Contains(ParameterType);
+        ValidState = ValidateParameter(parameter);
+    }
+
+    private readonly ValidationError ValidateParameter(ParameterInfo paramInfo)
+    {
+        ValidationError valid = ValidationError.Valid;
+        // arrays MUST be a "params T[]" parameter
+        // this enforces them being last *and* only having one
+        if (ParameterType.IsArray && !paramInfo.IsDefined(typeof(ParamArrayAttribute), false))
+            valid |= ValidationError.ArrayNotParams;
+        if (!_typeConverters.ContainsKey(UnderlyingValueType))
+            valid |= ValidationError.UnsupportedType;
+
+        return valid;
     }
 
     public object Parse(string input)
     {
-        return TypeConverters[ParameterType](input);
+        Type paramType = ParameterType;
+        if (paramType.TryUnwrapArrayType(out Type elementType))
+            paramType = elementType;
+        if (paramType.TryUnwrapNullableType(out _))
+        {
+            if (string.Equals(input, "null", StringComparison.OrdinalIgnoreCase))
+                return null;
+        }
+
+        return _typeConverters[UnderlyingValueType](input);
     }
 }

--- a/Nautilus/Extensions/GeneralExtensions.cs
+++ b/Nautilus/Extensions/GeneralExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Text;
 using UnityEngine;
 
 namespace Nautilus.Extensions;
@@ -42,5 +44,19 @@ public static class GeneralExtensions
             ErrorMessage.AddMessage(message);
         else if (msg.timeEnd <= Time.time + @this.timeFadeOut)
             msg.timeEnd += @this.timeFadeOut + @this.timeInvisible;
+    }
+
+    /// <summary>
+    /// Concatenates string representations of the provided <paramref name="values"/>,
+    /// using the specified <paramref name="separator"/> between them.
+    /// </summary>
+    /// <typeparam name="T">Type of value that will be converted to <see cref="string"/>.</typeparam>
+    /// <param name="builder">The <see cref="StringBuilder"/>.</param>
+    /// <param name="separator">The <see cref="string"/> to insert between each pair of values.</param>
+    /// <param name="values">Values to concatenate into the <paramref name="builder"/>.</param>
+    /// <returns>The provided <see cref="StringBuilder"/>.</returns>
+    public static StringBuilder AppendJoin<T>(this StringBuilder builder, string separator, IEnumerable<T> values)
+    {
+        return builder.Append(string.Join(separator, values));
     }
 }

--- a/Nautilus/Extensions/TypeExtensions.cs
+++ b/Nautilus/Extensions/TypeExtensions.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+
+namespace Nautilus.Extensions;
+
+internal static class TypeExtensions
+{
+    private static readonly List<string> _builtinTypeAliases = new()
+    {
+        "void",
+        null,   // all other types
+        "DBNull",
+        "bool",
+        "char",
+        "sbyte",
+        "byte",
+        "short",
+        "ushort",
+        "int",
+        "uint",
+        "long",
+        "ulong",
+        "float",
+        "double",
+        "decimal",
+        null,   // DateTime?
+        null,   // ???
+        "string"
+    };
+
+    /// <summary>
+    /// Format the given <paramref name="type"/>'s name into a more developer-friendly form.
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns></returns>
+    public static string GetFriendlyName(this Type type)
+    {
+        if (type.TryUnwrapArrayType(out Type elementType))
+            return GetFriendlyName(elementType) + "[]";
+        
+        if (type.TryUnwrapNullableType(out Type valueType))
+            return GetFriendlyName(valueType) + "?";
+        
+        // TODO: format tuples as well
+        
+        if (type.IsConstructedGenericType)
+            return type.Name[..type.Name.LastIndexOf('`')]
+                + $"<{type.GenericTypeArguments.Select(GetFriendlyName).Join()}>";
+        
+        return _builtinTypeAliases[(int) Type.GetTypeCode(type)] ?? type.Name;
+    }
+
+    /// <summary>
+    /// "Unwraps" the inner <paramref name="type"/> from an array and/or nullable type.
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns>
+    /// The inner type - for example, <see cref="string"/> from a <see cref="Array">string[]</see>, or <see cref="bool"/> from <see cref="Nullable{T}">bool?</see>.<br/>
+    /// If the <paramref name="type"/> isn't wrapped, it is returned as-is.
+    /// </returns>
+    public static Type GetUnderlyingType(this Type type)
+    {
+        if (type.TryUnwrapArrayType(out Type elementType))
+            type = elementType;
+        if (type.TryUnwrapNullableType(out Type valueType))
+            type = valueType;
+        return type;
+    }
+
+    public static bool TryUnwrapArrayType(this Type type, out Type elementType)
+    {
+        // GetElementType checks if it's an array, pointer, or reference
+        elementType = type.GetElementType();
+        return type.IsArray // restrict to arrays only
+            && elementType != null;
+    }
+
+    public static bool TryUnwrapNullableType(this Type type, out Type valueType)
+    {
+        valueType = Nullable.GetUnderlyingType(type);
+        return valueType != null;
+    }
+}

--- a/Nautilus/Patchers/ConsoleCommandsPatcher.cs
+++ b/Nautilus/Patchers/ConsoleCommandsPatcher.cs
@@ -1,11 +1,13 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Text.RegularExpressions;
 using BepInEx.Logging;
 using HarmonyLib;
 using Nautilus.Commands;
+using Nautilus.Extensions;
 using Nautilus.Utility;
 using UnityEngine;
 
@@ -13,7 +15,7 @@ namespace Nautilus.Patchers;
 
 internal static class ConsoleCommandsPatcher
 {
-    private static Dictionary<string, ConsoleCommand> ConsoleCommands = new();
+    private static Dictionary<string, ConsoleCommand> ConsoleCommands = new(StringComparer.OrdinalIgnoreCase);
 
     private static Color CommandColor = new(1, 1, 0);
     private static Color ParameterTypeColor = new(0, 1, 1);
@@ -63,17 +65,41 @@ internal static class ConsoleCommandsPatcher
             return;
         }
 
-        // if any of the parameter types of the method are unsupported, print an error and don't add it
-        if (!consoleCommand.HasValidParameterTypes())
+        // if any of the parameters of the method aren't valid, print an error and don't add it
+        if (consoleCommand.GetInvalidParameters().Any())
         {
-            string error = $"Could not register custom command {GetColoredString(consoleCommand)} for mod " +
-                           $"{GetColoredString(consoleCommand.ModName, ModOriginColor)}\n" +
-                           "The following parameters have unsupported types:\n" +
-                           consoleCommand.GetInvalidParameters().Select(param => GetColoredString(param)).Join(delimiter: "\n") +
-                           "Supported parameter types:\n" +
-                           Parameter.SupportedTypes.Select(type => type.Name).Join();
+            List<Parameter> parametersWithUnsupportedTypes = new();
+            List<Parameter> nonParamsArrayParameters = new();
+            foreach (var parameter in consoleCommand.GetInvalidParameters())
+            {
+                Parameter.ValidationError state = parameter.ValidState;
+                if (state.HasFlag(Parameter.ValidationError.UnsupportedType))
+                    parametersWithUnsupportedTypes.Add(parameter);
+                if (state.HasFlag(Parameter.ValidationError.ArrayNotParams))
+                    nonParamsArrayParameters.Add(parameter);
+            }
+            
+            StringBuilder error = new StringBuilder(
+                $"Could not register custom command {GetColoredString(consoleCommand)} for mod " +
+                $"{GetColoredString(consoleCommand.ModName, ModOriginColor)}"
+            );
 
-            LogAndAnnounce(error, LogLevel.Error);
+            if (parametersWithUnsupportedTypes.Count > 0)
+            {
+                error.AppendLine("The following parameters have unsupported types:");
+                error.AppendJoin("\n", parametersWithUnsupportedTypes.Select(GetColoredString));
+                error.AppendLine("\nSupported parameter types:");
+                error.AppendJoin(",", Parameter.SupportedTypes.Select(type => type.GetFriendlyName()));
+            }
+
+            if (nonParamsArrayParameters.Count > 0)
+            {
+                error.AppendLine("Array parameters must be marked as 'params'.");
+                error.AppendLine("Incorrect parameters:");
+                error.AppendJoin(",", nonParamsArrayParameters.Select(GetColoredString));
+            }
+
+            LogAndAnnounce(error.ToString(), LogLevel.Error);
 
             return;
         }
@@ -148,7 +174,7 @@ internal static class ConsoleCommandsPatcher
         input = input.Trim();
         string[] components = input.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
 
-        string trigger = components[0].ToLowerInvariant();
+        string trigger = components[0];
 
         if (!ConsoleCommands.TryGetValue(trigger, out ConsoleCommand command))
         {
@@ -156,30 +182,39 @@ internal static class ConsoleCommandsPatcher
             return false;
         }
 
-        IEnumerable<string> parameters = components.Skip(1);
+        List<string> inputParameters = components.Skip(1).ToList();
+
+        (int consumed, int parsed) = command.TryParseParameters(inputParameters, out object[] parsedParameters);
 
         // If the parameters couldn't be parsed by the command, print a user and developer-friendly error message both
         // on-screen and in the log.
-        if (!command.TryParseParameters(parameters, out object[] parsedParameters))
+        bool consumedAll = consumed >= inputParameters.Count;
+        bool parsedAll = parsed == command.Parameters.Count;
+        if (!consumedAll || !parsedAll)
         {
-            if (parsedParameters != null)
+            if (!parsedAll)
             {
-                // Find the first invalid parameter
-                string invalidParameter = null;
-                string parameterTypeName = null;
-                for (int i = 0; i < parsedParameters.Length; i++)
+                if (parsedParameters != null)
                 {
-                    if (parsedParameters[i] == null)
-                    {
-                        invalidParameter = parameters.ElementAt(i);
-                        parameterTypeName = command.ParameterTypes[i].Name;
-                        break;
-                    }
-                }
+                    // Get the first invalid parameter
+                    string invalidInput = inputParameters[consumed];
 
-                // Print a message about why it is invalid
-                string error = $"{GetColoredString(invalidParameter, ParameterInputColor)} is not a valid " +
-                               $"{GetColoredString(parameterTypeName, ParameterTypeColor)}!";
+                    var invalidParameter = command.Parameters[parsed];
+                    string parameterTypeName = invalidParameter.UnderlyingValueType.GetFriendlyName();
+
+                    // Print a message about why it is invalid
+                    string error = $"{invalidParameter.Name} " +
+                                   $"{GetColoredString(invalidInput, ParameterInputColor)} is not a valid " +
+                                   $"{GetColoredString(parameterTypeName, ParameterTypeColor)}!";
+
+                    LogAndAnnounce(error, LogLevel.Error);
+                }
+            }
+            else if (!consumedAll)
+            {
+                string error = "Received too many parameters!\n" +
+                    $"expected {GetColoredString(command.Parameters.Count.ToString(), ParameterTypeColor)} " +
+                    $"but got {GetColoredString(inputParameters.Count.ToString(), ParameterInputColor)}";
 
                 LogAndAnnounce(error, LogLevel.Error);
             }
@@ -187,14 +222,14 @@ internal static class ConsoleCommandsPatcher
             // Print a message about what parameters the command expects
             string parameterInfoString = $"{GetColoredString(command.Trigger, CommandColor)} " +
                                          "expects the following parameters\n" +
-                                         command.Parameters.Select(param => GetColoredString(param)).Join(delimiter: "\n");
+                                         command.Parameters.Select(GetColoredString).Join(delimiter: "\n");
 
             LogAndAnnounce(parameterInfoString, LogLevel.Error);
 
             // Print a message detailing all received parameters.
-            if (parameters.Any())
+            if (inputParameters.Any())
             {
-                InternalLogger.Announce($"Received parameters: {parameters.Join()}", LogLevel.Error, true);
+                InternalLogger.Announce($"Received parameters: {inputParameters.Join()}", LogLevel.Error, true);
             }
 
             return true; // We've handled the command insofar as we've handled and reported the user error to them.
@@ -232,7 +267,7 @@ internal static class ConsoleCommandsPatcher
 
     private static string GetColoredString(Parameter parameter)
     {
-        return $"{parameter.Name}: {GetColoredString(parameter.ParameterType.Name, ParameterTypeColor)}" +
+        return $"{parameter.Name}: {GetColoredString(parameter.ParameterType.GetFriendlyName(), ParameterTypeColor)}" +
                (parameter.IsOptional ? $" {GetColoredString("(optional)", ParameterOptionalColor)}" : string.Empty);
     }
 

--- a/Nautilus/Patchers/ConsoleCommandsPatcher.cs
+++ b/Nautilus/Patchers/ConsoleCommandsPatcher.cs
@@ -81,7 +81,7 @@ internal static class ConsoleCommandsPatcher
             
             StringBuilder error = new StringBuilder(
                 $"Could not register custom command {GetColoredString(consoleCommand)} for mod " +
-                $"{GetColoredString(consoleCommand.ModName, ModOriginColor)}"
+                $"{GetColoredString(consoleCommand.ModName, ModOriginColor)}\n"
             );
 
             if (parametersWithUnsupportedTypes.Count > 0)
@@ -203,7 +203,7 @@ internal static class ConsoleCommandsPatcher
                     string parameterTypeName = invalidParameter.UnderlyingValueType.GetFriendlyName();
 
                     // Print a message about why it is invalid
-                    string error = $"{invalidParameter.Name} " +
+                    string error = $"Parameter {GetColoredString(invalidParameter.Name, ParameterOptionalColor)} could not be parsed:\n" +
                                    $"{GetColoredString(invalidInput, ParameterInputColor)} is not a valid " +
                                    $"{GetColoredString(parameterTypeName, ParameterTypeColor)}!";
 


### PR DESCRIPTION
### Changes made in this pull request
#### Console commands
  - Allow using nullable value types in parameters
    - A command like `ToggleSomething(bool? enable = null)` can now be registered and can e.g. print the current status of the toggle if called with no arguments
  - Allow using a `params T[]` parameter to consume the rest of the input
    - This allows commands to parse an arbitrary number of (still primitively-typed) parameters
    - Something simple like a command that repeats your input back at you is now extremely easy to define
    - It only makes sense to have one `params` array and only as the last parameter - which is enforced by the compiler

### Breaking changes
  - No breaking changes to existing commands from my testing