### PR TITLE
Remove prefab requests array and lock cache dictionary

### DIFF
--- a/Nautilus/Assets/ModPrefabCache.cs
+++ b/Nautilus/Assets/ModPrefabCache.cs
@@ -89,34 +89,31 @@ internal class ModPrefabCacheInstance: MonoBehaviour
     {
         var prefabIdentifier = prefab.GetComponent<PrefabIdentifier>();
 
-        if(prefabIdentifier == null)
+        if (prefabIdentifier == null)
         {
             InternalLogger.Warn($"ModPrefabCache: prefab {prefab.name} is missing a PrefabIdentifier component! Unable to add to cache.");
             return;
         }
 
-        lock (Entries)
+        if (!Entries.ContainsKey(prefabIdentifier.classId))
         {
-            if(!Entries.ContainsKey(prefabIdentifier.classId))
+            Entries.Add(prefabIdentifier.classId, prefab);
+            InternalLogger.Debug($"ModPrefabCache: added prefab {prefab}");
+            // Proper prefabs can never exist in the scene, so parenting them is dangerous and pointless. 
+            if (prefab.IsPrefab())
             {
-                Entries.Add(prefabIdentifier.classId, prefab);
-                InternalLogger.Debug($"ModPrefabCache: added prefab {prefab}");
-                // Proper prefabs can never exist in the scene, so parenting them is dangerous and pointless. 
-                if (prefab.IsPrefab())
-                {
-                    InternalLogger.Debug($"Game Object: {prefab} is a proper prefab. Skipping parenting for cache.");
-                }
-                else
-                {
-                    prefab.transform.parent = _prefabRoot;
-                    prefab.SetActive(true);
-                }
+                InternalLogger.Debug($"Game Object: {prefab} is a proper prefab. Skipping parenting for cache.");
             }
-            else // this should never happen
+            else
             {
-                InternalLogger.Debug($"ModPrefabCache: prefab {prefabIdentifier.classId} already existed in cache!");
-            }   
+                prefab.transform.parent = _prefabRoot;
+                prefab.SetActive(true);
+            }
         }
+        else
+        {
+            InternalLogger.Debug($"ModPrefabCache: prefab {prefabIdentifier.classId} already existed in cache!");
+        }   
     }
 
     public void RemoveCachedPrefab(string classId)

--- a/Nautilus/Assets/ModPrefabCache.cs
+++ b/Nautilus/Assets/ModPrefabCache.cs
@@ -113,9 +113,9 @@ internal class ModPrefabCacheInstance: MonoBehaviour
                 prefab.SetActive(true);
             }
         }
-        else
+        else // This should never happen
         {
-            InternalLogger.Debug($"ModPrefabCache: prefab {prefabIdentifier.classId} already existed in cache!");
+            InternalLogger.Warn($"ModPrefabCache: prefab {prefabIdentifier.classId} already existed in cache!");
         }   
     }
 

--- a/Nautilus/Assets/ModPrefabCache.cs
+++ b/Nautilus/Assets/ModPrefabCache.cs
@@ -114,7 +114,7 @@ internal class ModPrefabCacheInstance: MonoBehaviour
             }
             else // this should never happen
             {
-                InternalLogger.Warn($"ModPrefabCache: prefab {prefabIdentifier.classId} already existed in cache!");
+                InternalLogger.Debug($"ModPrefabCache: prefab {prefabIdentifier.classId} already existed in cache!");
             }   
         }
     }

--- a/Nautilus/Assets/ModPrefabCache.cs
+++ b/Nautilus/Assets/ModPrefabCache.cs
@@ -85,6 +85,7 @@ internal class ModPrefabCacheInstance: MonoBehaviour
 
         gameObject.AddComponent<SceneCleanerPreserve>();
         DontDestroyOnLoad(gameObject);
+        SaveUtils.RegisterOnQuitEvent(ModPrefabCache.RunningPrefabs.Clear);
     }
 
     public void EnterPrefabIntoCache(GameObject prefab)

--- a/Nautilus/Assets/ModPrefabCache.cs
+++ b/Nautilus/Assets/ModPrefabCache.cs
@@ -11,6 +11,8 @@ namespace Nautilus.Assets;
 /// </summary>
 public static class ModPrefabCache
 {
+    internal static HashSet<string> RunningPrefabs = new();
+    
     private static ModPrefabCacheInstance _cacheInstance;
 
     /// <summary> Adds the given prefab to the cache. </summary>

--- a/Nautilus/Assets/ModPrefabRequest.cs
+++ b/Nautilus/Assets/ModPrefabRequest.cs
@@ -20,7 +20,6 @@ internal class ModPrefabRequest: IPrefabRequest
     public ModPrefabRequest(PrefabInfo prefabInfo)
     {
         this.prefabInfo = prefabInfo;
-        ModPrefabCache.Requests[prefabInfo.ClassID] = this;
     }
 
     private void Init()

--- a/Nautilus/Patchers/PrefabDatabasePatcher.cs
+++ b/Nautilus/Patchers/PrefabDatabasePatcher.cs
@@ -79,11 +79,6 @@ internal static class PrefabDatabasePatcher
             return null;
         }
 
-        if(ModPrefabCache.Requests.TryGetValue(prefabInfo.ClassID, out var request))
-        {            
-            return request;
-        }
-
         return new ModPrefabRequest(prefabInfo);
     }
 


### PR DESCRIPTION
### Changes made in this pull request

  - Removed the dictionary of mod prefab requests. Now duplicate requests made around the same moment will wait for the first one to complete.
  - Prefab spawning (specifically coordinated spawns) should work as intended now.
  - Cache entries should never be duplicated.
  - Our previous approach made more sense, but wasn't thread safe. Coroutines are too fragile for that.

### Breaking changes

  - Should be none