### PR TITLE
Fixed infinite loop from parse metadata call

### DIFF
--- a/Nautilus/Patchers/LanguagePatcher.cs
+++ b/Nautilus/Patchers/LanguagePatcher.cs
@@ -90,7 +90,7 @@ internal static class LanguagePatcher
         HarmonyMethod insertLinesMethod = new(AccessTools.Method(typeof(LanguagePatcher), nameof(InsertCustomLines)));
         HarmonyMethod loadLanguagesMethod = new(AccessTools.Method(typeof(LanguagePatcher), nameof(LoadLanguageFilePrefix)));
 
-        harmony.Patch(AccessTools.Method(typeof(Language), nameof(Language.ParseMetaData)), prefix: insertLinesMethod);
+        harmony.Patch(AccessTools.Method(typeof(Language), nameof(LanguageSDF.Initialize)), prefix: insertLinesMethod);
         harmony.Patch(AccessTools.Method(typeof(Language), nameof(Language.GetKeysFor)), prefix: insertLinesMethod);
         harmony.Patch(AccessTools.Method(typeof(Language), nameof(Language.TryGet)), prefix: repatchCheckMethod);
         harmony.Patch(AccessTools.Method(typeof(Language), nameof(Language.Contains)), prefix: repatchCheckMethod);


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed an infinite loop caused from #536 everytime a language line gets added.