### PR TITLE
Fix: resolve overlapping tab nodes

### DIFF
--- a/Nautilus/Patchers/CraftDataPatcher.cs
+++ b/Nautilus/Patchers/CraftDataPatcher.cs
@@ -118,6 +118,34 @@ internal partial class CraftDataPatcher
         parent.icon.SetActive(false);
     }
 
+    [HarmonyPatch(typeof(uGUI_CraftingMenu), nameof(uGUI_CraftingMenu.Expand))]
+    [HarmonyPostfix]
+    private static void uGUI_CraftingMenuExpandPostfix(uGUI_CraftingMenu __instance, uGUI_CraftingMenu.Node node)
+    {
+        uGUI_CraftingMenu.Node parent = node.parent as uGUI_CraftingMenu.Node;
+        if (node.parent == null)
+        {
+            return;
+        }
+        if (__instance.IsGrid(node))
+        {
+            using (IEnumerator<uGUI_CraftingMenu.Node> childEnumerator = parent.GetEnumerator())
+            {
+                while (childEnumerator.MoveNext())
+                {
+                    uGUI_CraftingMenu.Node thisChild = childEnumerator.Current;
+                    if (thisChild == node)
+                    {
+                        continue;
+                    }
+                    if (thisChild.action == TreeAction.Expand)
+                    {
+                        thisChild.icon.SetActive(false);
+                    }
+                }
+            }
+        }
+    }
     [HarmonyPrefix]
     [HarmonyPatch(typeof(CraftData), nameof(CraftData.GetTechType), new Type[] { typeof(GameObject), typeof(GameObject) }, argumentVariations: new ArgumentType[] { ArgumentType.Normal, ArgumentType.Out })]
     private static void CraftDataGetTechTypePrefix(GameObject obj, out GameObject go, ref TechType __result)


### PR DESCRIPTION
### Changes made in this pull request

  - Fix an issue where crafting nodes sometimes overlap. If there are multiple tab nodes under the same node, and one of those tab nodes is expanded, the other tab nodes remain visible. This can cause nodes to be inaccessible. The resolution is a simple postfix patch over the uGUI_CraftingMenu.Expand method. See the images below for a before/after.

### Breaking changes

  - N/A


![20241125235929_1](https://github.com/user-attachments/assets/e61eaac4-33b9-4126-84e0-13923d135e8d)
![20241126000101_1](https://github.com/user-attachments/assets/938eeeb5-7850-43ca-9983-7b9c39f4826a)
![20241125235934_1](https://github.com/user-attachments/assets/e910c5bb-3c6a-4057-9e5b-951c4a97c148)
