### PR TITLE
Specified game process

### DIFF
--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -15,8 +15,13 @@ namespace Nautilus;
 /// <summary>
 /// WARNING: This class is for use only by BepInEx.
 /// </summary>
-[BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
 [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+[BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
+#if BELOWZERO
+[BepInProcess("SubnauticaZero.exe")]
+#else
+[BepInProcess("Subnautica.exe")]
+#endif
 public class Initializer : BaseUnityPlugin
 {
     private static readonly Harmony _harmony = new(PluginInfo.PLUGIN_GUID);


### PR DESCRIPTION
### Changes made in this pull request

  - Added `BepInProcess` attribute to specify the game for SN and BZ builds. That way it's easier to tell if someone installed the wrong build for one of the games.