### PR TITLE
Prefab cache now resets

### DIFF
--- a/Nautilus/Assets/ModPrefabCache.cs
+++ b/Nautilus/Assets/ModPrefabCache.cs
@@ -38,6 +38,7 @@ public static class ModPrefabCache
     /// Any prefab with the matching <paramref name="classId"/> will be removed from the cache.
     /// </summary>
     /// <param name="classId">The class id of the prefab that will be removed.</param>
+    /// <remarks>This operation is extremely dangerous on custom prefabs that are directly registering an asset bundle prefab as it may make the prefab unusable in the current session.<br/>Avoid using this method unless you know what you're doing.</remarks>
     public static void RemovePrefabFromCache(string classId)
     {
         if(_cacheInstance == null)
@@ -85,7 +86,9 @@ internal class ModPrefabCacheInstance: MonoBehaviour
 
         gameObject.AddComponent<SceneCleanerPreserve>();
         DontDestroyOnLoad(gameObject);
+        
         SaveUtils.RegisterOnQuitEvent(ModPrefabCache.RunningPrefabs.Clear);
+        SaveUtils.RegisterOnQuitEvent(RemoveFakePrefabs);
     }
 
     public void EnterPrefabIntoCache(GameObject prefab)
@@ -122,12 +125,44 @@ internal class ModPrefabCacheInstance: MonoBehaviour
 
     public void RemoveCachedPrefab(string classId)
     {
-        if (Entries.TryGetValue(classId, out var prefab))
+        if (!Entries.TryGetValue(classId, out var prefab))
         {
-            if(!prefab.IsPrefab())
-                Destroy(prefab);
-            InternalLogger.Debug($"ModPrefabCache: removed prefab {classId}");
+            return;
+        }
+        
+        if (!prefab)
+        {
+            InternalLogger.Debug($"ModPrefabCache: Prefab for '{classId}' is null; removing entry.");
             Entries.Remove(classId);
+            return;
+        }
+            
+        if (!prefab.IsPrefab())
+        {
+            Destroy(prefab);
+        }
+            
+        InternalLogger.Debug($"ModPrefabCache: removing prefab '{classId}'");
+        Entries.Remove(classId);
+    }
+
+    private void RemoveFakePrefabs()
+    {
+        foreach (var prefab in new Dictionary<string, GameObject>(Entries))
+        {
+            if (prefab.Value is null)
+            {
+                Entries.Remove(prefab.Key);
+                continue;
+            }
+
+            if (prefab.Value.IsPrefab())
+            {
+                continue;
+            }
+            
+            Destroy(prefab.Value);
+            Entries.Remove(prefab.Key);
         }
     }
 

--- a/Nautilus/Assets/ModPrefabCache.cs
+++ b/Nautilus/Assets/ModPrefabCache.cs
@@ -150,7 +150,7 @@ internal class ModPrefabCacheInstance: MonoBehaviour
     {
         foreach (var prefab in new Dictionary<string, GameObject>(Entries))
         {
-            if (prefab.Value is null)
+            if (prefab.Value.Exists() is null)
             {
                 Entries.Remove(prefab.Key);
                 continue;

--- a/Nautilus/Extensions/GameObjectExtensions.cs
+++ b/Nautilus/Extensions/GameObjectExtensions.cs
@@ -5,6 +5,7 @@ using Nautilus.Patchers;
 using Nautilus.Utility;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
+using UnityEngine.SceneManagement;
 using Object = UnityEngine.Object;
 
 namespace Nautilus.Extensions;
@@ -136,9 +137,10 @@ public static class GameObjectExtensions
     /// </summary>
     /// <param name="gameObject">The game object to check.</param>
     /// <returns>True if this game object is a proper prefab, otherwise false.</returns>
+    /// <exception cref="System.NullReferenceException"><paramref name="gameObject"/> is null.</exception>
     public static bool IsPrefab(this GameObject gameObject)
     {
-        return gameObject.transform.parent == null && !gameObject.activeInHierarchy && gameObject.activeSelf;
+        return gameObject.scene.name is null && gameObject.scene.loadingState is Scene.LoadingState.NotLoaded;
     }
     
     /// <summary>


### PR DESCRIPTION
### Changes made in this pull request

  - Prefab cache now resets on world quit
  - Fixed `ModPrefabCache.RemovePrefabFromCache()` NRE
  - Fixed `GameObjectExtensions.IsPrefab` sometimes failing
  - Added more docs.

### Breaking changes

  - Custom prefabs that have user-defined improperly-written first time caches (static fields) may start failing from this change.

### Thorough testing is required
- SN1: [Nautilus_SN.STABLE_1.0.0.0.pre.30_ALPHA.zip](https://github.com/SubnauticaModding/Nautilus/files/14967404/Nautilus_SN.STABLE_1.0.0.0.pre.30_ALPHA.zip)
- BZ: [Nautilus_BZ.STABLE_1.0.0.0.pre.30_ALPHA.zip](https://github.com/SubnauticaModding/Nautilus/files/14967405/Nautilus_BZ.STABLE_1.0.0.0.pre.30_ALPHA.zip)
