### PR TITLE
Localization not affecting tab nodes & Language Metadata

### DIFF
--- a/Nautilus/Crafting/TabNode.cs
+++ b/Nautilus/Crafting/TabNode.cs
@@ -1,10 +1,8 @@
-using Nautilus.Handlers;
-using Nautilus.Utility;
-
 namespace Nautilus.Crafting;
 
-using Nautilus.Assets;
-using Nautilus.Patchers;
+using Assets;
+using Handlers;
+using Utility;
 
 #if SUBNAUTICA
 using Sprite = Atlas.Sprite;

--- a/Nautilus/Crafting/TabNode.cs
+++ b/Nautilus/Crafting/TabNode.cs
@@ -1,3 +1,6 @@
+using Nautilus.Handlers;
+using Nautilus.Utility;
+
 namespace Nautilus.Crafting;
 
 using Nautilus.Assets;
@@ -15,15 +18,25 @@ internal class TabNode : Node
     internal Sprite Sprite { get; set; }
     internal string DisplayName { get; set; }
     internal string Name { get; set; }
+    internal string Id { get; }
 
-    internal TabNode(string[] path, CraftTree.Type scheme, Sprite sprite, string name, string displayName, string language = "English") : base(path, scheme)
+    internal TabNode(string[] path, CraftTree.Type scheme, Sprite sprite, string name, string displayName) : base(path, scheme)
     {
         Sprite = sprite;
         DisplayName = displayName;
         Name = name;
+        Id = $"{Scheme.ToString()}_{Name}";
 
-        ModSprite.Add(new ModSprite(SpriteManager.Group.Category, $"{Scheme.ToString()}_{Name}", Sprite));
-        LanguagePatcher.AddCustomLanguageLine($"{Scheme.ToString()}Menu_{Name}", DisplayName, language);
+        ModSprite.Add(new ModSprite(SpriteManager.Group.Category, Id, Sprite));
+
+        if (!string.IsNullOrEmpty(displayName))
+        {
+            LanguageHandler.SetLanguageLine(Id, displayName);
+        }
+        else if (string.IsNullOrEmpty(Language.main.Get(name)))
+        {
+            InternalLogger.Warn($"Display name was not specified and no existing language line has been found for Tab node '{name}'.");
+        }
     }
 
 }

--- a/Nautilus/Handlers/CraftTreeHandler.cs
+++ b/Nautilus/Handlers/CraftTreeHandler.cs
@@ -56,7 +56,7 @@ public static class CraftTreeHandler
     /// </summary>
     /// <param name="craftTree">The target craft tree to edit.</param>
     /// <param name="name">The ID of the tab node. Must be unique!</param>
-    /// <param name="displayName">The display name of the tab, which will show up when you hover your mouse on the tab.</param>
+    /// <param name="displayName">The display name of the tab, which will show up when you hover your mouse on the tab. If null or empty, this will use the language line "{craftTreeName}_{tabName}" instead.</param>
     /// <param name="sprite">The sprite of the tab.</param>        
     public static void AddTabNode(CraftTree.Type craftTree, string name, string displayName, Atlas.Sprite sprite)
     {
@@ -75,7 +75,7 @@ public static class CraftTreeHandler
     /// </summary>
     /// <param name="craftTree">The target craft tree to edit.</param>
     /// <param name="name">The ID of the tab node. Must be unique!</param>
-    /// <param name="displayName">The display name of the tab, which will show up when you hover your mouse on the tab.</param>
+    /// <param name="displayName">The display name of the tab, which will show up when you hover your mouse on the tab. If null or empty, this will use the language line "{craftTreeName}_{tabName}" instead.</param>
     /// <param name="sprite">The sprite of the tab.</param>
 
     public static void AddTabNode(CraftTree.Type craftTree, string name, string displayName, UnityEngine.Sprite sprite)
@@ -95,7 +95,7 @@ public static class CraftTreeHandler
     /// </summary>
     /// <param name="craftTree">The target craft tree to edit.</param>
     /// <param name="name">The ID of the tab node. Must be unique!</param>
-    /// <param name="displayName">The display name of the tab, which will show up when you hover your mouse on the tab.</param>
+    /// <param name="displayName">The display name of the tab, which will show up when you hover your mouse on the tab. If null or empty, this will use the language line "{craftTreeName}_{tabName}" instead.</param>
     /// <param name="sprite">The sprite of the tab.</param>
     /// <param name="stepsToTab">
     /// <para>The steps to the target tab.</para>
@@ -120,7 +120,7 @@ public static class CraftTreeHandler
     /// </summary>
     /// <param name="craftTree">The target craft tree to edit.</param>
     /// <param name="name">The ID of the tab node. Must be unique!</param>
-    /// <param name="displayName">The display name of the tab, which will show up when you hover your mouse on the tab.</param>
+    /// <param name="displayName">The display name of the tab, which will show up when you hover your mouse on the tab. If null or empty, this will use the language line "{craftTreeName}_{tabName}" instead.</param>
     /// <param name="sprite">The sprite of the tab.</param>
     /// <param name="stepsToTab">
     /// <para>The steps to the target tab.</para>
@@ -146,7 +146,7 @@ public static class CraftTreeHandler
     /// </summary>
     /// <param name="craftTree">The target craft tree to edit.</param>
     /// <param name="name">The ID of the tab node. Must be unique!</param>
-    /// <param name="displayName">The display name of the tab, which will show up when you hover your mouse on the tab.</param>
+    /// <param name="displayName">The display name of the tab, which will show up when you hover your mouse on the tab. If null or empty, this will use the language line "{craftTreeName}_{tabName}" instead.</param>
     /// <param name="sprite">The sprite of the tab.</param>        
     public static void AddTabNode(CraftTree.Type craftTree, string name, string displayName, UnityEngine.Sprite sprite)
     {
@@ -165,7 +165,7 @@ public static class CraftTreeHandler
     /// </summary>
     /// <param name="craftTree">The target craft tree to edit.</param>
     /// <param name="name">The ID of the tab node. Must be unique!</param>
-    /// <param name="displayName">The display name of the tab, which will show up when you hover your mouse on the tab.</param>
+    /// <param name="displayName">The display name of the tab, which will show up when you hover your mouse on the tab. If null or empty, this will use the language line "{craftTreeName}_{tabName}" instead.</param>
     /// <param name="sprite">The sprite of the tab.</param>
     /// <param name="stepsToTab">
     /// <para>The steps to the target tab.</para>

--- a/Nautilus/Patchers/LanguagePatcher.cs
+++ b/Nautilus/Patchers/LanguagePatcher.cs
@@ -63,7 +63,10 @@ internal static class LanguagePatcher
         }
             
         if (_currentLanguage == FallbackLanguage)
+        {
+            __instance.ParseMetaData();
             return;
+        }
             
         var diffStrings = currentStrings.Except(fallbackStrings);
 		
@@ -72,6 +75,8 @@ internal static class LanguagePatcher
         {
             __instance.strings[currentOnlyString.Key] = currentOnlyString.Value;
         }
+        
+        __instance.ParseMetaData();
     }
         
     private static void LoadLanguageFilePrefix(string language)


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed a bug where localization wasn't affecting tab nodes, resulting in constant display names despite translation for other languages being registered
  - Fixed a bug where metadata wasn't getting generated unless the language was changed, resulting in bugs for subtitles.