### PR TITLE
Prefab roots should not be deactivated by Nautilus

### DIFF
--- a/Nautilus/Handlers/PrefabHandler.cs
+++ b/Nautilus/Handlers/PrefabHandler.cs
@@ -60,7 +60,6 @@ public static class PrefabHandler
             InternalLogger.Error($"PrefabHandler: PrefabFactory returned null for {info.ClassID}");
             yield break;
         }
-        obj.SetActive(false);
 
         var techType = info.TechType;
         var classId = info.ClassID;


### PR DESCRIPTION
### Changes made in this pull request

  - Removed an unnecessary `SetActive(false)` call that affected all prefabs during their construction.
    - This caused "real prefabs" to stay deactivated, which led to unintentional behavior (such as stopping buildables from working entirely).

### Breaking changes

  - Uncached prefabs that live in the scene ("fake prefabs") may now need to be manually disabled by modders. Otherwise, they will remain active within the world.
    - This change will likely not affect any existing mods. Uncached prefabs are meant for advanced use cases only.