### PR TITLE
Increase publish docs dotnet version from 7.x to 8.x

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Dotnet Setup
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.x
+        dotnet-version: 8.x
       
     - name: Build Project
       run: dotnet build Nautilus.sln -c SN.STABLE


### PR DESCRIPTION
### Changes made in this pull request

  - Increased dotnet version of publish docs GitHub action from 7 to 8.

### Breaking changes

  - Hopefully none