### PR TITLE
fix: Prevent ArgumentException on KnownTech reinit in running game.

### DIFF
--- a/Nautilus/Patchers/KnownTechPatcher.cs
+++ b/Nautilus/Patchers/KnownTechPatcher.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using HarmonyLib;
 using Handlers;
 using Utility;
@@ -44,7 +45,9 @@ internal class KnownTechPatcher
         KnownTech.compoundTech = KnownTech.ValidateCompoundTech(pdaData.compoundTech);
         KnownTech.analysisTech = KnownTech.ValidateAnalysisTech(pdaData.analysisTech);
         KnownTech.knownTech.AddRange(knownTech);
-        knownCompound.ForEach(x => KnownTech.knownCompoundTech.Add(x.Key, x.Value));
+        knownCompound
+            .Where(tech => !KnownTech.knownCompoundTech.ContainsKey(tech.Key))
+            .ForEach(tech => KnownTech.knownCompoundTech.Add(tech.Key, tech.Value));
         KnownTech.AddRange(pdaData.defaultTech, false);
     }
 


### PR DESCRIPTION
`KnownTechPatcher` uses a naked dictionary Add() for known compound tech based on data that is already in that same dictionary. This leads to an ArgumentException if a mod attempts to change KnownTech in any way late into a running game, particularly if the cyclops has already been unlocked.

### Changes made in this pull request

- Check whether known compound tech is already in the dictionary before adding to it.

### Breaking changes

- None, this is a small fix.