### PR TITLE
Now you can stop custom prefabs from getting cached

### DIFF
--- a/Nautilus/Assets/CustomPrefabExtensions.cs
+++ b/Nautilus/Assets/CustomPrefabExtensions.cs
@@ -1,0 +1,32 @@
+﻿using Nautilus.Utility;
+
+namespace Nautilus.Assets;
+
+/// <summary>
+/// Represents extension methods for the <see cref="CustomPrefab"/> class.
+/// </summary>
+public static class CustomPrefabExtensions
+{
+    /// <summary>
+    /// Removes the current prefab from the prefab cache and doesn't allow it to get cached later.
+    /// </summary>
+    /// <param name="customPrefab">The custom prefab to remove from the prefab cache.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static ICustomPrefab RemoveFromCache(this CustomPrefab customPrefab)
+    {
+        if (customPrefab.Info == default)
+        {
+            return customPrefab;
+        }
+
+        if (string.IsNullOrWhiteSpace(customPrefab.Info.ClassID))
+        {
+            InternalLogger.Error($"Couldn't remove prefab '{customPrefab.Info}' from cache because the class ID is null.");
+            return customPrefab;
+        }
+        
+        ModPrefabCache.RemovePrefabFromCache(customPrefab.Info.ClassID);
+
+        return customPrefab;
+    }
+}

--- a/Nautilus/Assets/ModPrefabCache.cs
+++ b/Nautilus/Assets/ModPrefabCache.cs
@@ -1,6 +1,7 @@
 using Nautilus.Utility;
 using System.Collections.Generic;
 using Nautilus.Extensions;
+using Nautilus.Handlers;
 using UnityEngine;
 
 namespace Nautilus.Assets;
@@ -16,7 +17,7 @@ public static class ModPrefabCache
     private static ModPrefabCacheInstance _cacheInstance;
 
     /// <summary> Adds the given prefab to the cache. </summary>
-    /// <param name="prefab"> The prefab object that is disabled and cached. </param>
+    /// <param name="prefab"> The prefab object that is disabled and cached.</param>
     public static void AddPrefab(GameObject prefab)
     {
         EnsureCacheExists();
@@ -41,8 +42,11 @@ public static class ModPrefabCache
     /// <remarks>This operation is extremely dangerous on custom prefabs that are directly registering an asset bundle prefab as it may make the prefab unusable in the current session.<br/>Avoid using this method unless you know what you're doing.</remarks>
     public static void RemovePrefabFromCache(string classId)
     {
-        if(_cacheInstance == null)
+        if (_cacheInstance == null)
+        {
+            ModPrefabCacheInstance.BannedPrefabs.Add(classId);
             return;
+        }
 
         _cacheInstance.RemoveCachedPrefab(classId);
     }
@@ -74,7 +78,10 @@ public static class ModPrefabCache
 
 internal class ModPrefabCacheInstance: MonoBehaviour
 {
-    public Dictionary<string, GameObject> Entries { get; } = new Dictionary<string, GameObject>();
+    public Dictionary<string, GameObject> Entries { get; } = new();
+    
+    // Prefabs that are banned from getting cached
+    internal static readonly HashSet<string> BannedPrefabs = new();
 
     private Transform _prefabRoot;
 
@@ -98,6 +105,11 @@ internal class ModPrefabCacheInstance: MonoBehaviour
         if (prefabIdentifier == null)
         {
             InternalLogger.Warn($"ModPrefabCache: prefab {prefab.name} is missing a PrefabIdentifier component! Unable to add to cache.");
+            return;
+        }
+
+        if (BannedPrefabs.Contains(prefabIdentifier.classId))
+        {
             return;
         }
 
@@ -125,6 +137,8 @@ internal class ModPrefabCacheInstance: MonoBehaviour
 
     public void RemoveCachedPrefab(string classId)
     {
+        BannedPrefabs.Add(classId);
+
         if (!Entries.TryGetValue(classId, out var prefab))
         {
             return;
@@ -142,8 +156,8 @@ internal class ModPrefabCacheInstance: MonoBehaviour
             Destroy(prefab);
         }
             
-        InternalLogger.Debug($"ModPrefabCache: removing prefab '{classId}'");
         Entries.Remove(classId);
+        InternalLogger.Debug($"ModPrefabCache: removing prefab '{classId}'");
     }
 
     private void RemoveFakePrefabs()

--- a/Nautilus/Assets/ModPrefabCache.cs
+++ b/Nautilus/Assets/ModPrefabCache.cs
@@ -44,6 +44,7 @@ public static class ModPrefabCache
     {
         if (_cacheInstance == null)
         {
+            InternalLogger.Debug($"Removed '{classId}' from prefab cache.");
             ModPrefabCacheInstance.BannedPrefabs.Add(classId);
             return;
         }

--- a/Nautilus/Assets/ModPrefabRequest.cs
+++ b/Nautilus/Assets/ModPrefabRequest.cs
@@ -50,7 +50,7 @@ internal class ModPrefabRequest: IPrefabRequest
 
     public bool TryGetPrefab(out GameObject result)
     {
-        return ModPrefabCache.TryGetPrefabFromCache(prefabInfo.ClassID, out result) && result != null;
+        return result = taskResult.Get();
     }
 
     public bool MoveNext()
@@ -66,6 +66,7 @@ internal class ModPrefabRequest: IPrefabRequest
     public void Reset()
     {
         task.Reset();
+        taskResult.Set(null);
         Done = false;
     }
 


### PR DESCRIPTION
### Changes made in this pull request

  - Previously we had methods to remove a prefab from the cache, but users didn't have a place to call it, so it was useless. This PR allows users to remove prefabs at real-time (regardless of being in patch time, or in a world).
  - Added a new extension method for `CustomPrefab` to remove a custom prefab from the cache.
  - Fixed a bug where if a custom prefab's game object returns null, the game freezes
  
  ### ~~NOT TESTED~~