### PR TITLE
SaveDataCache no longer carry values across saves

### DIFF
--- a/Nautilus/Utility/JsonUtils.cs
+++ b/Nautilus/Utility/JsonUtils.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using BepInEx.Logging;
+using Nautilus.Json;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -64,7 +65,7 @@ public static class JsonUtils
         
         foreach (var property in contract.Properties)
         {
-            if (property.Writable && property.ValueProvider != null)
+            if (property.Writable && property.ValueProvider != null && !property.Ignored)
             {
                 property.ValueProvider.SetValue(target, property.ValueProvider.GetValue(@default));
             }


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed a bug where if you get into a save that has a save data cache, then you quit to main menu, then create a new world, the cache from the previous save would get carried to the new one.
  
Fixes #598 

### Breaking changes

  - While this is a bug, mods that used this bug as a feature and fellback to the previous save's cache will find this PR a breaking change.
  
### Builds (up-to-date with 3e7e363)
SN1: [Nautilus_SN.STABLE_1.0.0.37.zip](https://github.com/user-attachments/files/19629207/Nautilus_SN.STABLE_1.0.0.37.zip)
BZ: [Nautilus_BZ.STABLE_1.0.0.37.zip](https://github.com/user-attachments/files/19629229/Nautilus_BZ.STABLE_1.0.0.37.zip)
