### PR TITLE
Seatruck Fabricator & Fix tabs and crafting nodes on same level

### DIFF
--- a/Nautilus/Handlers/CraftTreeHandler.cs
+++ b/Nautilus/Handlers/CraftTreeHandler.cs
@@ -29,7 +29,6 @@ public static class CraftTreeHandler
 
         nodes.Add(new CraftingNode(stepsToTab, craftTree, craftingItem));
         CraftTreePatcher.CraftingNodes[craftTree] = nodes;
-        CraftTreePatcher.CachedTrees.Remove(craftTree);
     }
 
     /// <summary>
@@ -47,7 +46,6 @@ public static class CraftTreeHandler
 
         nodes.Add(new CraftingNode(new string[0], craftTree, craftingItem));
         CraftTreePatcher.CraftingNodes[craftTree] = nodes;
-        CraftTreePatcher.CachedTrees.Remove(craftTree);
     }
 
 #if SUBNAUTICA
@@ -67,7 +65,6 @@ public static class CraftTreeHandler
 
         craftTreeTabNodes.Add(new TabNode(new string[0], craftTree, sprite, name, displayName));
         CraftTreePatcher.TabNodes[craftTree] = craftTreeTabNodes;
-        CraftTreePatcher.CachedTrees.Remove(craftTree);
     }
 
     /// <summary>
@@ -87,7 +84,6 @@ public static class CraftTreeHandler
 
         craftTreeTabNodes.Add(new TabNode(new string[0], craftTree, new Atlas.Sprite(sprite), name, displayName));
         CraftTreePatcher.TabNodes[craftTree] = craftTreeTabNodes;
-        CraftTreePatcher.CachedTrees.Remove(craftTree);
     }
 
     /// <summary>
@@ -112,7 +108,6 @@ public static class CraftTreeHandler
 
         craftTreeTabNodes.Add(new TabNode(stepsToTab, craftTree, sprite, name, displayName));
         CraftTreePatcher.TabNodes[craftTree] = craftTreeTabNodes;
-        CraftTreePatcher.CachedTrees.Remove(craftTree);
     }
 
     /// <summary>
@@ -137,7 +132,6 @@ public static class CraftTreeHandler
 
         craftTreeTabNodes.Add(new TabNode(stepsToTab, craftTree, new Atlas.Sprite(sprite), name, displayName));
         CraftTreePatcher.TabNodes[craftTree] = craftTreeTabNodes;
-        CraftTreePatcher.CachedTrees.Remove(craftTree);
     }
 
 #elif BELOWZERO
@@ -157,7 +151,6 @@ public static class CraftTreeHandler
 
         craftTreeTabNodes.Add(new TabNode(new string[0], craftTree, sprite, name, displayName));
         CraftTreePatcher.TabNodes[craftTree] = craftTreeTabNodes;
-        CraftTreePatcher.CachedTrees.Remove(craftTree);
     }
 
     /// <summary>
@@ -182,7 +175,6 @@ public static class CraftTreeHandler
 
         craftTreeTabNodes.Add(new TabNode(stepsToTab, craftTree, sprite, name, displayName));
         CraftTreePatcher.TabNodes[craftTree] = craftTreeTabNodes;
-        CraftTreePatcher.CachedTrees.Remove(craftTree);
     }
 
 #endif
@@ -209,7 +201,6 @@ public static class CraftTreeHandler
 
         nodesToRemove.Add(new Node(stepsToNode, craftTree));
         CraftTreePatcher.NodesToRemove[craftTree] = nodesToRemove;
-        CraftTreePatcher.CachedTrees.Remove(craftTree);
     }
 
     /// <summary>

--- a/Nautilus/Patchers/CraftTreePatcher.cs
+++ b/Nautilus/Patchers/CraftTreePatcher.cs
@@ -205,13 +205,8 @@ internal class CraftTreePatcher
         {
             if (!TraverseTree(tree.nodes, customNode.Path, out var currentNode))
             {
-                InternalLogger.Warn($"Cannot add Crafting node: {customNode.TechType.AsString()} to {customNode.Scheme} at {string.Join("/", customNode.Path)} as the parent node could not be found.");
-
-                if (!TraverseTree(tree.nodes, new[] { FallbackTabNode + customNode.Scheme }, out currentNode))
-                {
-                    InternalLogger.Error($"Cannot add Crafting node: {customNode.TechType.AsString()} to {customNode.Scheme} at {string.Join("/", customNode.Path)} as the fallback node could not be found.");
-                    continue;
-                }
+                InternalLogger.Error($"Cannot add Crafting node: {customNode.TechType.AsString()} to {customNode.Scheme} at {string.Join("/", customNode.Path)} as the parent node could not be found.");
+                continue;
             }
 
             if (currentNode.nodes.Any(x => x is CraftNode craftNode && craftNode.action == TreeAction.Expand))

--- a/Nautilus/Patchers/CraftTreePatcher.cs
+++ b/Nautilus/Patchers/CraftTreePatcher.cs
@@ -82,12 +82,6 @@ internal class CraftTreePatcher
                 continue;
             }
 
-            /*if (currentNode.nodes.Any(node => node is CraftNode craftNode && craftNode.action == TreeAction.Craft))
-            {
-                InternalLogger.Error($"Cannot add tab: {customNode.Name} to {customNode.Scheme} at {string.Join("/", customNode.Path)} as it is being added to a parent node that contains crafting nodes. {string.Join(", ", currentNode.nodes.Where(node => node is CraftNode craftNode && craftNode.action == TreeAction.Craft).Select(x => x.id))} ");
-                continue;
-            }*/
-
             // Add the new tab node.
             currentNode.AddNode(new TreeNode[]
             {

--- a/Nautilus/Patchers/CraftTreePatcher.cs
+++ b/Nautilus/Patchers/CraftTreePatcher.cs
@@ -86,6 +86,45 @@ internal class CraftTreePatcher
         }
         InternalLogger.Info($"Reorganized {removedNodes.Count} {treeType} nodes into new {vanillaTab} tab.");
     }
+    
+    [HarmonyPatch(typeof(uGUI_CraftingMenu), nameof(uGUI_CraftingMenu.IsGrid))] 
+    [HarmonyPrefix]
+    private static bool ShouldGridPostfix(uGUI_CraftingMenu.Node node, ref bool __result)
+    { 
+        __result = ShouldGrid();
+        return false;
+        
+        bool ShouldGrid()
+        {
+            var craftings = 0;
+            var tabs = 0;
+
+            foreach (var child in node)
+            {
+                if (child.action == TreeAction.Expand)
+                {
+                    tabs++;
+                }
+                else if (child.action == TreeAction.Craft)
+                {
+                    craftings++;
+                }
+            }
+
+            return craftings > tabs;
+        }
+    }
+
+    [HarmonyPatch(typeof(uGUI_CraftingMenu), nameof(uGUI_CraftingMenu.Collapse))] 
+    [HarmonyPostfix]
+    private static void CollapsePostfix(uGUI_CraftingMenu.Node parent)
+    {
+        if (parent == null) return;
+
+        if (parent.action != TreeAction.Craft) return;
+
+        parent.icon.SetActive(false);
+    }
 
     [HarmonyPostfix]
     [HarmonyPatch(typeof(CraftTree), nameof(CraftTree.GetTree))]


### PR DESCRIPTION
Closes #330 

The vanilla and fallback tabs added in #486 were not only hated by the majority of the community, but also completely changed how craft trees work in general which is against what Nautilus is supposed to be (that it's a collection of modder convenience tools, not vanilla game changes).

This PR was originally meant to fix the seatruck fabricator only, but it's now turned to an opportunity to revert the Workbench organization PR as it was related to this problem.

### Changes made in this pull request

  - Added a patch to make crafting nodes and tabs work on the same level
  - Removed vanilla and fallback tabs
  - Fixed Seatruck fabricator not getting modded tree nodes.

### Breaking changes

  - Removes the vanilla and fallback tabs, but the mods that were adding crafting nodes on tab levels should still be fine.