### PR TITLE
Fix BZ process filter for macOS

### DIFF
--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -19,6 +19,7 @@ namespace Nautilus;
 [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
 #if BELOWZERO
 [BepInProcess("SubnauticaZero.exe")]
+[BepInProcess("Subnautica Below Zero")] // actual macOS executable file within SubnauticaZero.app
 #else
 [BepInProcess("Subnautica.exe")]
 #endif


### PR DESCRIPTION
### Changes made in this pull request

  - Added an additional process filter for the executable file used on macOS for BZ

### Rationale

On macOS, while the `.app` for the game is named `SubnauticaZero.app`, this is not an executable file and is not what is typically seen by BepInEx as the name of the process. A folder with an `.app` extension is a special folder structure used by Apple to denote an application package. Inside of it is a metadata file that tells macOS what to do when the .app is "executed," and in the case of BZ it points to the file `SubnauticaZero.app/Contents/MacOS/Subnautica Below Zero`. This file is the actual executable that runs the Unity app on macOS, and is what BepInEx sees as the name of the running process. Thus, the `SubnauticaZero.exe` process filter does not catch this (the `.exe` is inconsequential - BepInEx strips file extensions when comparing process names).

As some of you may be aware, I created [BZMacProcessFix ](https://github.com/toebeann/Tobey.BZMacProcessFix) to address this since not only SML/Nautilus have this issue (QMM does as well, and since it is no longer being maintained, will never work on macOS without this workaround). However it seems that in some cases this patcher is unable to fulfill its task, mainly reported by users of old macOS versions that I am unable to test on eg. 32bit Mojave. It is therefore recommended not to rely solely on this patcher, and to actually include the correct process filter for macOS in your BepInEx plugins wherever possible.

Note that no change is required for OG Subnautica as the executable on macOS is simply named `Subnautica`, which is covered by the `Subnautica.exe` process filter as file extensions are ignored when comparing.

### How can we verify the macOS executable name without having access to macOS?

If you head to the Depots tab of the steamdb.info page for the game, then click the ID next to the macOS config for the game, this will take you to a file listing for the depot (https://steamdb.info/depot/848453/ as of current writing). In this file listing you can see an entry for `SubnauticaZero.app/Contents/MacOS/Subnautica Below Zero`, which coincidentally is the only file listed within the `SubnauticaZero.app/Contents/MacOS` folder. macOS application packages rely on executable files which will be referenced by the application's metadata (eg. to determine what executable to run when the application is "executed") being placed in this folder, so you can largely rely on this.