### PR TITLE
Custom FMOD support for PlayableDirector

### DIFF
--- a/Nautilus/Handlers/CustomSoundHandler.cs
+++ b/Nautilus/Handlers/CustomSoundHandler.cs
@@ -169,4 +169,41 @@ public static class CustomSoundHandler
     {
         return CustomSoundPatcher.EmitterPlayedChannels.TryGetValue(id, out channel);
     }
+
+    
+    /// <summary>
+    /// Attaches the specified channel to the given transform. This results in the sound position following the <paramref name="transform"/>.
+    /// </summary>
+    /// <param name="channel">The channel to attach.</param>
+    /// <param name="transform">The transform which the channel will follow.</param>
+    public static void AttachChannelToGameObject(Channel channel, Transform transform)
+    {
+        var index = CustomSoundPatcher.AttachedChannels.FindIndex(x => x.Channel.handle == channel.handle);
+        var attachedChannel = new CustomSoundPatcher.AttachedChannel(channel, transform);
+        if (index == -1)
+        {
+            CustomSoundPatcher.AttachedChannels.Add(attachedChannel);
+        }
+        else
+        {
+            CustomSoundPatcher.AttachedChannels[index] = attachedChannel;
+        }
+        
+        CustomSoundPatcher.SetChannel3DAttributes(channel, transform);
+    }
+    
+    /// <summary>
+    /// Detaches the specified channel from any game object.
+    /// </summary>
+    /// <param name="channel">The channel to detach.</param>
+    public static void DetachChannelFromGameObject(Channel channel)
+    {
+        var index = CustomSoundPatcher.AttachedChannels.FindIndex(x => x.Channel.handle == channel.handle);
+        if (index == -1)
+        {
+            InternalLogger.Warn($"{nameof(CustomSoundHandler)}: The specified channel is not attached to any game object.");
+        }
+        
+        CustomSoundPatcher.AttachedChannels.RemoveAt(index);
+    }
 }

--- a/Nautilus/Nautilus.csproj
+++ b/Nautilus/Nautilus.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="PolySharp" Version="1.13.1" PrivateAssets="all" />
 
     <Publicize Include="Newtonsoft.Json" />
+    <Publicize Include="FMODUnity" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Subnautica Below Zero extensively uses PlayableDirectors for cinematics, which play FMOD sounds in a very different way compared to what we got. This PR also works for SN1.


### Changes made in this pull request

  - Added a way to attach channels to game objects. This way the sound will follow the position of the game object it's attached to
  - Added custom FMOD support for playable behaviour.