### PR TITLE
Support protobuf serializer for custom types

### DIFF
--- a/Example mod/SerializableBehaviourExample.cs
+++ b/Example mod/SerializableBehaviourExample.cs
@@ -10,10 +10,20 @@ namespace Nautilus.Examples;
 [BepInDependency("com.snmodding.nautilus")]
 internal class SerializableBehaviourExample : BaseUnityPlugin
 {
+    // You need to store the generated methods so they can be used in your serialize and deserialize static methods
+    public static Action<RealtimeCounter, int, ProtoWriter> serializeMethodInfo;
+    public static Func<RealtimeCounter, ProtoReader, RealtimeCounter> deserializeMethodInfo;
+
     private void Awake()
     {
-        // Don't forget to register your serializable type
-        // You can pick whatever type ID you want as long it's not used by another mod or by Subnautica itself
+        // We first generate automatically the serialize and deserialize methods for our serializable type
+        var methodInfos = ProtobufSerializerHandler.GenerateSerializeAndDeserializeMethods<RealtimeCounter>();
+        // And we store them somewhere easily accessible
+        serializeMethodInfo = methodInfos.Item1;
+        deserializeMethodInfo = methodInfos.Item2;
+
+        // Don't forget to register your serializable type with the right serialize and deserialize method (those which you created manually)
+        // You can pick whatever type ID (e.g. 3141592) you want as long it's not used by another mod or by Subnautica itself
         ProtobufSerializerHandler.RegisterSerializableType<RealtimeCounter>(3141592, RealtimeCounter.Serialize, RealtimeCounter.Deserialize);
     }
 }
@@ -23,26 +33,26 @@ internal class RealtimeCounter : MonoBehaviour, IProtoEventListener
 {
     public DateTimeOffset StartedCounting { get; private set; } = DateTimeOffset.UtcNow;
 
-    // If you plan on distributing updates to your mod and maybe updating the serialized MonoBehaviours' fields,
+    // If you plan on updating your mod and in particular, updating the serialized MonoBehaviours' fields,
     // you will need to update the version number and adapt your data in the OnProtoDeserialize method.
     // If you're just making a new serializable MonoBehaviour, set version to 1
     // If you don't care about updating your mod, you can just ignore everything concerning the version variable
-    [ProtoMember(1), NonSerialized]
+    [ProtobufSerializerHandler.SubnauticaSerialized(1)]
     public int version = 2;
 
     // Variable to be serialized
-    [ProtoMember(2), NonSerialized]
+    [ProtobufSerializerHandler.SubnauticaSerialized(2)]
     public double totalRealtimeMs;
 
     // This is an example of how you can give a default value to your serialized variables
-    [ProtoMember(3), NonSerialized]
+    [ProtobufSerializerHandler.SubnauticaSerialized(3)]
     public long firstLaunchUnixTimeMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-    // Some listeners from the optional interface IProtoEventListener
+    // Below are two listeners from the optional interface IProtoEventListener:
     // OnProtoDeserialize happens after this MonoBehaviour's GameObject full hierarchy is deserialized
     public void OnProtoDeserialize(ProtobufSerializer serializer)
     {
-        // This happens when this MonoBehaviour is loaded for the first time after being updated
+        // This happens when this MonoBehaviour is loaded for the first time after being updated (serialized version was 1 but it should be 2)
         // You can find another example in Subnautica's code, like WaterParkCreature.OnProtoDeserialize
         if (version == 1)
         {
@@ -57,57 +67,36 @@ internal class RealtimeCounter : MonoBehaviour, IProtoEventListener
     // OnProtoSerialize happens before this MonoBehaviour's GameObject full hierarchy is serialized
     public void OnProtoSerialize(ProtobufSerializer serializer)
     {
+        // Ensure the serialized version is the newest one
         version = 2;
 
+        // Doing some stuff according to your needs
         totalRealtimeMs += (DateTimeOffset.UtcNow - StartedCounting).TotalMilliseconds;
         StartedCounting = DateTimeOffset.UtcNow;
         Debug.Log($"Serialized realtime counter with {totalRealtimeMs}ms [first launch at: {DateTimeOffset.FromUnixTimeMilliseconds(firstLaunchUnixTimeMs)}]");
     }
 
-    // The required static methods for Protobuf serializer to serialize and deserialize this MonoBehaviour
+    // Below are the required static methods for Protobuf serializer to serialize and deserialize this MonoBehaviour
     // You can find more examples in ProtobufSerializerPrecompiled just like Serialize11492366 and Deserialize11492366
-    // Serialize must be a static void with parameters (YourType, int, ProtoWriter)
+    // Serialize must be a "static void" with parameters (YourType, int, ProtoWriter)
     public static void Serialize(RealtimeCounter realtimeCounter, int objTypeId, ProtoWriter writer)
     {
-        // If you only have basic types this will be straightforward but you may need to adapt this with more complex ones
-        // Please pick the right WireType for your variables and adapt the following Write[Object] call
-        ProtoWriter.WriteFieldHeader(1, WireType.Variant, writer);
-        ProtoWriter.WriteInt32(realtimeCounter.version, writer);
+        // If you only have basic types you only need to use the generated methods but you may need to adapt this with more complex types
+        // In that situation, please pick the right WireType for your variables and adapt the following Write[Object] call
 
-        ProtoWriter.WriteFieldHeader(2, WireType.Fixed64, writer);
-        ProtoWriter.WriteDouble(realtimeCounter.totalRealtimeMs, writer);
-
-        ProtoWriter.WriteFieldHeader(3, WireType.Fixed64, writer);
-        ProtoWriter.WriteInt64(realtimeCounter.firstLaunchUnixTimeMs, writer);
+        // In this case, we only have basic types to serialize so we just invoke the generated method
+        SerializableBehaviourExample.serializeMethodInfo.Invoke(realtimeCounter, objTypeId, writer);
     }
 
-    // Deserialize must be a static YourType with parameters (YourType, ProtoReader)
+    // Deserialize must be a "static YourType" with parameters (YourType, ProtoReader)
     public static RealtimeCounter Deserialize(RealtimeCounter realtimeCounter, ProtoReader reader)
     {
         // Here you need to use the methods Read[Object] accordingly to what you wrote in Serialize: Write[Object]
         // Also the different cases must be using the same field numbers as defined in Serialize
-        for (int i = reader.ReadFieldHeader(); i > 0; i = reader.ReadFieldHeader())
-        {
-            switch (i)
-            {
-                case 1:
-                    // We used ProtoWriter.WriteInt32 so here we need reader.ReadInt32
-                    realtimeCounter.version = reader.ReadInt32();
-                    break;
 
-                case 2:
-                    realtimeCounter.totalRealtimeMs = reader.ReadInt64();
-                    break;
+        // In this case, we only have basic types to serialize so we just invoke the generated method
+        realtimeCounter = SerializableBehaviourExample.deserializeMethodInfo.Invoke(realtimeCounter, reader);
 
-                case 3:
-                    realtimeCounter.firstLaunchUnixTimeMs = reader.ReadInt64();
-                    break;
-
-                default:
-                    reader.SkipField();
-                    break;
-            }
-        }
         // Return the same object you've been modifying
         return realtimeCounter;
     }

--- a/Example mod/SerializableBehaviourExample.cs
+++ b/Example mod/SerializableBehaviourExample.cs
@@ -1,5 +1,7 @@
 using System;
 using BepInEx;
+using Nautilus.Assets;
+using Nautilus.Assets.PrefabTemplates;
 using Nautilus.Handlers;
 using ProtoBuf;
 using UnityEngine;
@@ -11,20 +13,34 @@ namespace Nautilus.Examples;
 internal class SerializableBehaviourExample : BaseUnityPlugin
 {
     // You need to store the generated methods so they can be used in your serialize and deserialize static methods
-    public static Action<RealtimeCounter, int, ProtoWriter> serializeMethodInfo;
-    public static Func<RealtimeCounter, ProtoReader, RealtimeCounter> deserializeMethodInfo;
+    public static Action<RealtimeCounter, int, ProtoWriter> realtimeCounterSerializeMethodInfo;
+    public static Func<RealtimeCounter, ProtoReader, RealtimeCounter> realtimeCounterDeserializeMethodInfo;
+    public static Action<StopwatchSignExample, int, ProtoWriter> stopwatchSignExampleSerializeMethodInfo;
+    public static Func<StopwatchSignExample, ProtoReader, StopwatchSignExample> stopwatchSignExampleDeserializeMethodInfo;
 
     private void Awake()
     {
         // We first generate automatically the serialize and deserialize methods for our serializable type
-        var methodInfos = ProtobufSerializerHandler.GenerateSerializeAndDeserializeMethods<RealtimeCounter>();
+        var realtimeCounterMethodInfos = ProtobufSerializerHandler.GenerateSerializeAndDeserializeMethods<RealtimeCounter>();
         // And we store them somewhere easily accessible
-        serializeMethodInfo = methodInfos.Item1;
-        deserializeMethodInfo = methodInfos.Item2;
+        realtimeCounterSerializeMethodInfo = realtimeCounterMethodInfos.Item1;
+        realtimeCounterDeserializeMethodInfo = realtimeCounterMethodInfos.Item2;
+        
+        // Do it for the stopwatch
+        var stopwatchSignMethodInfos = ProtobufSerializerHandler.GenerateSerializeAndDeserializeMethods<StopwatchSignExample>();
+        stopwatchSignExampleSerializeMethodInfo = stopwatchSignMethodInfos.Item1;
+        stopwatchSignExampleDeserializeMethodInfo = stopwatchSignMethodInfos.Item2;
 
         // Don't forget to register your serializable type with the right serialize and deserialize method (those which you created manually)
         // You can pick whatever type ID (e.g. 3141592) you want as long it's not used by another mod or by Subnautica itself
         ProtobufSerializerHandler.RegisterSerializableType<RealtimeCounter>(3141592, RealtimeCounter.Serialize, RealtimeCounter.Deserialize);
+        ProtobufSerializerHandler.RegisterSerializableType<StopwatchSignExample>(3141593, StopwatchSignExample.Serialize, StopwatchSignExample.Deserialize);
+
+        var stopwatchSign = new CustomPrefab(PrefabInfo.WithTechType("StopwatchSign"));
+        var stopwatchSignTemplate = new CloneTemplate(stopwatchSign.Info, TechType.Sign);
+        stopwatchSignTemplate.ModifyPrefab += go => go.AddComponent<StopwatchSignExample>();
+        stopwatchSign.SetGameObject(stopwatchSignTemplate);
+        stopwatchSign.Register();
     }
 }
 
@@ -85,7 +101,7 @@ internal class RealtimeCounter : MonoBehaviour, IProtoEventListener
         // In that situation, please pick the right WireType for your variables and adapt the following Write[Object] call
 
         // In this case, we only have basic types to serialize so we just invoke the generated method
-        SerializableBehaviourExample.serializeMethodInfo.Invoke(realtimeCounter, objTypeId, writer);
+        SerializableBehaviourExample.realtimeCounterSerializeMethodInfo.Invoke(realtimeCounter, objTypeId, writer);
     }
 
     // Deserialize must be a "static YourType" with parameters (YourType, ProtoReader)
@@ -95,9 +111,77 @@ internal class RealtimeCounter : MonoBehaviour, IProtoEventListener
         // Also the different cases must be using the same field numbers as defined in Serialize
 
         // In this case, we only have basic types to serialize so we just invoke the generated method
-        realtimeCounter = SerializableBehaviourExample.deserializeMethodInfo.Invoke(realtimeCounter, reader);
+        realtimeCounter = SerializableBehaviourExample.realtimeCounterDeserializeMethodInfo.Invoke(realtimeCounter, reader);
 
         // Return the same object you've been modifying
         return realtimeCounter;
+    }
+}
+
+[ProtoContract]
+internal class StopwatchSignExample : MonoBehaviour, IProtoEventListener
+{
+    [ProtobufSerializerHandler.SubnauticaSerialized(1)]
+    public int version = 1;
+
+    [ProtobufSerializerHandler.SubnauticaSerialized(2)]
+    public float timePassed;
+    
+    [ProtobufSerializerHandler.SubnauticaSerialized(3)]
+    public int serializations;
+    
+    [ProtobufSerializerHandler.SubnauticaSerialized(4)]
+    public int deserializations;
+    
+    private Sign _sign;
+
+    private void Start()
+    {
+        _sign = GetComponent<Sign>();
+    }
+    
+    private void Update()
+    {
+        if (_sign) _sign.signInput.inputField.text = timePassed.ToString("#.0") + $"\nSerializations: {serializations}" + $"\nDeserializations: {deserializations}";
+        timePassed += Time.deltaTime;
+    }
+    
+    // Below are two listeners from the optional interface IProtoEventListener:
+    // OnProtoDeserialize happens after this MonoBehaviour's GameObject full hierarchy is deserialized
+    public void OnProtoDeserialize(ProtobufSerializer serializer)
+    {
+        deserializations++;
+    }
+
+    // OnProtoSerialize happens before this MonoBehaviour's GameObject full hierarchy is serialized
+    public void OnProtoSerialize(ProtobufSerializer serializer)
+    {
+        version = 1;
+        serializations++;
+    }
+
+    // Below are the required static methods for Protobuf serializer to serialize and deserialize this MonoBehaviour
+    // You can find more examples in ProtobufSerializerPrecompiled just like Serialize11492366 and Deserialize11492366
+    // Serialize must be a "static void" with parameters (YourType, int, ProtoWriter)
+    public static void Serialize(StopwatchSignExample stopwatchSignExample, int objTypeId, ProtoWriter writer)
+    {
+        // If you only have basic types you only need to use the generated methods but you may need to adapt this with more complex types
+        // In that situation, please pick the right WireType for your variables and adapt the following Write[Object] call
+
+        // In this case, we only have basic types to serialize so we just invoke the generated method
+        SerializableBehaviourExample.stopwatchSignExampleSerializeMethodInfo.Invoke(stopwatchSignExample, objTypeId, writer);
+    }
+
+    // Deserialize must be a "static YourType" with parameters (YourType, ProtoReader)
+    public static StopwatchSignExample Deserialize(StopwatchSignExample stopwatchSignExample, ProtoReader reader)
+    {
+        // Here you need to use the methods Read[Object] accordingly to what you wrote in Serialize: Write[Object]
+        // Also the different cases must be using the same field numbers as defined in Serialize
+
+        // In this case, we only have basic types to serialize so we just invoke the generated method
+        stopwatchSignExample = SerializableBehaviourExample.stopwatchSignExampleDeserializeMethodInfo.Invoke(stopwatchSignExample, reader);
+
+        // Return the same object you've been modifying
+        return stopwatchSignExample;
     }
 }

--- a/Example mod/SerializableBehaviourExample.cs
+++ b/Example mod/SerializableBehaviourExample.cs
@@ -1,0 +1,114 @@
+using System;
+using BepInEx;
+using Nautilus.Handlers;
+using ProtoBuf;
+using UnityEngine;
+
+namespace Nautilus.Examples;
+
+[BepInPlugin("com.snmodding.nautilus.serializablebehaviour", "Nautilus Serializable Behaviour Example Mod", PluginInfo.PLUGIN_VERSION)]
+[BepInDependency("com.snmodding.nautilus")]
+internal class SerializableBehaviourExample : BaseUnityPlugin
+{
+    private void Awake()
+    {
+        // Don't forget to register your serializable type
+        // You can pick whatever type ID you want as long it's not used by another mod or by Subnautica itself
+        ProtobufSerializerHandler.RegisterSerializableType<RealtimeCounter>(3141592, RealtimeCounter.Serialize, RealtimeCounter.Deserialize);
+    }
+}
+
+[ProtoContract]
+internal class RealtimeCounter : MonoBehaviour, IProtoEventListener
+{
+    public DateTimeOffset StartedCounting { get; private set; } = DateTimeOffset.UtcNow;
+
+    // If you plan on distributing updates to your mod and maybe updating the serialized MonoBehaviours' fields,
+    // you will need to update the version number and adapt your data in the OnProtoDeserialize method.
+    // If you're just making a new serializable MonoBehaviour, set version to 1
+    // If you don't care about updating your mod, you can just ignore everything concerning the version variable
+    [ProtoMember(1), NonSerialized]
+    public int version = 2;
+
+    // Variable to be serialized
+    [ProtoMember(2), NonSerialized]
+    public double totalRealtimeMs;
+
+    // This is an example of how you can give a default value to your serialized variables
+    [ProtoMember(3), NonSerialized]
+    public long firstLaunchUnixTimeMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+    // Some listeners from the optional interface IProtoEventListener
+    // OnProtoDeserialize happens after this MonoBehaviour's GameObject full hierarchy is deserialized
+    public void OnProtoDeserialize(ProtobufSerializer serializer)
+    {
+        // This happens when this MonoBehaviour is loaded for the first time after being updated
+        // You can find another example in Subnautica's code, like WaterParkCreature.OnProtoDeserialize
+        if (version == 1)
+        {
+            // This has no particular meaning but stands as an example of how you can adapt your data in case of updating your serialized variables
+            firstLaunchUnixTimeMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - 1000;
+        }
+
+        StartedCounting = DateTimeOffset.UtcNow;
+        Debug.Log($"Deserialized realtime counter with {totalRealtimeMs}ms [first launch at: {DateTimeOffset.FromUnixTimeMilliseconds(firstLaunchUnixTimeMs)}]");
+    }
+
+    // OnProtoSerialize happens before this MonoBehaviour's GameObject full hierarchy is serialized
+    public void OnProtoSerialize(ProtobufSerializer serializer)
+    {
+        version = 2;
+
+        totalRealtimeMs += (DateTimeOffset.UtcNow - StartedCounting).TotalMilliseconds;
+        StartedCounting = DateTimeOffset.UtcNow;
+        Debug.Log($"Serialized realtime counter with {totalRealtimeMs}ms [first launch at: {DateTimeOffset.FromUnixTimeMilliseconds(firstLaunchUnixTimeMs)}]");
+    }
+
+    // The required static methods for Protobuf serializer to serialize and deserialize this MonoBehaviour
+    // You can find more examples in ProtobufSerializerPrecompiled just like Serialize11492366 and Deserialize11492366
+    // Serialize must be a static void with parameters (YourType, int, ProtoWriter)
+    public static void Serialize(RealtimeCounter realtimeCounter, int objTypeId, ProtoWriter writer)
+    {
+        // If you only have basic types this will be straightforward but you may need to adapt this with more complex ones
+        // Please pick the right WireType for your variables and adapt the following Write[Object] call
+        ProtoWriter.WriteFieldHeader(1, WireType.Variant, writer);
+        ProtoWriter.WriteInt32(realtimeCounter.version, writer);
+
+        ProtoWriter.WriteFieldHeader(2, WireType.Fixed64, writer);
+        ProtoWriter.WriteDouble(realtimeCounter.totalRealtimeMs, writer);
+
+        ProtoWriter.WriteFieldHeader(3, WireType.Fixed64, writer);
+        ProtoWriter.WriteInt64(realtimeCounter.firstLaunchUnixTimeMs, writer);
+    }
+
+    // Deserialize must be a static YourType with parameters (YourType, ProtoReader)
+    public static RealtimeCounter Deserialize(RealtimeCounter realtimeCounter, ProtoReader reader)
+    {
+        // Here you need to use the methods Read[Object] accordingly to what you wrote in Serialize: Write[Object]
+        // Also the different cases must be using the same field numbers as defined in Serialize
+        for (int i = reader.ReadFieldHeader(); i > 0; i = reader.ReadFieldHeader())
+        {
+            switch (i)
+            {
+                case 1:
+                    // We used ProtoWriter.WriteInt32 so here we need reader.ReadInt32
+                    realtimeCounter.version = reader.ReadInt32();
+                    break;
+
+                case 2:
+                    realtimeCounter.totalRealtimeMs = reader.ReadInt64();
+                    break;
+
+                case 3:
+                    realtimeCounter.firstLaunchUnixTimeMs = reader.ReadInt64();
+                    break;
+
+                default:
+                    reader.SkipField();
+                    break;
+            }
+        }
+        // Return the same object you've been modifying
+        return realtimeCounter;
+    }
+}

--- a/Nautilus/Handlers/ProtobufSerializerHandler.cs
+++ b/Nautilus/Handlers/ProtobufSerializerHandler.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using Nautilus.Patchers;
+using Nautilus.Utility;
+using ProtoBuf;
+
+namespace Nautilus.Handlers;
+
+/// <summary>
+/// A handler class responsible for implementing Protobuf serialization to new custom types.
+/// </summary>
+public static class ProtobufSerializerHandler
+{
+    internal static Dictionary<int, SerializerEntry> SerializerEntries;
+
+    static ProtobufSerializerHandler()
+    {
+        InitializeSerializerEntries(ProtobufSerializerPrecompiledPatcher.serializeMethodInfo);
+    }
+
+    /// <summary>
+    /// Initialize <see cref="SerializerEntries"/> with Subnautica's known types
+    /// </summary>
+    private static void InitializeSerializerEntries(MethodInfo serializeMethodInfo)
+    {
+        SerializerEntries = new();
+
+        // We loop through the IL code instructions to find the exact match between a typeId and the method it calls
+        List<KeyValuePair<OpCode, object>> serializeMethodInstructions = PatchProcessor.ReadMethodBody(serializeMethodInfo).ToList();
+        for (int i = 0; i < serializeMethodInstructions.Count; i++)
+        {
+            KeyValuePair<OpCode, object> instruction = serializeMethodInstructions[i];
+            if (instruction.Key == OpCodes.Call)
+            {
+                // The castclass instruction is always 3 steps before the call instruction
+                Type objectType = (Type) serializeMethodInstructions[i - 3].Value;
+                // The ldc.i4 instruction is always 2 steps before the call instruction
+                int associatedTypeId = (int) serializeMethodInstructions[i - 2].Value;
+                // To get the methodName we remove the 5 first letters and we cut before the opening parenthese
+                string serializeMethodName = instruction.Value.ToString()[5..].Split('(')[0];
+                // The deserialize method name will be the same but with Deserialize[...] instead of Serialize[...]
+                string deserializeMethodName = serializeMethodName.Replace("S", "Des");
+
+                SerializerEntries.Add(associatedTypeId, new(objectType, serializeMethodName, deserializeMethodName));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Registers a type as serializable for Protobuf.
+    /// </summary>
+    /// <remarks>
+    /// This is the only method from <see cref="ProtobufSerializerPrecompiledPatcher"/> which should be used by mods.
+    /// </remarks>
+    /// <typeparam name="T">Type of the serializable type</typeparam>
+    /// <param name="typeId">
+    /// An arbitrary unique type id which shouldn't be already used by Subnautica nor by any other mod.
+    /// Look through <see cref="ProtobufSerializerPrecompiled"/> to ensure the id is not already taken.
+    /// </param>
+    /// <param name="serializeMethod">
+    /// A reference to the serialize method.
+    /// NB: Take inspiration from <see cref="ProtobufSerializerPrecompiled.Serialize11492366"/> to understand how make one.
+    /// </param>
+    /// <param name="deserializeMethod">
+    /// A reference to the serialize method.
+    /// NB: Take inspiration from <see cref="ProtobufSerializerPrecompiled.Deserialize11492366"/> to understand how make one.
+    /// </param>
+    public static void RegisterSerializableType<T>(int typeId, Action<T, int, ProtoWriter> serializeMethod, Func<T, ProtoReader, T> deserializeMethod)
+    {
+        if (SerializerEntries.ContainsKey(typeId))
+        {
+            throw new DuplicateTypeIdException(typeId, typeof(T));
+        }
+        ProtobufSerializerPrecompiled.knownTypes.Add(typeof(T), typeId);
+        SerializerEntries.Add(typeId, new(serializeMethod.Method, deserializeMethod.Method, typeof(T)));
+    }
+
+    /// <summary>
+    /// Data structure which holds the method data for serialization and deserialization.
+    /// </summary>
+    internal class SerializerEntry
+    {
+        internal MethodInfo SerializeInfo;
+        internal MethodInfo DeserializeInfo;
+        internal Type Type;
+
+        /// <summary>
+        /// Constructor to be commonly used when adding a new serializable type.
+        /// </summary>
+        /// <param name="serializeInfo">A static method ran when Subnautica serializes the <see cref="Type"/></param>
+        /// <param name="deserializeInfo">A static method ran when Subnautica deserializes the <see cref="Type"/></param>
+        /// <param name="type">The type to be serializable</param>
+        public SerializerEntry(MethodInfo serializeInfo, MethodInfo deserializeInfo, Type type)
+        {
+            if (!serializeInfo.IsStatic)
+            {
+                throw new ArgumentException($"The provided serialize method '{serializeInfo.Name}' should be static for type '{type}'");
+            }
+            if (!deserializeInfo.IsStatic)
+            {
+                throw new ArgumentException($"The provided deserialize method '{deserializeInfo.Name}' should be static for type '{type}'");
+
+            }
+            SerializeInfo = serializeInfo;
+            DeserializeInfo = deserializeInfo;
+            Type = type;
+        }
+
+        /// <summary>
+        /// Constructor to be used for Subnautica's default known types only.
+        /// </summary>
+        public SerializerEntry(Type type, string serializeMethodName, string deserializeMethodName)
+        {
+            SerializeInfo = ReflectionHelper.GetInstanceMethod<ProtobufSerializerPrecompiled>(serializeMethodName);
+            DeserializeInfo = ReflectionHelper.GetInstanceMethod<ProtobufSerializerPrecompiled>(deserializeMethodName);
+            Type = type;
+        }
+    }
+
+    /// <summary>
+    /// The exception that is thrown when a <see cref="SerializerEntry"/> is attempted to be added when an existing one of the same type already exists.
+    /// </summary>
+    public class DuplicateTypeIdException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DuplicateTypeIdException"/> class with default properties.
+        /// </summary>
+        /// <param name="typeId">Type id of the already registered serializer entry.</param>
+        /// <param name="type">Type of the requested</param>
+        public DuplicateTypeIdException(int typeId, Type type) : base
+            ($"Cannot register serializable type '{type}' with id '{typeId}' because it is already used by either Subnautica or another instance.")
+        {
+
+        }
+    }
+}

--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -79,5 +79,6 @@ public class Initializer : BaseUnityPlugin
         WaterParkPatcher.Patch(_harmony);
         ModMessageSystem.Patch();
         BiomePatcher.Patch(_harmony);
+        ProtobufSerializerPrecompiledPatcher.Patch(_harmony);
     }
 }

--- a/Nautilus/Patchers/ProtobufSerializerPrecompiledPatcher.cs
+++ b/Nautilus/Patchers/ProtobufSerializerPrecompiledPatcher.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Reflection.Emit;
 using HarmonyLib;
+using Nautilus.Handlers;
 using Nautilus.Utility;
 using ProtoBuf;
 
@@ -15,76 +13,16 @@ namespace Nautilus.Patchers;
 /// </summary>
 internal static class ProtobufSerializerPrecompiledPatcher
 {
-    internal static Dictionary<int, SerializerEntry> SerializerEntries;
+    internal static MethodInfo serializeMethodInfo = ReflectionHelper.GetInstanceMethod<ProtobufSerializerPrecompiled>(nameof(ProtobufSerializerPrecompiled.Serialize));
+    internal static MethodInfo deserializeMethodInfo = ReflectionHelper.GetInstanceMethod<ProtobufSerializerPrecompiled>(nameof(ProtobufSerializerPrecompiled.Deserialize));
 
     internal static void Patch(Harmony harmony)
     {
-        MethodInfo serializeMethodInfo = ReflectionHelper.GetInstanceMethod<ProtobufSerializerPrecompiled>(nameof(ProtobufSerializerPrecompiled.Serialize));
         HarmonyMethod optimizedSerialize = new(AccessTools.Method(typeof(ProtobufSerializerPrecompiledPatcher), nameof(OptimizedSerializePrefix)));
         harmony.Patch(serializeMethodInfo, prefix: optimizedSerialize);
 
-        MethodInfo deserializeMethodInfo = ReflectionHelper.GetInstanceMethod<ProtobufSerializerPrecompiled>(nameof(ProtobufSerializerPrecompiled.Deserialize));
         HarmonyMethod optimizedDeserialize = new(AccessTools.Method(typeof(ProtobufSerializerPrecompiledPatcher), nameof(OptimizedDeserializePrefix)));
-        harmony.Patch(deserializeMethodInfo, prefix: optimizedDeserialize);
-
-        InitializeSerializerEntries(serializeMethodInfo);
-    }
-
-    /// <summary>
-    /// Initialize <see cref="SerializerEntries"/> with Subnautica's known types
-    /// </summary>
-    private static void InitializeSerializerEntries(MethodInfo serializeMethodInfo)
-    {
-        SerializerEntries = new();
-        
-        // We loop through the IL code instructions to find the exact match between a typeId and the method it calls
-        List<KeyValuePair<OpCode, object>> serializeMethodInstructions = PatchProcessor.ReadMethodBody(serializeMethodInfo).ToList();
-        for (int i = 0; i < serializeMethodInstructions.Count; i++)
-        {
-            KeyValuePair<OpCode, object> instruction = serializeMethodInstructions[i];
-            if (instruction.Key == OpCodes.Call)
-            {
-                // The castclass instruction is always 3 steps before the call instruction
-                Type objectType = (Type)serializeMethodInstructions[i - 3].Value;
-                // The ldc.i4 instruction is always 2 steps before the call instruction
-                int associatedTypeId = (int)serializeMethodInstructions[i - 2].Value;
-                // To get the methodName we remove the 5 first letters and we cut before the opening parenthese
-                string serializeMethodName = instruction.Value.ToString()[5..].Split('(')[0];
-                // The deserialize method name will be the same but with Deserialize[...] instead of Serialize[...]
-                string deserializeMethodName = serializeMethodName.Replace("S", "Des");
-
-                SerializerEntries.Add(associatedTypeId, new(objectType, serializeMethodName, deserializeMethodName));
-            }
-        }
-    }
-
-    /// <summary>
-    /// Registers a type as serializable for Protobuf.
-    /// </summary>
-    /// <remarks>
-    /// This is the only method from <see cref="ProtobufSerializerPrecompiledPatcher"/> which should be used by mods.
-    /// </remarks>
-    /// <typeparam name="T">Type of the serializable type</typeparam>
-    /// <param name="typeId">
-    /// An arbitrary unique type id which shouldn't be already used by Subnautica nor by any other mod.
-    /// Look through <see cref="ProtobufSerializerPrecompiled"/> to ensure the id is not already taken.
-    /// </param>
-    /// <param name="serializeMethod">
-    /// A reference to the serialize method.
-    /// NB: Take inspiration from <see cref="ProtobufSerializerPrecompiled.Serialize11492366"/> to understand how make one.
-    /// </param>
-    /// <param name="deserializeMethod">
-    /// A reference to the serialize method.
-    /// NB: Take inspiration from <see cref="ProtobufSerializerPrecompiled.Deserialize11492366"/> to understand how make one.
-    /// </param>
-    public static void RegisterSerializableType<T>(int typeId, Action<T, int, ProtoWriter> serializeMethod, Func<T, ProtoReader, T> deserializeMethod)
-    {
-        if (SerializerEntries.ContainsKey(typeId))
-        {
-            throw new DuplicateTypeIdException(typeId, typeof(T));
-        }
-        ProtobufSerializerPrecompiled.knownTypes.Add(typeof(T), typeId);
-        SerializerEntries.Add(typeId, new(serializeMethod.Method, deserializeMethod.Method, typeof(T)));
+        harmony.Patch(deserializeMethodInfo, prefix: optimizedDeserialize);        
     }
 
     /// <summary>
@@ -92,7 +30,7 @@ internal static class ProtobufSerializerPrecompiledPatcher
     /// </summary>
     private static bool OptimizedSerializePrefix(int num, object obj, ProtoWriter writer, ProtobufSerializerPrecompiled __instance)
     {
-        if (SerializerEntries.TryGetValue(num, out SerializerEntry entry))
+        if (ProtobufSerializerHandler.SerializerEntries.TryGetValue(num, out ProtobufSerializerHandler.SerializerEntry entry))
         {
             // Always provide __instance but it's only used for Subnautica's known types as custom types methods must be static
             entry.SerializeInfo.Invoke(__instance, new object[] { Convert.ChangeType(obj, entry.Type), num, writer });
@@ -105,69 +43,10 @@ internal static class ProtobufSerializerPrecompiledPatcher
     /// </summary>
     private static bool OptimizedDeserializePrefix(int num, object obj, ProtoReader reader, ProtobufSerializerPrecompiled __instance, ref object __result)
     {
-        if (SerializerEntries.TryGetValue(num, out SerializerEntry entry))
+        if (ProtobufSerializerHandler.SerializerEntries.TryGetValue(num, out ProtobufSerializerHandler.SerializerEntry entry))
         {
             __result = entry.DeserializeInfo.Invoke(__instance, new object[] { Convert.ChangeType(obj, entry.Type), reader });
         }
         return false;
-    }
-
-    /// <summary>
-    /// Data structure which holds the method data for serialization and deserialization.
-    /// </summary>
-    public class SerializerEntry
-    {
-        internal MethodInfo SerializeInfo;
-        internal MethodInfo DeserializeInfo;
-        internal Type Type;
-
-        /// <summary>
-        /// Constructor to be commonly used when adding a new serializable type.
-        /// </summary>
-        /// <param name="serializeInfo">A static method ran when Subnautica serializes the <see cref="Type"/></param>
-        /// <param name="deserializeInfo">A static method ran when Subnautica deserializes the <see cref="Type"/></param>
-        /// <param name="type">The type to be serializable</param>
-        public SerializerEntry(MethodInfo serializeInfo, MethodInfo deserializeInfo, Type type)
-        {
-            if (!serializeInfo.IsStatic)
-            {
-                throw new ArgumentException($"The provided serialize method '{serializeInfo.Name}' should be static for type '{type}'");
-            }
-            if (!deserializeInfo.IsStatic)
-            {
-                throw new ArgumentException($"The provided deserialize method '{deserializeInfo.Name}' should be static for type '{type}'");
-
-            }
-            SerializeInfo = serializeInfo;
-            DeserializeInfo = deserializeInfo;
-            Type = type;
-        }
-
-        /// <summary>
-        /// Constructor to be used for Subnautica's default known types only.
-        /// </summary>
-        public SerializerEntry(Type type, string serializeMethodName, string deserializeMethodName)
-        {
-            SerializeInfo = ReflectionHelper.GetInstanceMethod<ProtobufSerializerPrecompiled>(serializeMethodName);
-            DeserializeInfo = ReflectionHelper.GetInstanceMethod<ProtobufSerializerPrecompiled>(deserializeMethodName);
-            Type = type;
-        }
-    }
-
-    /// <summary>
-    /// The exception that is thrown when a <see cref="SerializerEntry"/> is attempted to be added when an existing one of the same type already exists.
-    /// </summary>
-    public class DuplicateTypeIdException : Exception
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DuplicateTypeIdException"/> class with default properties.
-        /// </summary>
-        /// <param name="typeId">Type id of the already registered serializer entry.</param>
-        /// <param name="type">Type of the requested</param>
-        public DuplicateTypeIdException(int typeId, Type type) : base
-            ($"Cannot register serializable type '{type}' with id '{typeId}' because it is already used by either Subnautica or another instance.")
-        {
-
-        }
     }
 }

--- a/Nautilus/Patchers/ProtobufSerializerPrecompiledPatcher.cs
+++ b/Nautilus/Patchers/ProtobufSerializerPrecompiledPatcher.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using Nautilus.Utility;
+using ProtoBuf;
+
+namespace Nautilus.Patchers;
+
+/// <summary>
+/// Replaces <see cref="ProtobufSerializerPrecompiled.Serialize"/> and <see cref="ProtobufSerializerPrecompiled.Deserialize"/>
+/// by a dictionary lookup instead of an if tree. Also enables mods from serializing classes using the Protobuf serializer.
+/// </summary>
+internal static class ProtobufSerializerPrecompiledPatcher
+{
+    internal static Dictionary<int, SerializerEntry> SerializerEntries;
+
+    internal static void Patch(Harmony harmony)
+    {
+        MethodInfo serializeMethodInfo = ReflectionHelper.GetInstanceMethod<ProtobufSerializerPrecompiled>(nameof(ProtobufSerializerPrecompiled.Serialize));
+        HarmonyMethod optimizedSerialize = new(AccessTools.Method(typeof(ProtobufSerializerPrecompiledPatcher), nameof(OptimizedSerializePrefix)));
+        harmony.Patch(serializeMethodInfo, prefix: optimizedSerialize);
+
+        MethodInfo deserializeMethodInfo = ReflectionHelper.GetInstanceMethod<ProtobufSerializerPrecompiled>(nameof(ProtobufSerializerPrecompiled.Deserialize));
+        HarmonyMethod optimizedDeserialize = new(AccessTools.Method(typeof(ProtobufSerializerPrecompiledPatcher), nameof(OptimizedDeserializePrefix)));
+        harmony.Patch(deserializeMethodInfo, prefix: optimizedDeserialize);
+
+        InitializeSerializerEntries(serializeMethodInfo);
+    }
+
+    /// <summary>
+    /// Initialize <see cref="SerializerEntries"/> with Subnautica's known types
+    /// </summary>
+    private static void InitializeSerializerEntries(MethodInfo serializeMethodInfo)
+    {
+        SerializerEntries = new();
+        
+        // We loop through the IL code instructions to find the exact match between a typeId and the method it calls
+        List<KeyValuePair<OpCode, object>> serializeMethodInstructions = PatchProcessor.ReadMethodBody(serializeMethodInfo).ToList();
+        for (int i = 0; i < serializeMethodInstructions.Count; i++)
+        {
+            KeyValuePair<OpCode, object> instruction = serializeMethodInstructions[i];
+            if (instruction.Key == OpCodes.Call)
+            {
+                // The castclass instruction is always 3 steps before the call instruction
+                Type objectType = (Type)serializeMethodInstructions[i - 3].Value;
+                // The ldc.i4 instruction is always 2 steps before the call instruction
+                int associatedTypeId = (int)serializeMethodInstructions[i - 2].Value;
+                // To get the methodName we remove the 5 first letters and we cut before the opening parenthese
+                string serializeMethodName = instruction.Value.ToString()[5..].Split('(')[0];
+                // The deserialize method name will be the same but with Deserialize[...] instead of Serialize[...]
+                string deserializeMethodName = serializeMethodName.Replace("S", "Des");
+
+                SerializerEntries.Add(associatedTypeId, new(objectType, serializeMethodName, deserializeMethodName));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Registers a type as serializable for Protobuf.
+    /// </summary>
+    /// <remarks>
+    /// This is the only method from <see cref="ProtobufSerializerPrecompiledPatcher"/> which should be used by mods.
+    /// </remarks>
+    /// <typeparam name="T">Type of the serializable type</typeparam>
+    /// <param name="typeId">
+    /// An arbitrary unique type id which shouldn't be already used by Subnautica nor by any other mod.
+    /// Look through <see cref="ProtobufSerializerPrecompiled"/> to ensure the id is not already taken.
+    /// </param>
+    /// <param name="serializeMethod">
+    /// A reference to the serialize method.
+    /// NB: Take inspiration from <see cref="ProtobufSerializerPrecompiled.Serialize11492366"/> to understand how make one.
+    /// </param>
+    /// <param name="deserializeMethod">
+    /// A reference to the serialize method.
+    /// NB: Take inspiration from <see cref="ProtobufSerializerPrecompiled.Deserialize11492366"/> to understand how make one.
+    /// </param>
+    public static void RegisterSerializableType<T>(int typeId, Action<T, int, ProtoWriter> serializeMethod, Func<T, ProtoReader, T> deserializeMethod)
+    {
+        if (SerializerEntries.ContainsKey(typeId))
+        {
+            throw new DuplicateTypeIdException(typeId, typeof(T));
+        }
+        ProtobufSerializerPrecompiled.knownTypes.Add(typeof(T), typeId);
+        SerializerEntries.Add(typeId, new(serializeMethod.Method, deserializeMethod.Method, typeof(T)));
+    }
+
+    /// <summary>
+    /// Prefix to replace <see cref="ProtobufSerializerPrecompiled.Serialize"/>'s if tree by a dictionary lookup
+    /// </summary>
+    private static bool OptimizedSerializePrefix(int num, object obj, ProtoWriter writer, ProtobufSerializerPrecompiled __instance)
+    {
+        if (SerializerEntries.TryGetValue(num, out SerializerEntry entry))
+        {
+            // Always provide __instance but it's only used for Subnautica's known types as custom types methods must be static
+            entry.SerializeInfo.Invoke(__instance, new object[] { Convert.ChangeType(obj, entry.Type), num, writer });
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Prefix to replace <see cref="ProtobufSerializerPrecompiled.Deserialize"/>'s if tree by a dictionary lookup
+    /// </summary>
+    private static bool OptimizedDeserializePrefix(int num, object obj, ProtoReader reader, ProtobufSerializerPrecompiled __instance, ref object __result)
+    {
+        if (SerializerEntries.TryGetValue(num, out SerializerEntry entry))
+        {
+            __result = entry.DeserializeInfo.Invoke(__instance, new object[] { Convert.ChangeType(obj, entry.Type), reader });
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Data structure which holds the method data for serialization and deserialization.
+    /// </summary>
+    public class SerializerEntry
+    {
+        internal MethodInfo SerializeInfo;
+        internal MethodInfo DeserializeInfo;
+        internal Type Type;
+
+        /// <summary>
+        /// Constructor to be commonly used when adding a new serializable type.
+        /// </summary>
+        /// <param name="serializeInfo">A static method ran when Subnautica serializes the <see cref="Type"/></param>
+        /// <param name="deserializeInfo">A static method ran when Subnautica deserializes the <see cref="Type"/></param>
+        /// <param name="type">The type to be serializable</param>
+        public SerializerEntry(MethodInfo serializeInfo, MethodInfo deserializeInfo, Type type)
+        {
+            if (!serializeInfo.IsStatic)
+            {
+                throw new ArgumentException($"The provided serialize method '{serializeInfo.Name}' should be static for type '{type}'");
+            }
+            if (!deserializeInfo.IsStatic)
+            {
+                throw new ArgumentException($"The provided deserialize method '{deserializeInfo.Name}' should be static for type '{type}'");
+
+            }
+            SerializeInfo = serializeInfo;
+            DeserializeInfo = deserializeInfo;
+            Type = type;
+        }
+
+        /// <summary>
+        /// Constructor to be used for Subnautica's default known types only.
+        /// </summary>
+        public SerializerEntry(Type type, string serializeMethodName, string deserializeMethodName)
+        {
+            SerializeInfo = ReflectionHelper.GetInstanceMethod<ProtobufSerializerPrecompiled>(serializeMethodName);
+            DeserializeInfo = ReflectionHelper.GetInstanceMethod<ProtobufSerializerPrecompiled>(deserializeMethodName);
+            Type = type;
+        }
+    }
+
+    /// <summary>
+    /// The exception that is thrown when a <see cref="SerializerEntry"/> is attempted to be added when an existing one of the same type already exists.
+    /// </summary>
+    public class DuplicateTypeIdException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DuplicateTypeIdException"/> class with default properties.
+        /// </summary>
+        /// <param name="typeId">Type id of the already registered serializer entry.</param>
+        /// <param name="type">Type of the requested</param>
+        public DuplicateTypeIdException(int typeId, Type type) : base
+            ($"Cannot register serializable type '{type}' with id '{typeId}' because it is already used by either Subnautica or another instance.")
+        {
+
+        }
+    }
+}

--- a/Nautilus/Patchers/ProtobufSerializerPrecompiledPatcher.cs
+++ b/Nautilus/Patchers/ProtobufSerializerPrecompiledPatcher.cs
@@ -30,7 +30,7 @@ internal static class ProtobufSerializerPrecompiledPatcher
     /// </summary>
     private static bool OptimizedSerializePrefix(int num, object obj, ProtoWriter writer, ProtobufSerializerPrecompiled __instance)
     {
-        if (ProtobufSerializerHandler.SerializerEntries.TryGetValue(num, out ProtobufSerializerHandler.SerializerEntry entry))
+        if (ProtobufSerializerHandler.SerializerEntries.TryGetValue(obj.GetType(), out ProtobufSerializerHandler.SerializerEntry entry))
         {
             // Always provide __instance but it's only used for Subnautica's known types as custom types methods must be static
             entry.SerializeInfo.Invoke(__instance, new object[] { Convert.ChangeType(obj, entry.Type), num, writer });
@@ -43,7 +43,7 @@ internal static class ProtobufSerializerPrecompiledPatcher
     /// </summary>
     private static bool OptimizedDeserializePrefix(int num, object obj, ProtoReader reader, ProtobufSerializerPrecompiled __instance, ref object __result)
     {
-        if (ProtobufSerializerHandler.SerializerEntries.TryGetValue(num, out ProtobufSerializerHandler.SerializerEntry entry))
+        if (ProtobufSerializerHandler.SerializerEntries.TryGetValue(obj.GetType(), out ProtobufSerializerHandler.SerializerEntry entry))
         {
             __result = entry.DeserializeInfo.Invoke(__instance, new object[] { Convert.ChangeType(obj, entry.Type), reader });
         }

--- a/Nautilus/Patchers/ProtobufSerializerPrecompiledPatcher.cs
+++ b/Nautilus/Patchers/ProtobufSerializerPrecompiledPatcher.cs
@@ -22,7 +22,7 @@ internal static class ProtobufSerializerPrecompiledPatcher
         harmony.Patch(serializeMethodInfo, prefix: optimizedSerialize);
 
         HarmonyMethod optimizedDeserialize = new(AccessTools.Method(typeof(ProtobufSerializerPrecompiledPatcher), nameof(OptimizedDeserializePrefix)));
-        harmony.Patch(deserializeMethodInfo, prefix: optimizedDeserialize);        
+        harmony.Patch(deserializeMethodInfo, prefix: optimizedDeserialize);
     }
 
     /// <summary>
@@ -41,7 +41,7 @@ internal static class ProtobufSerializerPrecompiledPatcher
     /// <summary>
     /// Prefix to replace <see cref="ProtobufSerializerPrecompiled.Deserialize"/>'s if tree by a dictionary lookup
     /// </summary>
-    private static bool OptimizedDeserializePrefix(int num, object obj, ProtoReader reader, ProtobufSerializerPrecompiled __instance, ref object __result)
+    private static bool OptimizedDeserializePrefix(object obj, ProtoReader reader, ProtobufSerializerPrecompiled __instance, ref object __result)
     {
         if (ProtobufSerializerHandler.SerializerEntries.TryGetValue(obj.GetType(), out ProtobufSerializerHandler.SerializerEntry entry))
         {


### PR DESCRIPTION
### Changes made in this pull request

  - Add the possibility to serialize our own types through the protobuf serializer
  - Replace ProtobufSerializerPrecompiled.Serialize and ProtobufSerializerPrecompiled.Deserialize methods which used a big if-tree to have a dictionary lookup instead
  
As I don't own BZ, someone else will need to adapt this code for it.