### PR TITLE
Add OnSpawned callback to Coordinated Spawns SpawnInfos

### DIFF
--- a/Nautilus/Handlers/CoordinatedSpawnsHandler.cs
+++ b/Nautilus/Handlers/CoordinatedSpawnsHandler.cs
@@ -77,6 +77,7 @@ public struct SpawnInfo : IEquatable<SpawnInfo>
     internal Vector3 Scale { get; }
     // For the sake of backwards compatibility, a scale of 0x0x0 is automatically converted to 1x1x1. Sorry, no 0x scale entities allowed.
     internal Vector3 ActualScale => Scale == default ? Vector3.one : Scale;
+    internal Action<GameObject> OnSpawned { get; }
 
     /// <summary>
     /// Initializes a new <see cref="SpawnInfo"/>.
@@ -84,7 +85,7 @@ public struct SpawnInfo : IEquatable<SpawnInfo>
     /// <param name="techType">TechType to spawn.</param>
     /// <param name="spawnPosition">Position to spawn into.</param>
     public SpawnInfo(TechType techType, Vector3 spawnPosition)
-        : this(default, techType, spawnPosition, Quaternion.identity, Vector3.one) { }
+        : this(default, techType, spawnPosition, Quaternion.identity, Vector3.one, null) { }
 
     /// <summary>
     /// Initializes a new <see cref="SpawnInfo"/>.
@@ -92,7 +93,7 @@ public struct SpawnInfo : IEquatable<SpawnInfo>
     /// <param name="classId">ClassID to spawn.</param>
     /// <param name="spawnPosition">Position to spawn into.</param>
     public SpawnInfo(string classId, Vector3 spawnPosition)
-        : this(classId, default, spawnPosition, Quaternion.identity, Vector3.one) { }
+        : this(classId, default, spawnPosition, Quaternion.identity, Vector3.one, null) { }
 
     /// <summary>
     /// Initializes a new <see cref="SpawnInfo"/>.
@@ -101,7 +102,7 @@ public struct SpawnInfo : IEquatable<SpawnInfo>
     /// <param name="spawnPosition">Position to spawn into.</param>
     /// <param name="rotation">Rotation to spawn at.</param>
     public SpawnInfo(TechType techType, Vector3 spawnPosition, Quaternion rotation)
-        : this(default, techType, spawnPosition, rotation, Vector3.one) { }
+        : this(default, techType, spawnPosition, rotation, Vector3.one, null) { }
 
     /// <summary>
     /// Initializes a new <see cref="SpawnInfo"/>.
@@ -110,7 +111,7 @@ public struct SpawnInfo : IEquatable<SpawnInfo>
     /// <param name="spawnPosition">Position to spawn into.</param>
     /// <param name="rotation">Rotation to spawn at.</param>
     public SpawnInfo(string classId, Vector3 spawnPosition, Quaternion rotation)
-        : this(classId, default, spawnPosition, rotation, Vector3.one) { }
+        : this(classId, default, spawnPosition, rotation, Vector3.one, null) { }
     
     /// <summary>
     /// Initializes a new <see cref="SpawnInfo"/>.
@@ -120,7 +121,7 @@ public struct SpawnInfo : IEquatable<SpawnInfo>
     /// <param name="rotation">Rotation to spawn at.</param>
     /// <param name="scale">Scale to spawn with.</param>
     public SpawnInfo(TechType techType, Vector3 spawnPosition, Quaternion rotation, Vector3 scale)
-        : this(default, techType, spawnPosition, rotation, scale) { }
+        : this(default, techType, spawnPosition, rotation, scale, null) { }
 
     /// <summary>
     /// Initializes a new <see cref="SpawnInfo"/>.
@@ -130,7 +131,7 @@ public struct SpawnInfo : IEquatable<SpawnInfo>
     /// <param name="rotation">Rotation to spawn at.</param>
     /// <param name="scale">Scale to spawn with.</param>
     public SpawnInfo(string classId, Vector3 spawnPosition, Quaternion rotation, Vector3 scale)
-        : this(classId, default, spawnPosition, rotation, scale) { }
+        : this(classId, default, spawnPosition, rotation, scale, null) { }
 
     /// <summary>
     /// Initializes a new <see cref="SpawnInfo"/>.
@@ -139,7 +140,7 @@ public struct SpawnInfo : IEquatable<SpawnInfo>
     /// <param name="spawnPosition">Position to spawn into.</param>
     /// <param name="rotation">Rotation to spawn at.</param>
     public SpawnInfo(TechType techType, Vector3 spawnPosition, Vector3 rotation)
-        : this(default, techType, spawnPosition, Quaternion.Euler(rotation), Vector3.one) { }
+        : this(default, techType, spawnPosition, Quaternion.Euler(rotation), Vector3.one, null) { }
 
     /// <summary>
     /// Initializes a new <see cref="SpawnInfo"/>.
@@ -148,7 +149,7 @@ public struct SpawnInfo : IEquatable<SpawnInfo>
     /// <param name="spawnPosition">Position to spawn into.</param>
     /// <param name="rotation">Rotation to spawn at.</param>
     public SpawnInfo(string classId, Vector3 spawnPosition, Vector3 rotation)
-        : this(classId, default, spawnPosition, Quaternion.Euler(rotation), Vector3.one) { }
+        : this(classId, default, spawnPosition, Quaternion.Euler(rotation), Vector3.one, null) { }
     
     /// <summary>
     /// Initializes a new <see cref="SpawnInfo"/>.
@@ -158,7 +159,7 @@ public struct SpawnInfo : IEquatable<SpawnInfo>
     /// <param name="rotation">Rotation to spawn at.</param>
     /// <param name="scale">Scale to spawn with.</param>
     public SpawnInfo(TechType techType, Vector3 spawnPosition, Vector3 rotation, Vector3 scale)
-        : this(default, techType, spawnPosition, Quaternion.Euler(rotation), scale) { }
+        : this(default, techType, spawnPosition, Quaternion.Euler(rotation), scale, null) { }
 
     /// <summary>
     /// Initializes a new <see cref="SpawnInfo"/>.
@@ -168,10 +169,32 @@ public struct SpawnInfo : IEquatable<SpawnInfo>
     /// <param name="rotation">Rotation to spawn at.</param>
     /// <param name="scale">Scale to spawn with.</param>
     public SpawnInfo(string classId, Vector3 spawnPosition, Vector3 rotation, Vector3 scale)
-        : this(classId, default, spawnPosition, Quaternion.Euler(rotation), scale) { }
+        : this(classId, default, spawnPosition, Quaternion.Euler(rotation), scale, null) { }
+    
+    /// <summary>
+    /// Initializes a new <see cref="SpawnInfo"/>.
+    /// </summary>
+    /// <param name="techType">TechType to spawn.</param>
+    /// <param name="spawnPosition">Position to spawn into.</param>
+    /// <param name="rotation">Rotation to spawn at.</param>
+    /// <param name="scale">Scale to spawn with.</param>
+    /// <param name="onSpawned">Callback that is used when the object is successfully spawned.</param>
+    public SpawnInfo(TechType techType, Vector3 spawnPosition, Quaternion rotation, Vector3 scale, Action<GameObject> onSpawned)
+        : this(default, techType, spawnPosition, rotation, scale, onSpawned) { }
 
+    /// <summary>
+    /// Initializes a new <see cref="SpawnInfo"/>.
+    /// </summary>
+    /// <param name="classId">ClassID to spawn.</param>
+    /// <param name="spawnPosition">Position to spawn into.</param>
+    /// <param name="rotation">Rotation to spawn at.</param>
+    /// <param name="scale">Scale to spawn with.</param>
+    /// <param name="onSpawned">Callback that is used when the object is successfully spawned.</param>
+    public SpawnInfo(string classId, Vector3 spawnPosition, Quaternion rotation, Vector3 scale, Action<GameObject> onSpawned)
+        : this(classId, default, spawnPosition, rotation, scale, onSpawned) { }
+    
     [JsonConstructor]
-    internal SpawnInfo(string classId, TechType techType, Vector3 spawnPosition, Quaternion rotation, Vector3 scale)
+    internal SpawnInfo(string classId, TechType techType, Vector3 spawnPosition, Quaternion rotation, Vector3 scale, Action<GameObject> onSpawned)
     {
         ClassId = classId;
         TechType = techType;
@@ -183,6 +206,7 @@ public struct SpawnInfo : IEquatable<SpawnInfo>
             _ => SpawnType.TechType
         };
         Scale = scale;
+        OnSpawned = onSpawned;
     }
 
     /// <summary>

--- a/Nautilus/MonoBehaviours/EntitySpawner.cs
+++ b/Nautilus/MonoBehaviours/EntitySpawner.cs
@@ -68,6 +68,8 @@ internal class EntitySpawner : MonoBehaviour
 
             obj.SetActive(true);
 
+            spawnInfo.OnSpawned?.Invoke(obj);
+
             LargeWorldEntity.Register(obj);
 
             LargeWorldStreamerPatcher.SavedSpawnInfos.Add(spawnInfo);


### PR DESCRIPTION
### Changes made in this pull request

  - Added an OnSpawned callback to the SpawnInfo struct which allows modders to implement custom behavior immediately after an object is spawned.
  - Added two new constructors to SpawnInfo for this callback, both of which require EVERYTHING to be filled out. This is a better alternative than continuing the absurd exponential growth of overloads.

### Breaking changes

  - None