### PR TITLE
Change crafting gadget tree failure log level to Debug

### DIFF
--- a/Nautilus/Assets/Gadgets/CraftingGadget.cs
+++ b/Nautilus/Assets/Gadgets/CraftingGadget.cs
@@ -104,7 +104,7 @@ public class CraftingGadget : Gadget
         }
         else if (!prefab.TryGetGadget(out ScanningGadget scanningGadget) || !scanningGadget.IsBuildable)
         {
-            InternalLogger.Log($"Prefab '{prefab.Info.ClassID}' was not automatically registered into a crafting tree.");
+            InternalLogger.Debug($"Prefab '{prefab.Info.ClassID}' was not automatically registered into a crafting tree.");
         }
 
         if (CraftingTime >= 0f)


### PR DESCRIPTION
### Changes made in this pull request

  - Changed the log level when the crafting gadget attempts to add an item to a nonexistent tree from the default to Debug.

### Breaking changes

  - None