### PR TITLE
Add a dependency warning popup and a user-friendly menu to view errors

### DIFF
--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -85,5 +85,6 @@ public class Initializer : BaseUnityPlugin
         WaterParkPatcher.Patch(_harmony);
         ModMessageSystem.Patch();
         BiomePatcher.Patch(_harmony);
+        DependencyWarningPatcher.Patch(_harmony);
     }
 }

--- a/Nautilus/MonoBehaviours/PluginLoadErrorMenu.cs
+++ b/Nautilus/MonoBehaviours/PluginLoadErrorMenu.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace Nautilus.MonoBehaviours;
+
+internal class PluginLoadErrorMenu : MonoBehaviour
+{
+    public void OnButtonOpen() => gameObject.SetActive(true);
+    public void OnButtonClose() => gameObject.SetActive(false);
+}

--- a/Nautilus/Patchers/DependencyWarningPatcher.cs
+++ b/Nautilus/Patchers/DependencyWarningPatcher.cs
@@ -93,7 +93,11 @@ internal static class DependencyWarningPatcher
         layoutGroup.padding = new RectOffset(15, 15, 40, 15);
 #endif
         // Create a list of all error messages that should be displayed
-        var errorsToDisplay = new List<string> { formattedMissingDependencies };
+        var errorsToDisplay = new List<string>
+        {
+            $"<color=#FF0000>{formattedMissingDependencies}</color>",
+            "<color=#FFFFFF>Mod load errors:</color>"
+        };
         errorsToDisplay.AddRange(dependencyErrors.Where(ShouldDisplayError));
         // Add error messages to menu
         foreach (var error in errorsToDisplay)
@@ -104,6 +108,7 @@ internal static class DependencyWarningPatcher
             errorEntryText.text = error;
             errorEntryText.enableWordWrapping = true;
             errorEntryText.fontSize = 25;
+            errorEntryText.richText = true;
             errorEntryTextObj.SetActive(true);
             errorEntryTextObj.transform.localScale = Vector3.one;
         }

--- a/Nautilus/Patchers/DependencyWarningPatcher.cs
+++ b/Nautilus/Patchers/DependencyWarningPatcher.cs
@@ -81,6 +81,10 @@ internal static class DependencyWarningPatcher
         Object.DestroyImmediate(errorsMenuHeader.GetComponent<TranslationLiveUpdate>());
         errorsMenuPanel.transform.Find("Middle/TabsHolder").gameObject.SetActive(false);
         var panesHolder = errorsMenuPanel.transform.Find("Middle/PanesHolder");
+        foreach (Transform child in panesHolder)
+        {
+            Object.Destroy(child.gameObject);
+        }
         var mainPaneTransform = Object.Instantiate(panePrefab, panesHolder).transform;
         var mainPaneContent = mainPaneTransform.Find("Viewport/Content");
 #if BELOWZERO

--- a/Nautilus/Patchers/DependencyWarningPatcher.cs
+++ b/Nautilus/Patchers/DependencyWarningPatcher.cs
@@ -1,0 +1,102 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using BepInEx.Bootstrap;
+using HarmonyLib;
+using Nautilus.Utility;
+using TMPro;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Nautilus.Patchers;
+
+internal static class DependencyWarningPatcher
+{
+    internal static void Patch(Harmony harmony)
+    {
+        harmony.PatchAll(typeof(DependencyWarningPatcher));
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(uGUI_MainMenu), nameof(uGUI_MainMenu.Start))]
+    private static void MainMenuStartPostfix(uGUI_MainMenu __instance)
+    {
+        try
+        {
+            CreateDependencyWarningUI(__instance);
+        }
+        catch (System.Exception e)
+        {
+            InternalLogger.Error("Failed to create main menu dependency warning UI! Exception thrown: " + e);
+        }
+    }
+
+    private static void CreateDependencyWarningUI(uGUI_MainMenu mainMenu)
+    {
+        var missingDependencies = GetMissingDependencies();
+        if (missingDependencies.Count == 0)
+            return;
+
+        var textReference = mainMenu.transform.Find("Panel/MainMenu/PlayerName");
+        var textObject = Object.Instantiate(textReference.gameObject, textReference.parent, true);
+        textObject.name = "NautilusDependencyWarningText";
+        Object.DestroyImmediate(textObject.GetComponent<MainMenuPlayerName>());
+        textObject.SetActive(true);
+        var transform = textObject.GetComponent<RectTransform>();
+        transform.anchorMin = new Vector2(0, 0);
+        transform.anchorMax = new Vector2(1, 0);
+        transform.pivot = new Vector2(0.5f, 0);
+        transform.anchoredPosition = new Vector2(0f, 25);
+        transform.sizeDelta = new Vector2(1, 40);
+        var text = textObject.GetComponentInChildren<TextMeshProUGUI>();
+        text.overflowMode = TextOverflowModes.Ellipsis;
+        text.alignment = TextAlignmentOptions.Center;
+        text.color = Color.red;
+        text.richText = true;
+        text.geometrySortingOrder = VertexSortingOrder.Reverse;
+        text.fontStyle = FontStyles.Bold;
+        text.text = FormatMissingDependencies(missingDependencies);
+    }
+
+    private static string FormatMissingDependencies(IList<string> missingDependencies)
+    {
+        var sb = new StringBuilder();
+        sb.Append("Missing ");
+        sb.Append(missingDependencies.Count);
+        sb.Append(" dependenc");
+        sb.Append(missingDependencies.Count == 1 ? "y" : "ies");
+        sb.Append(": ");
+        for (int i = 0; i < missingDependencies.Count; i++)
+        {
+            sb.Append(missingDependencies[i]);
+            if (i < missingDependencies.Count - 1)
+            {
+                sb.Append(", ");
+            }
+        }
+
+        return $"<mark=#000000CC>{sb}</mark>";
+    }
+
+    private static List<string> GetMissingDependencies()
+    {
+        var missingDependencies = new HashSet<string>();
+        // Get the list of dependency log warning messages
+        // The format is as follows: "Could not load [{0}] because it has missing dependencies: {1}"
+        var dependencyErrors = new List<string>(Chainloader.DependencyErrors);
+        foreach (var error in dependencyErrors)
+        {
+            // Plugin GUIDs CANNOT contain colons, so this will only search for the colon in the log warning format
+            var indexOfColon = error.LastIndexOf(':');
+            // If the message didn't have a colon, it was of the wrong format
+            if (indexOfColon <= 0) continue;
+            // Otherwise, get the remainder of the string, which should be the dependency's GUID
+            var dependencyGuid = error[(indexOfColon + 2)..];
+            missingDependencies.Add(dependencyGuid);
+        }
+
+        var list = missingDependencies.ToList();
+        list.Sort();
+        return list;
+    }
+}

--- a/Nautilus/Patchers/DependencyWarningPatcher.cs
+++ b/Nautilus/Patchers/DependencyWarningPatcher.cs
@@ -1,11 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using BepInEx.Bootstrap;
 using HarmonyLib;
+using Nautilus.MonoBehaviours;
 using Nautilus.Utility;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 using Object = UnityEngine.Object;
 
 namespace Nautilus.Patchers;
@@ -25,7 +28,7 @@ internal static class DependencyWarningPatcher
         {
             CreateDependencyWarningUI(__instance);
         }
-        catch (System.Exception e)
+        catch (Exception e)
         {
             InternalLogger.Error("Failed to create main menu dependency warning UI! Exception thrown: " + e);
         }
@@ -33,21 +36,26 @@ internal static class DependencyWarningPatcher
 
     private static void CreateDependencyWarningUI(uGUI_MainMenu mainMenu)
     {
-        var missingDependencies = GetMissingDependencies();
-        if (missingDependencies.Count == 0)
+        var dependencyErrors = Chainloader.DependencyErrors;
+        if (dependencyErrors.Count == 0)
             return;
 
-        var textReference = mainMenu.transform.Find("Panel/MainMenu/PlayerName");
-        var textObject = Object.Instantiate(textReference.gameObject, textReference.parent, true);
+        var missingDependencies = GetMissingDependencies();
+        var formattedMissingDependencies = FormatMissingDependencies(missingDependencies);
+
+        // -- Add warning text --
+        var textReference = mainMenu.transform.Find("Panel/MainMenu/PlayerName").gameObject;
+        var textObject = Object.Instantiate(textReference, textReference.transform.parent, true);
         textObject.name = "NautilusDependencyWarningText";
         Object.DestroyImmediate(textObject.GetComponent<MainMenuPlayerName>());
         textObject.SetActive(true);
         var transform = textObject.GetComponent<RectTransform>();
-        transform.anchorMin = new Vector2(0, 0);
-        transform.anchorMax = new Vector2(1, 0);
+        transform.anchorMin = new Vector2(0, 1);
+        transform.anchorMax = new Vector2(1, 1);
         transform.pivot = new Vector2(0.5f, 0);
-        transform.anchoredPosition = new Vector2(0f, 25);
         transform.sizeDelta = new Vector2(1, 40);
+        transform.offsetMin = new Vector2(-0.5f, 0);
+        transform.offsetMax = new Vector2(-0.5f, 570);
         var text = textObject.GetComponentInChildren<TextMeshProUGUI>();
         text.overflowMode = TextOverflowModes.Ellipsis;
         text.alignment = TextAlignmentOptions.Center;
@@ -55,7 +63,78 @@ internal static class DependencyWarningPatcher
         text.richText = true;
         text.geometrySortingOrder = VertexSortingOrder.Reverse;
         text.fontStyle = FontStyles.Bold;
-        text.text = FormatMissingDependencies(missingDependencies);
+        text.text = "<mark=#000000CC>Some mods failed to load! Please view the mod load errors for more details.\n" +
+                    formattedMissingDependencies + "</mark>";
+
+        // -- Add mod load errors window --
+        var optionsWindowReference = mainMenu.transform.Find("Panel/Options");
+        var errorsMenuPanel =
+            Object.Instantiate(optionsWindowReference.gameObject, optionsWindowReference.parent, true);
+        errorsMenuPanel.name = "NautilusModErrorsWindow";
+        var menuBehaviour = errorsMenuPanel.AddComponent<PluginLoadErrorMenu>();
+        errorsMenuPanel.SetActive(false);
+        var optionsPanel = errorsMenuPanel.GetComponentInChildren<uGUI_OptionsPanel>();
+        var panePrefab = optionsPanel.panePrefab;
+        Object.DestroyImmediate(optionsPanel);
+        var errorsMenuHeader = errorsMenuPanel.transform.Find("Header");
+        errorsMenuHeader.gameObject.GetComponent<TextMeshProUGUI>().text = "BepInEx plugin load errors";
+        Object.DestroyImmediate(errorsMenuHeader.GetComponent<TranslationLiveUpdate>());
+        errorsMenuPanel.transform.Find("Middle/TabsHolder").gameObject.SetActive(false);
+        var panesHolder = errorsMenuPanel.transform.Find("Middle/PanesHolder");
+        var mainPaneTransform = Object.Instantiate(panePrefab, panesHolder).transform;
+        var mainPaneContent = mainPaneTransform.Find("Viewport/Content");
+        // Create a list of all error messages that should be displayed
+        var errorsToDisplay = new List<string> { formattedMissingDependencies };
+        errorsToDisplay.AddRange(dependencyErrors.Where(ShouldDisplayError));
+        // Add error messages to menu
+        foreach (var error in errorsToDisplay)
+        {
+            var errorEntryTextObj = Object.Instantiate(textReference, mainPaneContent, true);
+            Object.DestroyImmediate(errorEntryTextObj.GetComponent<MainMenuPlayerName>());
+            var errorEntryText = errorEntryTextObj.GetComponent<TextMeshProUGUI>();
+            errorEntryText.text = error;
+            errorEntryText.enableWordWrapping = true;
+            errorEntryText.fontSize = 25;
+            errorEntryTextObj.SetActive(true);
+            errorEntryTextObj.transform.localScale = Vector3.one;
+        }
+
+        // Fix up buttons and add close window button
+        var closeWindowButton = errorsMenuPanel.transform.Find("Bottom/ButtonBack").gameObject;
+        Object.DestroyImmediate(closeWindowButton.GetComponentInChildren<TranslationLiveUpdate>());
+        closeWindowButton.GetComponentInChildren<TextMeshProUGUI>().text = "Close";
+        var closeWindowButtonComponent = closeWindowButton.GetComponent<Button>();
+        closeWindowButtonComponent.onClick.RemoveAllListeners();
+        closeWindowButtonComponent.onClick.AddListener(menuBehaviour.OnButtonClose);
+        errorsMenuPanel.transform.Find("Bottom/ButtonApply").gameObject.SetActive(false);
+
+        // -- Add open button --
+        var openButtonParent = mainMenu.transform.Find("Panel/MainMenu");
+        var openButtonReference = mainMenu.transform.Find("Panel/Options/Bottom/ButtonBack");
+        var openButton = Object.Instantiate(openButtonReference.gameObject, openButtonParent, true);
+        openButton.name = "NautilusViewModLoadErrorsButton";
+        var buttonTransform = openButton.GetComponent<RectTransform>();
+        buttonTransform.SetSiblingIndex(0);
+        buttonTransform.anchorMin = new Vector2(0.65f, 0.77f);
+        buttonTransform.anchorMax = new Vector2(0.99f, 0.88f);
+        buttonTransform.offsetMin = new Vector2(-0.5f, -0.5f);
+        buttonTransform.offsetMax = new Vector2(0.5f, 0.5f);
+        buttonTransform.sizeDelta = Vector2.one;
+        Object.DestroyImmediate(openButton.GetComponentInChildren<TranslationLiveUpdate>());
+        buttonTransform.GetComponentInChildren<TextMeshProUGUI>().text =
+            $"View mod load errors ({dependencyErrors.Count})";
+        var openWindowButtonComponent = openButton.GetComponent<Button>();
+        openWindowButtonComponent.onClick.RemoveAllListeners();
+        openWindowButtonComponent.onClick.AddListener(menuBehaviour.OnButtonOpen);
+        openButton.SetActive(true);
+    }
+
+    private static bool ShouldDisplayError(string errorMessage)
+    {
+        // These errors occur for perfectly working mods, don't do any good for people, and will confuse users
+        if (errorMessage.Contains("targets a wrong version of BepInEx"))
+            return false;
+        return true;
     }
 
     private static string FormatMissingDependencies(IList<string> missingDependencies)
@@ -75,7 +154,7 @@ internal static class DependencyWarningPatcher
             }
         }
 
-        return $"<mark=#000000CC>{sb}</mark>";
+        return sb.ToString();
     }
 
     private static List<string> GetMissingDependencies()
@@ -90,9 +169,16 @@ internal static class DependencyWarningPatcher
             var indexOfColon = error.LastIndexOf(':');
             // If the message didn't have a colon, it was of the wrong format
             if (indexOfColon <= 0) continue;
+            // If the message contained the word "incompatible," it was an incompatibility error and should be ignored
+            var indexOfIncompatible = error.IndexOf("incompatible", StringComparison.Ordinal);
+            if (indexOfIncompatible >= 0 && indexOfIncompatible < indexOfColon) continue;
             // Otherwise, get the remainder of the string, which should be the dependency's GUID
-            var dependencyGuid = error[(indexOfColon + 2)..];
-            missingDependencies.Add(dependencyGuid);
+            var dependencyGuidText = error[(indexOfColon + 2)..];
+            var dependencyGuids = dependencyGuidText.Split(new[] {", "}, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var guid in dependencyGuids)
+            {
+                missingDependencies.Add(guid);
+            }
         }
 
         var list = missingDependencies.ToList();

--- a/Nautilus/Patchers/DependencyWarningPatcher.cs
+++ b/Nautilus/Patchers/DependencyWarningPatcher.cs
@@ -83,6 +83,11 @@ internal static class DependencyWarningPatcher
         var panesHolder = errorsMenuPanel.transform.Find("Middle/PanesHolder");
         var mainPaneTransform = Object.Instantiate(panePrefab, panesHolder).transform;
         var mainPaneContent = mainPaneTransform.Find("Viewport/Content");
+#if BELOWZERO
+        var layoutGroup = mainPaneContent.gameObject.GetComponent<VerticalLayoutGroup>();
+        layoutGroup.spacing = 65;
+        layoutGroup.padding = new RectOffset(15, 15, 40, 15);
+#endif
         // Create a list of all error messages that should be displayed
         var errorsToDisplay = new List<string> { formattedMissingDependencies };
         errorsToDisplay.AddRange(dependencyErrors.Where(ShouldDisplayError));

--- a/Nautilus/Patchers/DependencyWarningPatcher.cs
+++ b/Nautilus/Patchers/DependencyWarningPatcher.cs
@@ -115,8 +115,8 @@ internal static class DependencyWarningPatcher
         openButton.name = "NautilusViewModLoadErrorsButton";
         var buttonTransform = openButton.GetComponent<RectTransform>();
         buttonTransform.SetSiblingIndex(0);
-        buttonTransform.anchorMin = new Vector2(0.65f, 0.77f);
-        buttonTransform.anchorMax = new Vector2(0.99f, 0.88f);
+        buttonTransform.anchorMin = new Vector2(0.65f, 0.01f);
+        buttonTransform.anchorMax = new Vector2(0.99f, 0.12f);
         buttonTransform.offsetMin = new Vector2(-0.5f, -0.5f);
         buttonTransform.offsetMax = new Vector2(0.5f, 0.5f);
         buttonTransform.sizeDelta = Vector2.one;


### PR DESCRIPTION
### Changes made in this pull request

  - Added dependency warning text to the top of the screen
  - Added a button to view a window that displays all mod load errors

![NEWDependencyWarnings-SN1-1](https://github.com/user-attachments/assets/c22ee7f2-25e8-4668-8071-fa111565704d)
![NEWDependencyWarnings-SN1-2](https://github.com/user-attachments/assets/d3531296-a448-4366-b472-3f06beef2caa)
![NEWDependencyWarning-BZ-1](https://github.com/user-attachments/assets/2e9dfaa3-ef9f-4f94-b358-dfd4594f3cd9)
![NEWDependencyWarning-BZ-2](https://github.com/user-attachments/assets/abf4ac7c-8b20-45a3-a4cf-f1a3a198d20f)


### Breaking changes

  - None