### PR TITLE
Instantiate our prefab templates as deactivated

### DIFF
--- a/Nautilus/Assets/PrefabTemplates/AtmosphereVolumeTemplate.cs
+++ b/Nautilus/Assets/PrefabTemplates/AtmosphereVolumeTemplate.cs
@@ -66,6 +66,7 @@ public class AtmosphereVolumeTemplate : PrefabTemplate
     public override IEnumerator GetPrefabAsync(TaskResult<GameObject> gameObject)
     {
         var prefab = new GameObject(info.ClassID);
+        prefab.SetActive(false);
         prefab.layer = AtmosphereVolumesLayer;
         
         Collider collider = Shape switch

--- a/Nautilus/Assets/PrefabTemplates/CloneTemplate.cs
+++ b/Nautilus/Assets/PrefabTemplates/CloneTemplate.cs
@@ -79,6 +79,7 @@ public class CloneTemplate : PrefabTemplate
         GameObject obj = gameObject.Get();
         if (obj)
         {
+            obj.SetActive(false);
             ApplySkin(obj);
             ModifyPrefab?.Invoke(obj);
             if(ModifyPrefabAsync is { })
@@ -89,12 +90,13 @@ public class CloneTemplate : PrefabTemplate
 
         if (_spawnType == SpawnType.TechType)
         {
-            yield return CraftData.InstantiateFromPrefabAsync(_techTypeToClone, gameObject);
-            obj = gameObject.Get();
+            var task = CraftData.GetPrefabForTechTypeAsync(_techTypeToClone);
+            yield return task;
+            obj = Utils.InstantiateDeactivated(task.GetResult());
         }
         else if(_spawnType == SpawnType.Prefab)
         {
-            var task = _prefabToClone.InstantiateAsync();
+            var task = _prefabToClone.LoadAssetAsync();
             yield return task;
             
             if (task.Status != UnityEngine.ResourceManagement.AsyncOperations.AsyncOperationStatus.Succeeded)
@@ -103,7 +105,7 @@ public class CloneTemplate : PrefabTemplate
                 yield break;
             }
 
-            obj = task.Result;
+            obj = Utils.InstantiateDeactivated(task.Result);
         }
         else if(_spawnType == SpawnType.ClassId)
         {
@@ -116,7 +118,7 @@ public class CloneTemplate : PrefabTemplate
                 yield break;
             }
 
-            obj = Object.Instantiate(prefab);
+            obj = Utils.InstantiateDeactivated(prefab);
         }
 
         ApplySkin(obj);

--- a/Nautilus/Assets/PrefabTemplates/EggTemplate.cs
+++ b/Nautilus/Assets/PrefabTemplates/EggTemplate.cs
@@ -213,6 +213,7 @@ public class EggTemplate : PrefabTemplate
         var obj = gameObject.Get();
         if (obj)
         {
+            obj.SetActive(false);
             yield return ProcessEgg(obj);
             yield break;
         }
@@ -231,6 +232,7 @@ public class EggTemplate : PrefabTemplate
                                    """);
             yield break;
         }
+        obj.SetActive(false);
         yield return ProcessEgg(obj);
             
         gameObject.Set(obj);

--- a/Nautilus/Assets/PrefabTemplates/EnergySourceTemplate.cs
+++ b/Nautilus/Assets/PrefabTemplates/EnergySourceTemplate.cs
@@ -55,6 +55,7 @@ public class EnergySourceTemplate : PrefabTemplate
         var obj = gameObject.Get();
         if (obj)
         {
+            obj.SetActive(false);
             ApplyModifications(obj);
             yield break;
         }
@@ -68,7 +69,7 @@ public class EnergySourceTemplate : PrefabTemplate
         var task = CraftData.GetPrefabForTechTypeAsync(tt, false);
         yield return task;
 
-        var obj = GameObject.Instantiate(task.GetResult());
+        var obj = UWE.Utils.InstantiateDeactivated(task.GetResult());
 
         yield return ApplyModifications(obj);
         

--- a/Nautilus/Assets/PrefabTemplates/FabricatorTemplate.cs
+++ b/Nautilus/Assets/PrefabTemplates/FabricatorTemplate.cs
@@ -140,7 +140,7 @@ public class FabricatorTemplate : PrefabTemplate
             InternalLogger.Error($"Failed to get prefab for {FabricatorModel}!!!!!!!!   PLEASE REPORT THIS BUG TO THE NAUTILUS TEAM!");
         }
 
-        var obj = GameObject.Instantiate(prefab);
+        var obj = Utils.InstantiateDeactivated(prefab);
         yield return ApplyCrafterPrefab(obj);
         gameObject.Set(obj);
     }


### PR DESCRIPTION
### Changes made in this pull request

  - Changed all built-in Nautilus prefabs to instantiate prefabs deactivated whenever possible.

### Breaking changes

  - None, objects are automatically re-enabled when cached.