### PR TITLE
Re-introduce gridding in mixed craft tree tabs

### DIFF
--- a/Nautilus/Patchers/CraftDataPatcher.cs
+++ b/Nautilus/Patchers/CraftDataPatcher.cs
@@ -78,6 +78,45 @@ internal partial class CraftDataPatcher
 
         InternalLogger.Log("CraftDataPatcher is done.", LogLevel.Debug);
     }
+    
+    [HarmonyPatch(typeof(uGUI_CraftingMenu), nameof(uGUI_CraftingMenu.IsGrid))] 
+    [HarmonyPrefix]
+    private static bool ShouldGridPostfix(uGUI_CraftingMenu.Node node, ref bool __result)
+    { 
+        __result = ShouldGrid();
+        return false;
+
+        bool ShouldGrid()
+        {
+            var craftings = 0;
+            var tabs = 0;
+
+            foreach (var child in node)
+            {
+                if (child.action == TreeAction.Expand)
+                {
+                    tabs++;
+                }
+                else if (child.action == TreeAction.Craft)
+                {
+                    craftings++;
+                }
+            }
+
+            return craftings > tabs;
+        }
+    }
+
+    [HarmonyPatch(typeof(uGUI_CraftingMenu), nameof(uGUI_CraftingMenu.Collapse))] 
+    [HarmonyPostfix]
+    private static void CollapsePostfix(uGUI_CraftingMenu.Node parent)
+    {
+        if (parent == null) return;
+
+        if (parent.action != TreeAction.Craft) return;
+
+        parent.icon.SetActive(false);
+    }
 
     [HarmonyPrefix]
     [HarmonyPatch(typeof(CraftData), nameof(CraftData.GetTechType), new Type[] { typeof(GameObject), typeof(GameObject) }, argumentVariations: new ArgumentType[] { ArgumentType.Normal, ArgumentType.Out })]


### PR DESCRIPTION
### Changes made in this pull request

  - Re-introduce Metious's fix to craft tree grids in tabs with both craft and tab nodes (from https://github.com/SubnauticaModding/Nautilus/pull/556/commits/bb95bed9467017521eb6997e661e8c4cc9fe078f).

### Breaking changes

  - Only improvements should be made in this PR, but keep in mind that the ModdedWorkbench tab was removed in a previous PR.