### PR TITLE
Add support for Biome and Goto commands

### DIFF
--- a/Example mod/BiomeHandlerExample.cs
+++ b/Example mod/BiomeHandlerExample.cs
@@ -37,5 +37,8 @@ public class BiomeHandlerExample : BaseUnityPlugin
         
         // Add the biome somewhere to the world
         CoordinatedSpawnsHandler.RegisterCoordinatedSpawn(new SpawnInfo(volumePrefabInfo.ClassID, new Vector3(-1400, -80, 600), Quaternion.identity, new Vector3(50, 50, 50)));
+        
+        // Add this biome to the "biome" command
+        ConsoleCommandsHandler.AddBiomeTeleportPosition("nautilusexamplebiome", new Vector3(-1400, -80, 600));
     }
 }

--- a/Nautilus/Handlers/ConsoleCommandsHandler.cs
+++ b/Nautilus/Handlers/ConsoleCommandsHandler.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using HarmonyLib;
 using Nautilus.Commands;
 using Nautilus.Patchers;
+using UnityEngine;
 
 namespace Nautilus.Handlers;
 
@@ -78,5 +79,17 @@ public static class ConsoleCommandsHandler
     public static void RegisterConsoleCommands(Type type)
     {
         ConsoleCommandsPatcher.ParseCustomCommands(type);
+    }
+
+    public static void AddBiomeTeleportPosition(string biomeName, Vector3 position)
+    {
+        ConsoleCommandsPatcher.BiomeTeleportPositionsToAdd.Add(new TeleportPosition{name = biomeName, position = position});
+        ConsoleCommandsPatcher.UpdateTeleportPositions();
+    }
+    
+    public static void AddGotoTeleportPosition(string locationName, Vector3 position)
+    {
+        ConsoleCommandsPatcher.GotoTeleportPositionsToAdd.Add(new TeleportPosition{name = locationName, position = position});
+        ConsoleCommandsPatcher.UpdateTeleportPositions();
     }
 }

--- a/Nautilus/Handlers/ConsoleCommandsHandler.cs
+++ b/Nautilus/Handlers/ConsoleCommandsHandler.cs
@@ -81,12 +81,23 @@ public static class ConsoleCommandsHandler
         ConsoleCommandsPatcher.ParseCustomCommands(type);
     }
 
+    
+    /// <summary>
+    /// Adds a new teleport position to the "biome" command.
+    /// </summary>
+    /// <param name="biomeName">The name of the teleport. Case-insensitive, no spaces allowed.</param>
+    /// <param name="position">The world coordinates of the teleport.</param>
     public static void AddBiomeTeleportPosition(string biomeName, Vector3 position)
     {
         ConsoleCommandsPatcher.BiomeTeleportPositionsToAdd.Add(new TeleportPosition{name = biomeName, position = position});
         ConsoleCommandsPatcher.UpdateTeleportPositions();
     }
     
+    /// <summary>
+    /// Adds a new teleport position to the "goto" command.
+    /// </summary>
+    /// <param name="locationName">The name of the teleport. Case-insensitive, no spaces allowed.</param>
+    /// <param name="position">The world coordinates of the teleport.</param>
     public static void AddGotoTeleportPosition(string locationName, Vector3 position)
     {
         ConsoleCommandsPatcher.GotoTeleportPositionsToAdd.Add(new TeleportPosition{name = locationName, position = position});


### PR DESCRIPTION
### Changes made in this pull request

  - Added two new methods to the ConsoleCommandsHandler class which add locations to the existing base-game commands:
    - `AddBiomeTeleportPosition(string biomeName, Vector3 position)`
    - `AddGotoTeleportPosition(string locationName, Vector3 position)`

### Breaking changes

  - None