### PR TITLE
Fix improper check for renderers for Sky Applier

### DIFF
--- a/Nautilus/Utility/PrefabUtils.cs
+++ b/Nautilus/Utility/PrefabUtils.cs
@@ -94,7 +94,7 @@ public static class PrefabUtils
         prefab.EnsureComponent<LargeWorldEntity>().cellLevel = cellLevel;
             
         var renderers = prefab.GetComponentsInChildren<Renderer>(true);
-        if (renderers != null)
+        if (renderers != null && renderers.Length > 0)
         {
             prefab.EnsureComponent<SkyApplier>().renderers = renderers;
         }


### PR DESCRIPTION
### Changes made in this pull request

  - Check if array length is greater than zero instead of checking if the array is not null when adding SkyAppliers through `PrefabUtils.AddBasicComponents`.

### Breaking changes

  - None unless someone relied on a sky applier on a rendererless prefab