### PR TITLE
Fix base game issue: Atmosphere volumes don't trigger while piloting a vehicle

### DIFF
--- a/Nautilus/Assets/PrefabTemplates/AtmosphereVolumeTemplate.cs
+++ b/Nautilus/Assets/PrefabTemplates/AtmosphereVolumeTemplate.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace Nautilus.Assets.PrefabTemplates;
 
 /// <summary>
-/// A template for Atmosphere Volumes, which are basic invisible triggers for mini-biomes.
+/// A template for Atmosphere Volumes, which are basic invisible triggers for mini-biomes. Atmosphere volumes can affect fog, music, ambient sounds and even the player's swim speed.
 /// </summary>
 public class AtmosphereVolumeTemplate : PrefabTemplate
 {

--- a/Nautilus/Assets/PrefabTemplates/AtmosphereVolumeTemplate.cs
+++ b/Nautilus/Assets/PrefabTemplates/AtmosphereVolumeTemplate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using Nautilus.MonoBehaviours;
 using UnityEngine;
 
 namespace Nautilus.Assets.PrefabTemplates;
@@ -23,6 +24,10 @@ public class AtmosphereVolumeTemplate : PrefabTemplate
     /// The priority of this atmosphere volume. Atmosphere volumes with higher priorities override those with lower priorities. The default priority is 10.
     /// </summary>
     public int Priority { get; set; }
+    /// <summary>
+    /// Whether this atmosphere volume can be entered while inside a vehicle or not. For unknown reasons, this is NOT true for base game volumes. However, in this template, it is true by default.
+    /// </summary>
+    public bool CanEnterWhileInsideVehicle { get; set; } = true;
 
     /// <summary>
     /// Determines the loading distance of this atmosphere volume prefab. Default value is <see cref="LargeWorldEntity.CellLevel.Far"/>. Although vanilla prefabs always use Batch for this, this does not work with our custom systems.
@@ -78,6 +83,11 @@ public class AtmosphereVolumeTemplate : PrefabTemplate
         var atmosphereVolume = prefab.AddComponent<AtmosphereVolume>();
         atmosphereVolume.overrideBiome = OverrideBiome;
         atmosphereVolume.priority = Priority;
+
+        if (CanEnterWhileInsideVehicle)
+        {
+            prefab.AddComponent<AtmosphereVolumeTriggerFix>().atmosphereVolume = atmosphereVolume;
+        }
         
         ModifyPrefab?.Invoke(prefab);
         if (ModifyPrefabAsync is { })

--- a/Nautilus/MonoBehaviours/AtmosphereVolumeTriggerFix.cs
+++ b/Nautilus/MonoBehaviours/AtmosphereVolumeTriggerFix.cs
@@ -1,0 +1,28 @@
+﻿using UnityEngine;
+
+namespace Nautilus.MonoBehaviours;
+
+// In the base game, atmosphere volumes will not trigger while you're inside a vehicle. This file fixes that issue on custom atmosphere volumes (can be opted out).
+internal class AtmosphereVolumeTriggerFix : MonoBehaviour
+{
+    public AtmosphereVolume atmosphereVolume;
+    
+    private void Start()
+    {
+        InvokeRepeating(nameof(CheckTriggerEnter), Random.value, 3f);
+    }
+
+    private void CheckTriggerEnter()
+    {
+        if (atmosphereVolume.settingsActive || !isActiveAndEnabled)
+        {
+            return;
+        }
+        var playerObject = Player.mainObject;
+        if (playerObject == null) return;
+        if (atmosphereVolume.Contains(playerObject.transform.position))
+        {
+            atmosphereVolume.PushSettings();
+        }
+    }
+}


### PR DESCRIPTION
### Changes made in this pull request

  - Custom atmosphere volumes now interact with the player while inside a vehicle, unless this behavior is manually disabled.

### Breaking changes

  - Existing modded atmosphere volumes may be affected, but this should be a good change.