### PR TITLE
Fix duplicate entry in Fallbacks dictionary

### DIFF
--- a/Nautilus/Patchers/CraftTreePatcher.cs
+++ b/Nautilus/Patchers/CraftTreePatcher.cs
@@ -25,8 +25,7 @@ internal class CraftTreePatcher
         { CraftTree.Type.Fabricator, TechType.Fabricator },
         { CraftTree.Type.Constructor, TechType.Constructor },
         { CraftTree.Type.SeamothUpgrades, TechType.BaseUpgradeConsole },
-        { CraftTree.Type.MapRoom, TechType.BaseMapRoom },
-        { CraftTree.Type.Workbench, TechType.Workbench },
+        { CraftTree.Type.MapRoom, TechType.BaseMapRoom }
     };
     private const string FallbackTabNode = "Modded";
     private const string VanillaRoot = "Vanilla";


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed a major NRE that stopped many mods from working by removing a duplicate key of "Workbench" from `CraftTreePatcher.Fallbacks`.

### Breaking changes

  - None, this change is unbreaking