### PR TITLE
Survival Handler Fixes and Improvements.

### DIFF
--- a/Nautilus/Handlers/SurvivalHandler.cs
+++ b/Nautilus/Handlers/SurvivalHandler.cs
@@ -7,7 +7,7 @@ namespace Nautilus.Handlers;
 /// <summary>
 /// Handler class that relates to the <see cref="Survival"/> component. Allows the defining of oxygen or health gains when consuming specific items.
 /// </summary>
-public static class SurvivalHandler 
+public static class SurvivalHandler
 {
     /// <summary>
     /// <para>makes the item gives oxygen on use.</para>
@@ -15,56 +15,81 @@ public static class SurvivalHandler
     /// <param name="techType">the TechType that you want to make it give oxygen on use</param>
     /// <param name="oxygenGiven">the oxygen amount the item gives</param>
     /// <param name="isEdible">set it to <see langword="true" /> if the item is edible and has the <see cref="Eatable"/> component attached to it. 
-    /// <para>defaults to <see langword="false" /></para>
     /// </param>
     public static void GiveOxygenOnConsume(TechType techType, float oxygenGiven, bool isEdible)
     {
-        if (SurvivalPatcher.CustomSurvivalInventoryAction.TryGetValue(techType, out List<Action> action))
-        {
-            action.Add(() => { Player.main.GetComponent<OxygenManager>().AddOxygen(oxygenGiven); }); // add an action to the list
-            return;
-        }
-
-        // if we reach to this point then the techtype doesn't exist in the dictionary so we add it
-        SurvivalPatcher.CustomSurvivalInventoryAction[techType] = new List<Action>()
-        {
-            () =>
-            {
-                Player.main.GetComponent<OxygenManager>().AddOxygen(oxygenGiven);
-            }
-        };
         if (!isEdible)
         {
-            SurvivalPatcher.InventoryUseables.Add(techType);
+            SurvivalPatcher.InventoryUseables.Add(techType); // add it to the HashSet of useables if its not edible
         }
+
+        if (!SurvivalPatcher.CustomSurvivalInventoryAction.TryGetValue(techType, out List<Action> actions))
+            actions = new List<Action>();
+
+        // add an action to the list
+        actions.Add(() => 
+        {
+            var oxygenManager = Player.main.GetComponent<OxygenManager>();
+            if (oxygenGiven > 0f)
+                oxygenManager.AddOxygen(oxygenGiven);
+            else
+                oxygenManager.RemoveOxygen(oxygenGiven);
+        });
+
+        SurvivalPatcher.CustomSurvivalInventoryAction[techType] = actions;
     }
+
     /// <summary>
     /// <para>makes the item Heal the player on consume.</para>
     /// </summary>
     /// <param name="techType">the TechType that you want it to heal back</param>
     /// <param name="healthBack">amount to heal the player</param>
     /// <param name="isEdible">set it to <see langword="true" /> if the item is edible and has the <see cref="Eatable"/> component attached to it. 
-    /// <para>defaults to <see langword="false" /></para>
     /// </param>
     public static void GiveHealthOnConsume(TechType techType, float healthBack, bool isEdible)
     {
-        if (SurvivalPatcher.CustomSurvivalInventoryAction.TryGetValue(techType, out List<Action> action))
-        {
-            action.Add(() => { Player.main.GetComponent<LiveMixin>().AddHealth(healthBack); }); // add an action to the list
-            return;
-        }
-
-        // if we reach to this point then the techtype doesn't exist in the dictionary so we add it
-        SurvivalPatcher.CustomSurvivalInventoryAction[techType] = new List<Action>()
-        {
-            () =>
-            {
-                Player.main.GetComponent<LiveMixin>().AddHealth(healthBack);
-            }
-        };
         if (!isEdible)
         {
-            SurvivalPatcher.InventoryUseables.Add(techType);
+            SurvivalPatcher.InventoryUseables.Add(techType); // add it to the HashSet of useables if its not edible
         }
+
+        if (!SurvivalPatcher.CustomSurvivalInventoryAction.TryGetValue(techType, out List<Action> actions))
+            actions = new List<Action>();
+
+        actions.Add(() => {
+            var liveMixin = Player.main.GetComponent<LiveMixin>();
+            if (healthBack > 0)
+                liveMixin.AddHealth(healthBack); 
+            else
+                liveMixin.TakeDamage(-healthBack, default, DamageType.Poison);
+        }); 
+
+        SurvivalPatcher.CustomSurvivalInventoryAction[techType] = actions;
+    }
+
+    /// <summary>
+    /// <para>runs a custom action on consume.</para>
+    /// </summary>
+    /// <param name="techType">the TechType that you want it to heal back</param>
+    /// <param name="customAction"> the Action to perform.</param>
+    /// <param name="isEdible">set it to <see langword="true" /> if the item is edible and has the <see cref="Eatable"/> component attached to it. 
+    /// </param>
+    public static void RunActionOnConsume(TechType techType, Action customAction, bool isEdible)
+    {
+        if (techType == TechType.None)
+            throw new ArgumentNullException(nameof(techType), "TechType cannot be None.");
+        if (customAction == null)
+            throw new ArgumentNullException(nameof(customAction), "Action cannot be null.");
+
+        if (!isEdible)
+        {
+            SurvivalPatcher.InventoryUseables.Add(techType); // add it to the HashSet of useables if its not edible
+        }
+
+        if (!SurvivalPatcher.CustomSurvivalInventoryAction.TryGetValue(techType, out List<Action> actions))
+            actions = new List<Action>();
+
+        actions.Add(customAction);
+        SurvivalPatcher.CustomSurvivalInventoryAction[techType] = actions;
     }
 }

--- a/Nautilus/Handlers/SurvivalHandler.cs
+++ b/Nautilus/Handlers/SurvivalHandler.cs
@@ -33,7 +33,7 @@ public static class SurvivalHandler
             if (oxygenGiven > 0f)
                 oxygenManager.AddOxygen(oxygenGiven);
             else
-                oxygenManager.RemoveOxygen(oxygenGiven);
+                oxygenManager.RemoveOxygen(-oxygenGiven);
         });
 
         SurvivalPatcher.CustomSurvivalInventoryAction[techType] = actions;

--- a/Nautilus/Patchers/SurvivalPatcher.cs
+++ b/Nautilus/Patchers/SurvivalPatcher.cs
@@ -10,7 +10,7 @@ namespace Nautilus.Patchers;
 internal class SurvivalPatcher
 {
     internal static IDictionary<TechType, List<Action>> CustomSurvivalInventoryAction = new SelfCheckingDictionary<TechType, List<Action>>("CustomSurvivalInventoryAction", TechTypeExtensions.sTechTypeComparer);
-    internal static List<TechType> InventoryUseables = new();
+    internal static HashSet<TechType> InventoryUseables = new();
 
     internal static void Patch(Harmony harmony)
     {


### PR DESCRIPTION
Fix: Setting Negative oxygen did not work right.
Fix: Setting Negative Health would never kill and could glitch the player if reaching 0.
Fix: InventoryUsables was list instead of HashSet

Improvement: Added RunActionOnConsume(TechType techType, Action customAction, bool isEdible) to allow mods to send their own custom action to be performed when item is consumed.