### PR TITLE
Title Screen Additions

### DIFF
--- a/Nautilus/Handlers/LoadingScreen/LoadingScreenHandler.cs
+++ b/Nautilus/Handlers/LoadingScreen/LoadingScreenHandler.cs
@@ -1,4 +1,5 @@
-﻿using BepInEx;
+﻿using System;
+using BepInEx;
 using UnityEngine;
 
 namespace Nautilus.Handlers.LoadingScreen;
@@ -13,14 +14,18 @@ public static class LoadingScreenHandler
     public class LoadingScreenData
     {
         public Sprite loadingScreenImage;
-        public float minTimeToNextScreen;
+        public int priority;
+        public float timeToNextScreen;
         public string storyGoalRequirement;
+        public Func<bool> customRequirement;
         
-        public LoadingScreenData(Sprite loadingScreenImage, float minTimeToNextScreen = 7f, string storyGoalRequirement = null)
+        public LoadingScreenData(Sprite loadingScreenImage, int priority = 1, float timeToNextScreen = 7f, string storyGoalRequirement = null, Func<bool> customRequirement = null)
         {
             this.loadingScreenImage = loadingScreenImage;
-            this.minTimeToNextScreen = minTimeToNextScreen;
+            this.priority = priority;
+            this.timeToNextScreen = timeToNextScreen;
             this.storyGoalRequirement = storyGoalRequirement;
+            this.customRequirement = customRequirement;
         }
     }
 }

--- a/Nautilus/Handlers/LoadingScreen/LoadingScreenHandler.cs
+++ b/Nautilus/Handlers/LoadingScreen/LoadingScreenHandler.cs
@@ -4,21 +4,59 @@ using UnityEngine;
 
 namespace Nautilus.Handlers.LoadingScreen;
 
+/// <summary>
+/// Handles custom loading screens
+/// </summary>
 public static class LoadingScreenHandler
 {
+    /// <summary>
+    /// Register loading screens with Nautilus. Note that custom loading screens will only appear when your mod is selected as the current theme
+    /// </summary>
+    /// <param name="plugin">The plugin registering the loading screens</param>
+    /// <param name="loadingScreenDatas">The loading screens to register</param>
     public static void RegisterLoadingScreen(BaseUnityPlugin plugin, LoadingScreenData[] loadingScreenDatas)
     {
         LoadingScreenSetter.LoadingScreenDatas.Add(plugin.Info.Metadata.GUID, loadingScreenDatas);
     }
 
+    /// <summary>
+    /// A data class containing info for Nautilus to register a custom loading screen
+    /// </summary>
     public class LoadingScreenData
     {
-        public Sprite loadingScreenImage;
-        public int priority;
-        public float timeToNextScreen;
-        public string storyGoalRequirement;
-        public Func<bool> customRequirement;
+        /// <summary>
+        /// The image shown while loading
+        /// </summary>
+        public readonly Sprite loadingScreenImage;
         
+        /// <summary>
+        /// The priority over other loading screens registered
+        /// </summary>
+        public readonly int priority;
+        
+        /// <summary>
+        /// The time between loading screen transitions
+        /// </summary>
+        public readonly float timeToNextScreen;
+        
+        /// <summary>
+        /// The story goal required for the loading screen to show
+        /// </summary>
+        public readonly string storyGoalRequirement;
+        
+        /// <summary>
+        /// A custom requirement for the loading screen to show
+        /// </summary>
+        public readonly Func<bool> customRequirement;
+        
+        /// <summary>
+        /// Creates a new instance of <see cref="LoadingScreenData"/>
+        /// </summary>
+        /// <param name="loadingScreenImage">The image shown while loading</param>
+        /// <param name="priority">The priority over other loading screens registered</param>
+        /// <param name="timeToNextScreen">The time between loading screen transitions</param>
+        /// <param name="storyGoalRequirement">The story goal required for the loading screen to show</param>
+        /// <param name="customRequirement">A custom requirement for the loading screen to show</param>
         public LoadingScreenData(Sprite loadingScreenImage, int priority = 1, float timeToNextScreen = 7f, string storyGoalRequirement = null, Func<bool> customRequirement = null)
         {
             this.loadingScreenImage = loadingScreenImage;

--- a/Nautilus/Handlers/LoadingScreen/LoadingScreenHandler.cs
+++ b/Nautilus/Handlers/LoadingScreen/LoadingScreenHandler.cs
@@ -1,0 +1,26 @@
+﻿using BepInEx;
+using UnityEngine;
+
+namespace Nautilus.Handlers.LoadingScreen;
+
+public static class LoadingScreenHandler
+{
+    public static void RegisterLoadingScreen(BaseUnityPlugin plugin, LoadingScreenData[] loadingScreenDatas)
+    {
+        LoadingScreenSetter.LoadingScreenDatas.Add(plugin.Info.Metadata.GUID, loadingScreenDatas);
+    }
+
+    public class LoadingScreenData
+    {
+        public Sprite loadingScreenImage;
+        public float minTimeToNextScreen;
+        public string storyGoalRequirement;
+        
+        public LoadingScreenData(Sprite loadingScreenImage, float minTimeToNextScreen = 7f, string storyGoalRequirement = null)
+        {
+            this.loadingScreenImage = loadingScreenImage;
+            this.minTimeToNextScreen = minTimeToNextScreen;
+            this.storyGoalRequirement = storyGoalRequirement;
+        }
+    }
+}

--- a/Nautilus/Handlers/LoadingScreen/LoadingScreenSetter.cs
+++ b/Nautilus/Handlers/LoadingScreen/LoadingScreenSetter.cs
@@ -130,7 +130,6 @@ internal class LoadingScreenSetter : MonoBehaviour
 
         if (!StoryGoalManager.main) return false;
         
-        InternalLogger.Log($"Story goal manager = {StoryGoalManager.main}");
         if (StoryGoalManager.main.IsGoalComplete(screen.storyGoalRequirement)) return true;
 
         return false;

--- a/Nautilus/Handlers/LoadingScreen/LoadingScreenSetter.cs
+++ b/Nautilus/Handlers/LoadingScreen/LoadingScreenSetter.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using Nautilus.Patchers;
+using Nautilus.Utility;
+using Story;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Nautilus.Handlers.LoadingScreen;
+
+internal class LoadingScreenSetter : MonoBehaviour
+{
+    internal static readonly Dictionary<string, LoadingScreenHandler.LoadingScreenData[]> LoadingScreenDatas = new();
+
+    private uGUI_SceneLoading _sceneLoading;
+    private Sprite _defaultLoadingSprite;
+    private Image _loadingScreenImage;
+    private Image _loadingScreenImage2;
+    
+    private Image _targetFadeImage;
+    private Image BufferImage => _targetFadeImage == _loadingScreenImage ? _loadingScreenImage2 : _loadingScreenImage;
+
+    private bool _wasLoading;
+    private bool _isFading;
+    private int _currentScreenIndex;
+    private float _timeNextScreen;
+    private float _fadeProgress;
+
+    private LoadingScreenHandler.LoadingScreenData[] _possibleLoadingScreens;
+    
+    private void Start()
+    {
+        _sceneLoading = GetComponent<uGUI_SceneLoading>();
+        _loadingScreenImage = transform.Find("LoadingScreen/LoadingArtwork").GetComponent<Image>();
+        _loadingScreenImage2 = Instantiate(_loadingScreenImage.gameObject, _loadingScreenImage.transform.parent)
+            .GetComponent<Image>();
+        _loadingScreenImage2.transform.SetSiblingIndex(_loadingScreenImage.transform.GetSiblingIndex() + 1);
+
+        _defaultLoadingSprite = _loadingScreenImage.sprite;
+        _targetFadeImage = _loadingScreenImage;
+
+        MainMenuPatcher.onActiveModChanged += UpdatePotentialBackgrounds;
+        SetCurrentImage(null, true);
+    }
+
+    private void Update()
+    {
+        if (_sceneLoading.isLoading && !_wasLoading)
+        {
+            _currentScreenIndex = 0;
+            IncrementTimer();
+            SetCurrentImage(GetNextImage(), true);
+        }
+        
+        _wasLoading = _sceneLoading.isLoading;
+        
+        if (!_sceneLoading.isLoading) return;
+
+        if (!StoryGoalManager.main) return;
+
+        if (_possibleLoadingScreens == null) return;
+
+        if (Time.realtimeSinceStartup > _timeNextScreen)
+        {
+            SetCurrentImage(GetNextImage());
+            IncrementTimer();
+        }
+
+        HandleTransition();
+    }
+
+    private void SetCurrentImage(Sprite sprite, bool instant = false)
+    {
+        if (_targetFadeImage && sprite == BufferImage.sprite) return;
+        
+        sprite ??= _defaultLoadingSprite;
+        _targetFadeImage = BufferImage;
+        _targetFadeImage.sprite = sprite;
+
+        if (instant)
+        {
+            _targetFadeImage.color = Color.white;
+            BufferImage.color = Color.clear;
+            return;
+        }
+
+        _isFading = true;
+        _fadeProgress = 0;
+    }
+
+    private Sprite GetNextImage()
+    {
+        if (_possibleLoadingScreens == null) return null;
+
+        if (_possibleLoadingScreens.Length == 0) return null;
+
+        if (_possibleLoadingScreens.Length == 1 && ScreenIsValid(_possibleLoadingScreens[0]))
+            return _possibleLoadingScreens[0].loadingScreenImage;
+        
+        _currentScreenIndex++;
+        _currentScreenIndex %= _possibleLoadingScreens.Length;
+        
+        Sprite nextImage = null;
+        for (int i = _currentScreenIndex; i < _possibleLoadingScreens.Length; i++)
+        {
+            var screen = _possibleLoadingScreens[i];
+
+            if (ScreenIsValid(screen))
+            {
+                nextImage = screen.loadingScreenImage;
+                break;
+            }
+        }
+        
+        return nextImage;
+    }
+
+    private bool ScreenIsValid(LoadingScreenHandler.LoadingScreenData screen)
+    {
+        if (screen.storyGoalRequirement == null) return true;
+
+        if (StoryGoalManager.main.IsGoalComplete(screen.storyGoalRequirement)) return true;
+
+        return false;
+    }
+
+    private void HandleTransition()
+    {
+        if (!_isFading) return;
+        
+        _fadeProgress = Mathf.Clamp01(_fadeProgress + Time.unscaledDeltaTime * 0.5f);
+        _targetFadeImage.color = new Color(1, 1, 1, _fadeProgress);
+        BufferImage.color = new Color(1, 1, 1, 1 - _fadeProgress);
+        if (_fadeProgress >= 1)
+        {
+            _isFading = false;
+        }
+    }
+
+    private void IncrementTimer()
+    {
+        float timeIncrement = _possibleLoadingScreens == null
+            ? 2
+            : _possibleLoadingScreens[_currentScreenIndex].minTimeToNextScreen;
+        _timeNextScreen = Time.realtimeSinceStartup + timeIncrement;
+        
+        InternalLogger.Log($"Incrementing timer. Index = {_currentScreenIndex} | Time next screen = {_timeNextScreen} | Time = {Time.realtimeSinceStartup}");
+    }
+
+    private void UpdatePotentialBackgrounds()
+    {
+        var currentModGUID = MainMenuPatcher.GetActiveModGUID();
+        if (currentModGUID == "Subnautica")
+        {
+            _possibleLoadingScreens = null;
+            return;
+        }
+
+        LoadingScreenDatas.TryGetValue(currentModGUID, out _possibleLoadingScreens);
+    }
+}

--- a/Nautilus/Handlers/LoadingScreen/LoadingScreenSetter.cs
+++ b/Nautilus/Handlers/LoadingScreen/LoadingScreenSetter.cs
@@ -158,7 +158,7 @@ internal class LoadingScreenSetter : MonoBehaviour
 
     private void UpdatePotentialBackgrounds()
     {
-        var currentModGUID = MainMenuPatcher.GetActiveModGUID();
+        var currentModGUID = MainMenuPatcher.GetActiveModGuid();
         if (currentModGUID == "Subnautica")
         {
             _possibleLoadingScreens = null;

--- a/Nautilus/Handlers/TitleScreen/ApproveAllAddons.cs
+++ b/Nautilus/Handlers/TitleScreen/ApproveAllAddons.cs
@@ -1,0 +1,6 @@
+﻿namespace Nautilus.Handlers.TitleScreen;
+
+internal class ApproveAllAddons
+{
+    
+}

--- a/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
@@ -1,34 +1,34 @@
 ﻿namespace Nautilus.Handlers.TitleScreen;
 
 /// <summary>
-/// Enables and disables custom music depending on what mod theme is selected
+/// Enables and disables custom music depending on what mod theme is selected.
 /// </summary>
 public class MusicTitleAddon : TitleAddon
 {
     /// <summary>
-    /// The FMOD asset passed into the instance when created 
+    /// The FMOD asset passed into the instance when created.
     /// </summary>
     protected readonly FMODAsset _asset;
     
     /// <summary>
-    /// The custom emitter created in <see cref="MusicTitleAddon.Initialize"/>
+    /// The custom emitter created in <see cref="MusicTitleAddon.Initialize"/>.
     /// </summary>
     protected FMOD_CustomEmitter _customEmitter;
     
     /// <summary>
     /// Creates a new <see cref="MusicTitleAddon"/>. The music will be enabled when your mod is selected and disabled when the game starts or
-    /// if your theme is unselected
+    /// if your theme is unselected.
     /// </summary>
-    /// <param name="asset">The FMOD asset for the music you want to play. A fade out time is HIGHLY recommended</param>
+    /// <param name="asset">The FMOD asset for the music you want to play. A fade out time is HIGHLY recommended.</param>
     /// <param name="requiredGUIDs">The required mod GUIDs for this addon to enable. Each required mod must approve
-    /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/></param>
+    /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/>.</param>
     public MusicTitleAddon(FMODAsset asset, params string[] requiredGUIDs) : base (requiredGUIDs)
     {
         _asset = asset;
     }
 
     /// <summary>
-    /// Sets up the FMOD looping emitter with the provided asset
+    /// Sets up the FMOD looping emitter with the provided asset.
     /// </summary>
     public override void Initialize()
     {
@@ -39,7 +39,7 @@ public class MusicTitleAddon : TitleAddon
     }
 
     /// <summary>
-    /// Enables the music
+    /// Enables the music.
     /// </summary>
     public override void OnEnable()
     {
@@ -47,7 +47,7 @@ public class MusicTitleAddon : TitleAddon
     }
 
     /// <summary>
-    /// Disables the music
+    /// Disables the music.
     /// </summary>
     public override void OnDisable()
     {

--- a/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
@@ -4,16 +4,17 @@ namespace Nautilus.Handlers.TitleScreen;
 
 public class MusicTitleAddon : TitleAddon
 {
-    private readonly FMODAsset _asset;
-    private FMOD_CustomEmitter _customEmitter;
+    protected readonly FMODAsset _asset;
+    protected FMOD_CustomEmitter _customEmitter;
     
     public MusicTitleAddon(FMODAsset asset)
     {
         _asset = asset;
     }
 
-    public override void Initialize(GameObject functionalityRoot)
+    public override void Initialize()
     {
+        var functionalityRoot = MainMenuMusic.main.gameObject;
         _customEmitter = functionalityRoot.AddComponent<FMOD_CustomLoopingEmitter>();
         _customEmitter.asset = _asset;
         _customEmitter.restartOnPlay = true;

--- a/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
@@ -1,0 +1,21 @@
+﻿namespace Nautilus.Handlers.TitleScreen;
+
+public class MusicTitleAddon : TitleAddon
+{
+    private readonly FMOD_CustomEmitter _emitter;
+    
+    public MusicTitleAddon(FMOD_CustomEmitter emitter)
+    {
+        _emitter = emitter;
+    }
+
+    public override void OnEnable()
+    {
+        _emitter.Play();
+    }
+
+    public override void OnDisable()
+    {
+        _emitter.Stop();
+    }
+}

--- a/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
@@ -7,7 +7,7 @@ public class MusicTitleAddon : TitleAddon
     protected readonly FMODAsset _asset;
     protected FMOD_CustomEmitter _customEmitter;
     
-    public MusicTitleAddon(FMODAsset asset)
+    public MusicTitleAddon(FMODAsset asset, params string[] requiredGUIDs) : base (requiredGUIDs)
     {
         _asset = asset;
     }

--- a/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
@@ -1,21 +1,31 @@
-﻿namespace Nautilus.Handlers.TitleScreen;
+﻿using UnityEngine;
+
+namespace Nautilus.Handlers.TitleScreen;
 
 public class MusicTitleAddon : TitleAddon
 {
-    private readonly FMOD_CustomEmitter _emitter;
+    private readonly FMODAsset _asset;
+    private FMOD_CustomEmitter _customEmitter;
     
-    public MusicTitleAddon(FMOD_CustomEmitter emitter)
+    public MusicTitleAddon(FMODAsset asset)
     {
-        _emitter = emitter;
+        _asset = asset;
+    }
+
+    public override void Initialize(GameObject functionalityRoot)
+    {
+        _customEmitter = functionalityRoot.AddComponent<FMOD_CustomLoopingEmitter>();
+        _customEmitter.asset = _asset;
+        _customEmitter.restartOnPlay = true;
     }
 
     public override void OnEnable()
     {
-        _emitter.Play();
+        _customEmitter.Play();
     }
 
     public override void OnDisable()
     {
-        _emitter.Stop();
+        _customEmitter.Stop();
     }
 }

--- a/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
@@ -11,7 +11,7 @@ public class MusicTitleAddon : TitleAddon
     protected readonly FMODAsset Asset;
     
     /// <summary>
-    /// The custom emitter created in <see cref="MusicTitleAddon.Initialize"/>.
+    /// The custom emitter created in <see cref="OnInitialize"/>.
     /// </summary>
     protected FMOD_CustomEmitter CustomEmitter;
     
@@ -30,7 +30,7 @@ public class MusicTitleAddon : TitleAddon
     /// <summary>
     /// Sets up the FMOD looping emitter with the provided asset.
     /// </summary>
-    public override void Initialize()
+    protected override void OnInitialize()
     {
         var functionalityRoot = MainMenuMusic.main.gameObject;
         CustomEmitter = functionalityRoot.AddComponent<FMOD_CustomLoopingEmitter>();
@@ -41,20 +41,16 @@ public class MusicTitleAddon : TitleAddon
     /// <summary>
     /// Enables the music.
     /// </summary>
-    public override void OnEnable()
+    protected override void OnEnable()
     {
-        base.OnEnable();
-        
         CustomEmitter.Play();
     }
 
     /// <summary>
     /// Disables the music.
     /// </summary>
-    public override void OnDisable()
+    protected override void OnDisable()
     {
-        base.OnDisable();
-        
         CustomEmitter.Stop();
     }
 }

--- a/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
@@ -8,12 +8,12 @@ public class MusicTitleAddon : TitleAddon
     /// <summary>
     /// The FMOD asset passed into the instance when created.
     /// </summary>
-    protected readonly FMODAsset _asset;
+    protected readonly FMODAsset Asset;
     
     /// <summary>
     /// The custom emitter created in <see cref="MusicTitleAddon.Initialize"/>.
     /// </summary>
-    protected FMOD_CustomEmitter _customEmitter;
+    protected FMOD_CustomEmitter CustomEmitter;
     
     /// <summary>
     /// Creates a new <see cref="MusicTitleAddon"/>. The music will be enabled when your mod is selected and disabled when the game starts or
@@ -24,7 +24,7 @@ public class MusicTitleAddon : TitleAddon
     /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/>.</param>
     public MusicTitleAddon(FMODAsset asset, params string[] requiredGUIDs) : base (requiredGUIDs)
     {
-        _asset = asset;
+        Asset = asset;
     }
 
     /// <summary>
@@ -33,9 +33,9 @@ public class MusicTitleAddon : TitleAddon
     public override void Initialize()
     {
         var functionalityRoot = MainMenuMusic.main.gameObject;
-        _customEmitter = functionalityRoot.AddComponent<FMOD_CustomLoopingEmitter>();
-        _customEmitter.asset = _asset;
-        _customEmitter.restartOnPlay = true;
+        CustomEmitter = functionalityRoot.AddComponent<FMOD_CustomLoopingEmitter>();
+        CustomEmitter.asset = Asset;
+        CustomEmitter.restartOnPlay = true;
     }
 
     /// <summary>
@@ -43,7 +43,9 @@ public class MusicTitleAddon : TitleAddon
     /// </summary>
     public override void OnEnable()
     {
-        _customEmitter.Play();
+        base.OnEnable();
+        
+        CustomEmitter.Play();
     }
 
     /// <summary>
@@ -51,6 +53,8 @@ public class MusicTitleAddon : TitleAddon
     /// </summary>
     public override void OnDisable()
     {
-        _customEmitter.Stop();
+        base.OnDisable();
+        
+        CustomEmitter.Stop();
     }
 }

--- a/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/MusicTitleAddon.cs
@@ -1,17 +1,35 @@
-﻿using UnityEngine;
+﻿namespace Nautilus.Handlers.TitleScreen;
 
-namespace Nautilus.Handlers.TitleScreen;
-
+/// <summary>
+/// Enables and disables custom music depending on what mod theme is selected
+/// </summary>
 public class MusicTitleAddon : TitleAddon
 {
+    /// <summary>
+    /// The FMOD asset passed into the instance when created 
+    /// </summary>
     protected readonly FMODAsset _asset;
+    
+    /// <summary>
+    /// The custom emitter created in <see cref="MusicTitleAddon.Initialize"/>
+    /// </summary>
     protected FMOD_CustomEmitter _customEmitter;
     
+    /// <summary>
+    /// Creates a new <see cref="MusicTitleAddon"/>. The music will be enabled when your mod is selected and disabled when the game starts or
+    /// if your theme is unselected
+    /// </summary>
+    /// <param name="asset">The FMOD asset for the music you want to play. A fade out time is HIGHLY recommended</param>
+    /// <param name="requiredGUIDs">The required mod GUIDs for this addon to enable. Each required mod must approve
+    /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/></param>
     public MusicTitleAddon(FMODAsset asset, params string[] requiredGUIDs) : base (requiredGUIDs)
     {
         _asset = asset;
     }
 
+    /// <summary>
+    /// Sets up the FMOD looping emitter with the provided asset
+    /// </summary>
     public override void Initialize()
     {
         var functionalityRoot = MainMenuMusic.main.gameObject;
@@ -20,11 +38,17 @@ public class MusicTitleAddon : TitleAddon
         _customEmitter.restartOnPlay = true;
     }
 
+    /// <summary>
+    /// Enables the music
+    /// </summary>
     public override void OnEnable()
     {
         _customEmitter.Play();
     }
 
+    /// <summary>
+    /// Disables the music
+    /// </summary>
     public override void OnDisable()
     {
         _customEmitter.Stop();

--- a/Nautilus/Handlers/TitleScreen/SkyChangeTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/SkyChangeTitleAddon.cs
@@ -45,6 +45,8 @@ public class SkyChangeTitleAddon : TitleAddon, IManagedUpdateBehaviour
     /// </summary>
     public override void OnEnable()
     {
+        base.OnEnable();
+        
         DeregisterPreviousSkyChange();
         _previousSettings = uSkyManager.main != null ? GetSettingsFromSkyManager(uSkyManager.main) : null;
         _transitionActive = true;
@@ -59,6 +61,8 @@ public class SkyChangeTitleAddon : TitleAddon, IManagedUpdateBehaviour
     /// </summary>
     public override void OnDisable()
     {
+        base.OnDisable();
+        
         // Don't de-register JUST yet, let's first revert to the default sky until someone else takes over
         var skyManager = uSkyManager.main;
         if (skyManager != null && _transitionActive && !_revertingToDefaultSky)

--- a/Nautilus/Handlers/TitleScreen/SkyChangeTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/SkyChangeTitleAddon.cs
@@ -75,8 +75,10 @@ public class SkyChangeTitleAddon : TitleAddon, IManagedUpdateBehaviour
         base.OnDisable();
     }
 
-    // Called every frame while registered.
-    void IManagedUpdateBehaviour.ManagedUpdate()
+    /// <summary>
+    /// Called every frame while registered.
+    /// </summary>
+    public virtual void ManagedUpdate()
     {
         if (!_transitionActive)
             return;

--- a/Nautilus/Handlers/TitleScreen/SkyChangeTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/SkyChangeTitleAddon.cs
@@ -45,8 +45,6 @@ public class SkyChangeTitleAddon : TitleAddon, IManagedUpdateBehaviour
     /// </summary>
     public override void OnEnable()
     {
-        base.OnEnable();
-        
         DeregisterPreviousSkyChange();
         _previousSettings = uSkyManager.main != null ? GetSettingsFromSkyManager(uSkyManager.main) : null;
         _transitionActive = true;
@@ -54,6 +52,8 @@ public class SkyChangeTitleAddon : TitleAddon, IManagedUpdateBehaviour
         _revertingToDefaultSky = false;
         BehaviourUpdateUtils.Register(this);
         _activeSkyChange = this;
+        
+        base.OnEnable();
     }
 
     /// <summary>
@@ -61,11 +61,9 @@ public class SkyChangeTitleAddon : TitleAddon, IManagedUpdateBehaviour
     /// </summary>
     public override void OnDisable()
     {
-        base.OnDisable();
-        
         // Don't de-register JUST yet, let's first revert to the default sky until someone else takes over
         var skyManager = uSkyManager.main;
-        if (skyManager != null && _transitionActive && !_revertingToDefaultSky)
+        if (skyManager != null && !_revertingToDefaultSky)
         {
             StartRevertingToDefaultSky(skyManager);
         }
@@ -73,6 +71,8 @@ public class SkyChangeTitleAddon : TitleAddon, IManagedUpdateBehaviour
         {
             BehaviourUpdateUtils.Deregister(this);
         }
+        
+        base.OnDisable();
     }
 
     // Called every frame while registered.

--- a/Nautilus/Handlers/TitleScreen/SkyChangeTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/SkyChangeTitleAddon.cs
@@ -1,0 +1,225 @@
+﻿using Nautilus.Utility;
+using UnityEngine;
+
+namespace Nautilus.Handlers.TitleScreen;
+
+/// <summary>
+/// Handles changes to the sky in the main menu.
+/// </summary>
+/// <remarks>
+/// Only one instance is ever expected to exist at once. Otherwise, one instance will be arbitrarily chosen.
+/// </remarks>
+/// <seealso cref="uSkyManager"/>
+public class SkyChangeTitleAddon : TitleAddon, IManagedUpdateBehaviour
+{
+    private const float RevertToDefaultSkyDuration = 2f;
+
+    private readonly float _fadeInDuration;
+    private readonly Settings _settings;
+
+    private Settings? _previousSettings;
+    private float _timeTransitionStarted;
+    private bool _transitionActive;
+    private bool _revertingToDefaultSky;
+
+    private static Settings? _defaultSettings;
+    private static SkyChangeTitleAddon _activeSkyChange;
+
+    int IManagedUpdateBehaviour.managedUpdateIndex { get; set; }
+
+    /// <summary>
+    /// Activates the specified <see cref="uSkyManager"/> settings when the mod is selected.
+    /// </summary>
+    /// <param name="fadeInDuration">How long it takes in seconds for these changes to apply.</param>
+    /// <param name="settings">Your custom settings that override the default uSkyManager values.</param>
+    /// <param name="requiredGUIDs">The required mod GUIDs for this addon to enable. Each required mod must approve
+    /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/>.</param>
+    public SkyChangeTitleAddon(float fadeInDuration, Settings settings, params string[] requiredGUIDs) :
+        base(requiredGUIDs)
+    {
+        _fadeInDuration = fadeInDuration;
+        _settings = settings;
+    }
+
+    /// <summary>
+    /// Activates the sky change.
+    /// </summary>
+    public override void OnEnable()
+    {
+        DeregisterPreviousSkyChange();
+        _previousSettings = uSkyManager.main != null ? GetSettingsFromSkyManager(uSkyManager.main) : null;
+        _transitionActive = true;
+        _timeTransitionStarted = Time.time;
+        _revertingToDefaultSky = false;
+        BehaviourUpdateUtils.Register(this);
+        _activeSkyChange = this;
+    }
+
+    /// <summary>
+    /// De-activates the sky change.
+    /// </summary>
+    public override void OnDisable()
+    {
+        // Don't de-register JUST yet, let's first revert to the default sky until someone else takes over
+        var skyManager = uSkyManager.main;
+        if (skyManager != null && _transitionActive && !_revertingToDefaultSky)
+        {
+            StartRevertingToDefaultSky(skyManager);
+        }
+        else
+        {
+            BehaviourUpdateUtils.Deregister(this);
+        }
+    }
+
+    // Called every frame while registered.
+    void IManagedUpdateBehaviour.ManagedUpdate()
+    {
+        if (!_transitionActive)
+            return;
+
+        var skyManager = uSkyManager.main;
+        if (skyManager == null)
+            return;
+
+        if (_defaultSettings == null)
+        {
+            CacheDefaultSettings(skyManager);
+        }
+        
+        _previousSettings ??= _defaultSettings ?? new Settings();
+
+        var target = _revertingToDefaultSky ? _defaultSettings.Value : _settings;
+
+        var duration = GetTransitionDuration();
+        
+        skyManager.Timeline = LerpValue(_previousSettings.Value.TimeOfDay, target.TimeOfDay, duration);
+        skyManager.Exposure = LerpValue(_previousSettings.Value.Exposure, target.Exposure, duration);
+        skyManager.RayleighScattering =
+            LerpValue(_previousSettings.Value.RayleighScattering, target.RayleighScattering, duration);
+        skyManager.skyFogDensity = LerpValue(_previousSettings.Value.FogDensity, target.FogDensity, duration);
+
+        if (Time.time > _timeTransitionStarted + duration)
+        {
+            _transitionActive = false;
+            if (_revertingToDefaultSky)
+            {
+                _revertingToDefaultSky = false;
+                if (_activeSkyChange == this)
+                    _activeSkyChange = null;
+            }
+            BehaviourUpdateUtils.Deregister(this);
+        }
+    }
+
+    private float LerpValue(float previous, float target, float duration)
+    {
+        return Mathf.Lerp(previous, target, (Time.time - _timeTransitionStarted) / duration);
+    }
+
+    private float GetTransitionDuration() => _revertingToDefaultSky ? RevertToDefaultSkyDuration : _fadeInDuration;
+
+    private void StartRevertingToDefaultSky(uSkyManager skyManager)
+    {
+        if (!_transitionActive)
+            BehaviourUpdateUtils.Register(this);
+        _revertingToDefaultSky = true;
+        _transitionActive = true;
+        _timeTransitionStarted = Time.time;
+        _previousSettings = GetSettingsFromSkyManager(skyManager);
+    }
+
+    string IManagedBehaviour.GetProfileTag()
+    {
+        return "SkyChangeTitleAddon";
+    }
+
+    private static void CacheDefaultSettings(uSkyManager skyManager)
+    {
+        _defaultSettings = GetSettingsFromSkyManager(skyManager);
+    }
+
+    private static Settings GetSettingsFromSkyManager(uSkyManager skyManager)
+    {
+        return new Settings(skyManager.Timeline, skyManager.Exposure, skyManager.RayleighScattering,
+            skyManager.skyFogDensity);
+    }
+
+    private static void DeregisterPreviousSkyChange()
+    {
+        if (_activeSkyChange == null)
+            return;
+
+        BehaviourUpdateUtils.Deregister(_activeSkyChange);
+        _activeSkyChange._transitionActive = false;
+        _activeSkyChange._revertingToDefaultSky = false;
+        _activeSkyChange = null;
+    }
+
+    /// <summary>
+    /// Settings pertaining to the <see cref="uSkyManager"/> class.
+    /// </summary>
+    public struct Settings
+    {
+        /// <summary>
+        /// The time of day, roughly corresponding to Earth hours.
+        /// </summary>
+        /// <remarks>
+        /// The default value is 6.8 in SN1 and 15.1 in BZ.
+        /// <list type="bullet">
+        /// <item><description><b>Night (AM)</b>: 0.0–5.2</description></item>
+        /// <item><description><b>Dawn</b>: 5.2–6.0</description></item>
+        /// <item><description><b>Morning</b>: 6.0–12.0</description></item>
+        /// <item><description><b>Noon</b>: 12.0</description></item>
+        /// <item><description><b>Afternoon</b>: 12.0–18.0</description></item>
+        /// <item><description><b>Dusk</b>: 18.0–18.8</description></item>
+        /// <item><description><b>Night (PM)</b>: 18.0–24.0</description></item>
+        /// </list>
+        /// </remarks>
+        public float TimeOfDay { get; init; } = 6.8f;
+
+        /// <summary>
+        /// The sky's exposure value, directly correlated with the brightness of the sky.
+        /// </summary>
+        /// <remarks>
+        /// Only positive values are supported. The default value is 0.66 in SN1 and 0.9 in BZ.
+        /// </remarks>
+        public float Exposure { get; init; } = 0.66f;
+
+        /// <summary>
+        /// The strength of rayleigh scattering, affecting how strongly light scatters from particles in the atmosphere.
+        /// </summary>
+        /// <remarks>
+        /// Only positive values are supported. The default value is 1.0 in SN1 and 0.9 in BZ. By the way, this is what makes the sky blue.
+        /// </remarks>
+        public float RayleighScattering { get; init; } = 1f;
+
+        /// <summary>
+        /// The strength/density of the fog.
+        /// </summary>
+        /// <remarks>
+        /// Only positive values are supported. The default value is 0.0002 in SN1 and 0.001 in BZ.
+        /// </remarks>
+        public float FogDensity { get; init; } = 0.0002f;
+
+        /// <summary>
+        /// The main constructor.
+        /// </summary>
+        /// <param name="timeOfDay">The time of day, similar to 24-hour Earth time.</param>
+        /// <param name="exposure">The exposure or brightness of the sky.</param>
+        /// <param name="rayleighScattering">The strength of light scattering in the sky.</param>
+        /// <param name="fogDensity">The strength/density of fog. Can.</param>
+        public Settings(
+#if SUBNAUTICA
+            float timeOfDay = 6.8f, float exposure = 0.66f, float rayleighScattering = 1f, float fogDensity = 0.0002f)
+#elif BELOWZERO
+            float timeOfDay = 15.1f, float exposure = 0.9f, float rayleighScattering = 0.9f, float fogDensity = 0.0001f)
+#endif
+        {
+            TimeOfDay = timeOfDay;
+            Exposure = exposure;
+            RayleighScattering = rayleighScattering;
+            FogDensity = fogDensity;
+        }
+    }
+}

--- a/Nautilus/Handlers/TitleScreen/SkyChangeTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/SkyChangeTitleAddon.cs
@@ -43,7 +43,7 @@ public class SkyChangeTitleAddon : TitleAddon, IManagedUpdateBehaviour
     /// <summary>
     /// Activates the sky change.
     /// </summary>
-    public override void OnEnable()
+    protected override void OnEnable()
     {
         DeregisterPreviousSkyChange();
         _previousSettings = uSkyManager.main != null ? GetSettingsFromSkyManager(uSkyManager.main) : null;
@@ -52,14 +52,12 @@ public class SkyChangeTitleAddon : TitleAddon, IManagedUpdateBehaviour
         _revertingToDefaultSky = false;
         BehaviourUpdateUtils.Register(this);
         _activeSkyChange = this;
-        
-        base.OnEnable();
     }
 
     /// <summary>
     /// De-activates the sky change.
     /// </summary>
-    public override void OnDisable()
+    protected override void OnDisable()
     {
         // Don't de-register JUST yet, let's first revert to the default sky until someone else takes over
         var skyManager = uSkyManager.main;
@@ -71,8 +69,6 @@ public class SkyChangeTitleAddon : TitleAddon, IManagedUpdateBehaviour
         {
             BehaviourUpdateUtils.Deregister(this);
         }
-        
-        base.OnDisable();
     }
 
     /// <summary>

--- a/Nautilus/Handlers/TitleScreen/SkyChangeTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/SkyChangeTitleAddon.cs
@@ -1,5 +1,4 @@
-﻿using Nautilus.Utility;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace Nautilus.Handlers.TitleScreen;
 

--- a/Nautilus/Handlers/TitleScreen/TitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleAddon.cs
@@ -35,7 +35,7 @@ public abstract class TitleAddon
     /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/>.</param>
     protected TitleAddon(string[] requiredGUIDs)
     {
-        this.RequiredGUIDs = requiredGUIDs;
+        RequiredGUIDs = requiredGUIDs;
     }
 
     /// <summary>

--- a/Nautilus/Handlers/TitleScreen/TitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleAddon.cs
@@ -6,7 +6,7 @@ public abstract class TitleAddon
 {
     public bool isEnabled;
     
-    public virtual void Initialize(GameObject functionalityRoot) { }
+    public virtual void Initialize() { }
     public abstract void OnEnable();
     public abstract void OnDisable();
 }

--- a/Nautilus/Handlers/TitleScreen/TitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleAddon.cs
@@ -5,7 +5,18 @@ namespace Nautilus.Handlers.TitleScreen;
 public abstract class TitleAddon
 {
     public bool isEnabled;
+    public string[] requiredGUIDs;
+
+    protected TitleAddon()
+    {
+        
+    }
     
+    protected TitleAddon(string[] requiredGUIDs)
+    {
+        this.requiredGUIDs = requiredGUIDs;
+    }
+
     public virtual void Initialize() { }
     public abstract void OnEnable();
     public abstract void OnDisable();

--- a/Nautilus/Handlers/TitleScreen/TitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleAddon.cs
@@ -1,0 +1,8 @@
+﻿namespace Nautilus.Handlers.TitleScreen;
+
+public abstract class TitleAddon
+{
+    public virtual void Initialize() { }
+    public abstract void OnEnable();
+    public abstract void OnDisable();
+}

--- a/Nautilus/Handlers/TitleScreen/TitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleAddon.cs
@@ -8,17 +8,17 @@ public abstract class TitleAddon
     /// <summary>
     /// The GUID of the mod that owns this addon.
     /// </summary>
-    public string modGUID;
+    protected internal string ModGuid { get; internal set; }
     
     /// <summary>
     /// Whether the addon is currently enabled.
     /// </summary>
-    public bool isEnabled;
+    protected internal bool IsEnabled { get; internal set; }
     
     /// <summary>
     /// The required mod GUIDs for this addon to be enabled.
     /// </summary>
-    public string[] requiredGUIDs;
+    protected internal string[] RequiredGUIDs { get; }
 
     /// <summary>
     /// Creates a new instance of TitleAddon.
@@ -35,7 +35,7 @@ public abstract class TitleAddon
     /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/>.</param>
     protected TitleAddon(string[] requiredGUIDs)
     {
-        this.requiredGUIDs = requiredGUIDs;
+        this.RequiredGUIDs = requiredGUIDs;
     }
 
     /// <summary>

--- a/Nautilus/Handlers/TitleScreen/TitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleAddon.cs
@@ -38,25 +38,36 @@ public abstract class TitleAddon
         RequiredGUIDs = requiredGUIDs;
     }
 
+    internal void Initialize()
+    {
+        OnInitialize();
+    }
+    
+    internal void Enable()
+    {
+        IsEnabled = true;
+        OnEnable();
+    }
+
+    internal void Disable()
+    {
+        IsEnabled = false;
+        OnDisable();
+    }
+    
     /// <summary>
     /// Runs initialization code once before the main menu is loaded to set up required fields.
     /// </summary>
-    public virtual void Initialize() { }
+    protected virtual void OnInitialize() { }
 
     /// <summary>
     /// Called when the addon is enabled. This occurs when your mod is selected as the current theme.
     /// </summary>
-    public virtual void OnEnable()
-    {
-        IsEnabled = true;
-    }
+    protected abstract void OnEnable();
 
     /// <summary>
     /// Called when the addon is disabled. This occurs when your mod is deselected as the current theme, or
     /// if the addon inherits from <see cref="MusicTitleAddon"/> and the game starts.
     /// </summary>
-    public virtual void OnDisable()
-    {
-        IsEnabled = false;
-    }
+    protected abstract void OnDisable();
 }

--- a/Nautilus/Handlers/TitleScreen/TitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleAddon.cs
@@ -1,8 +1,12 @@
-﻿namespace Nautilus.Handlers.TitleScreen;
+﻿using UnityEngine;
+
+namespace Nautilus.Handlers.TitleScreen;
 
 public abstract class TitleAddon
 {
-    public virtual void Initialize() { }
+    public bool isEnabled;
+    
+    public virtual void Initialize(GameObject functionalityRoot) { }
     public abstract void OnEnable();
     public abstract void OnDisable();
 }

--- a/Nautilus/Handlers/TitleScreen/TitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleAddon.cs
@@ -4,6 +4,7 @@ namespace Nautilus.Handlers.TitleScreen;
 
 public abstract class TitleAddon
 {
+    public string modGUID;
     public bool isEnabled;
     public string[] requiredGUIDs;
 

--- a/Nautilus/Handlers/TitleScreen/TitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleAddon.cs
@@ -8,17 +8,17 @@ public abstract class TitleAddon
     /// <summary>
     /// The GUID of the mod that owns this addon.
     /// </summary>
-    protected internal string ModGuid { get; internal set; }
+    public string ModGuid { get; internal set; }
     
     /// <summary>
     /// Whether the addon is currently enabled.
     /// </summary>
-    protected internal bool IsEnabled { get; internal set; }
+    public bool IsEnabled { get; protected set; }
     
     /// <summary>
     /// The required mod GUIDs for this addon to be enabled.
     /// </summary>
-    protected internal string[] RequiredGUIDs { get; }
+    public string[] RequiredGUIDs { get; }
 
     /// <summary>
     /// Creates a new instance of TitleAddon.
@@ -42,15 +42,21 @@ public abstract class TitleAddon
     /// Runs initialization code once before the main menu is loaded to set up required fields.
     /// </summary>
     public virtual void Initialize() { }
-    
+
     /// <summary>
     /// Called when the addon is enabled. This occurs when your mod is selected as the current theme.
     /// </summary>
-    public abstract void OnEnable();
-    
+    public virtual void OnEnable()
+    {
+        IsEnabled = true;
+    }
+
     /// <summary>
     /// Called when the addon is disabled. This occurs when your mod is deselected as the current theme, or
     /// if the addon inherits from <see cref="MusicTitleAddon"/> and the game starts.
     /// </summary>
-    public abstract void OnDisable();
+    public virtual void OnDisable()
+    {
+        IsEnabled = false;
+    }
 }

--- a/Nautilus/Handlers/TitleScreen/TitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleAddon.cs
@@ -1,27 +1,27 @@
 ﻿namespace Nautilus.Handlers.TitleScreen;
 
 /// <summary>
-/// A custom title addon for the main menu. Inherit from this class to create your own main menu functionality
+/// A custom title addon for the main menu. Inherit from this class to create your own main menu functionality.
 /// </summary>
 public abstract class TitleAddon
 {
     /// <summary>
-    /// The GUID of the mod that owns this addon
+    /// The GUID of the mod that owns this addon.
     /// </summary>
     public string modGUID;
     
     /// <summary>
-    /// Whether the addon is currently enabled
+    /// Whether the addon is currently enabled.
     /// </summary>
     public bool isEnabled;
     
     /// <summary>
-    /// The required mod GUIDs for this addon to be enabled
+    /// The required mod GUIDs for this addon to be enabled.
     /// </summary>
     public string[] requiredGUIDs;
 
     /// <summary>
-    /// Creates a new instance of TitleAddon
+    /// Creates a new instance of TitleAddon.
     /// </summary>
     protected TitleAddon()
     {
@@ -29,28 +29,28 @@ public abstract class TitleAddon
     }
     
     /// <summary>
-    /// Creates a new instance of TitleAddon
+    /// Creates a new instance of TitleAddon.
     /// </summary>
     /// <param name="requiredGUIDs">The required mod GUIDs for this addon to enable. Each required mod must approve
-    /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/></param>
+    /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/>.</param>
     protected TitleAddon(string[] requiredGUIDs)
     {
         this.requiredGUIDs = requiredGUIDs;
     }
 
     /// <summary>
-    /// Runs initialization code once before the main menu is loaded to set up required fields
+    /// Runs initialization code once before the main menu is loaded to set up required fields.
     /// </summary>
     public virtual void Initialize() { }
     
     /// <summary>
-    /// Called when the addon is enabled. This occurs when your mod is selected as the current theme
+    /// Called when the addon is enabled. This occurs when your mod is selected as the current theme.
     /// </summary>
     public abstract void OnEnable();
     
     /// <summary>
     /// Called when the addon is disabled. This occurs when your mod is deselected as the current theme, or
-    /// if the addon inherits from <see cref="MusicTitleAddon"/> and the game starts
+    /// if the addon inherits from <see cref="MusicTitleAddon"/> and the game starts.
     /// </summary>
     public abstract void OnDisable();
 }

--- a/Nautilus/Handlers/TitleScreen/TitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleAddon.cs
@@ -13,7 +13,7 @@ public abstract class TitleAddon
     /// <summary>
     /// Whether the addon is currently enabled.
     /// </summary>
-    public bool IsEnabled { get; protected set; }
+    public bool IsEnabled { get; private set; }
     
     /// <summary>
     /// The required mod GUIDs for this addon to be enabled.

--- a/Nautilus/Handlers/TitleScreen/TitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleAddon.cs
@@ -1,24 +1,56 @@
-﻿using UnityEngine;
+﻿namespace Nautilus.Handlers.TitleScreen;
 
-namespace Nautilus.Handlers.TitleScreen;
-
+/// <summary>
+/// A custom title addon for the main menu. Inherit from this class to create your own main menu functionality
+/// </summary>
 public abstract class TitleAddon
 {
+    /// <summary>
+    /// The GUID of the mod that owns this addon
+    /// </summary>
     public string modGUID;
+    
+    /// <summary>
+    /// Whether the addon is currently enabled
+    /// </summary>
     public bool isEnabled;
+    
+    /// <summary>
+    /// The required mod GUIDs for this addon to be enabled
+    /// </summary>
     public string[] requiredGUIDs;
 
+    /// <summary>
+    /// Creates a new instance of TitleAddon
+    /// </summary>
     protected TitleAddon()
     {
         
     }
     
+    /// <summary>
+    /// Creates a new instance of TitleAddon
+    /// </summary>
+    /// <param name="requiredGUIDs">The required mod GUIDs for this addon to enable. Each required mod must approve
+    /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/></param>
     protected TitleAddon(string[] requiredGUIDs)
     {
         this.requiredGUIDs = requiredGUIDs;
     }
 
+    /// <summary>
+    /// Runs initialization code once before the main menu is loaded to set up required fields
+    /// </summary>
     public virtual void Initialize() { }
+    
+    /// <summary>
+    /// Called when the addon is enabled. This occurs when your mod is selected as the current theme
+    /// </summary>
     public abstract void OnEnable();
+    
+    /// <summary>
+    /// Called when the addon is disabled. This occurs when your mod is deselected as the current theme, or
+    /// if the addon inherits from <see cref="MusicTitleAddon"/> and the game starts
+    /// </summary>
     public abstract void OnDisable();
 }

--- a/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
@@ -12,21 +12,31 @@ public static class TitleScreenHandler
         MainMenuPatcher.RegisterTitleObjectData(guid, customTitleData);
     }
 
+    public static void ApproveTitleCollaboration(string guid, CollaborationData collaborationData)
+    {
+        MainMenuPatcher.CollaborationData.Add(guid, collaborationData);
+    }
+
     public class CustomTitleData
     {
         public readonly string localizationKey;
-        public readonly Dictionary<Type, TitleAddon> addons;
-        public GameObject functionalityRoot;
+        public readonly TitleAddon[] addons;
         
         public CustomTitleData(string localizationKey, params TitleAddon[] addons)
         {
             this.localizationKey = localizationKey;
 
-            this.addons = new();
-            foreach (var addon in addons)
-            {
-                this.addons.Add(addon.GetType(), addon);
-            }
+            this.addons = addons;
+        }
+    }
+
+    public struct CollaborationData
+    {
+        public Dictionary<string, Type[]> modApprovedAddons;
+
+        public CollaborationData(Dictionary<string, Type[]> modApprovedAddons)
+        {
+            this.modApprovedAddons = modApprovedAddons;
         }
     }
 }

--- a/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Nautilus.Patchers;
+using UnityEngine;
 
 namespace Nautilus.Handlers.TitleScreen;
 
@@ -15,6 +16,7 @@ public static class TitleScreenHandler
     {
         public readonly string localizationKey;
         public readonly Dictionary<Type, TitleAddon> addons;
+        public GameObject functionalityRoot;
         
         public CustomTitleData(string localizationKey, params TitleAddon[] addons)
         {

--- a/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
@@ -6,50 +6,50 @@ using Nautilus.Patchers;
 namespace Nautilus.Handlers.TitleScreen;
 
 /// <summary>
-/// Handles custom additions to the main menu (Title screen)
+/// Handles custom additions to the main menu (Title screen).
 /// </summary>
 public static class TitleScreenHandler
 {
     /// <summary>
-    /// Register title screen additions with Nautilus for automatic handling
+    /// Register title screen additions with Nautilus for automatic handling.
     /// </summary>
-    /// <param name="plugin">The plugin for your mod</param>
-    /// <param name="customTitleData">The custom title data for your additions</param>
+    /// <param name="plugin">The plugin for your mod.</param>
+    /// <param name="customTitleData">The custom title data for your additions.</param>
     public static void RegisterTitleScreenObject(BaseUnityPlugin plugin, CustomTitleData customTitleData)
     {
         MainMenuPatcher.RegisterTitleObjectData(plugin.Info.Metadata.GUID, customTitleData);
     }
 
     /// <summary>
-    /// Approve another mod to make specific title screen additions when your mod is installed
+    /// Approve another mod to make specific title screen additions when your mod is installed.
     /// </summary>
-    /// <param name="plugin">The plugin for your mod</param>
-    /// <param name="collaborationData">The collaboration data for the plugins you want to approve</param>
+    /// <param name="plugin">The plugin for your mod.</param>
+    /// <param name="collaborationData">The collaboration data for the plugins you want to approve.</param>
     public static void ApproveTitleCollaboration(BaseUnityPlugin plugin, CollaborationData collaborationData)
     {
         MainMenuPatcher.CollaborationData.Add(plugin.Info.Metadata.GUID, collaborationData);
     }
 
     /// <summary>
-    /// A data class containing additions for Nautilus to add to the main menu when your mod is selected as the current theme
+    /// A data class containing additions for Nautilus to add to the main menu when your mod is selected as the current theme.
     /// </summary>
     public class CustomTitleData
     {
         /// <summary>
-        /// The localization key for the name of your mod. Will be shown in the selectable themes option
+        /// The localization key for the name of your mod. Will be shown in the selectable themes option.
         /// </summary>
         public readonly string localizationKey;
         
         /// <summary>
-        /// The additions to the main menu that should be active when your mod is selected
+        /// The additions to the main menu that should be active when your mod is selected.
         /// </summary>
         public readonly TitleAddon[] addons;
         
         /// <summary>
         /// Creates a new instance of <see cref="CustomTitleData"/>
         /// </summary>
-        /// <param name="localizationKey">The localization key for the name of your mod. Will be shown in the selectable themes option</param>
-        /// <param name="addons">The additions to the main menu that should be active when your mod is selected</param>
+        /// <param name="localizationKey">The localization key for the name of your mod. Will be shown in the selectable themes option.</param>
+        /// <param name="addons">The additions to the main menu that should be active when your mod is selected.</param>
         public CustomTitleData(string localizationKey, params TitleAddon[] addons)
         {
             this.localizationKey = localizationKey;
@@ -59,25 +59,25 @@ public static class TitleScreenHandler
     }
 
     /// <summary>
-    /// A data class containing info allowing other mods to add mod-specific additions to the title screen
+    /// A data class containing info allowing other mods to add mod-specific additions to the title screen.
     /// </summary>
     public class CollaborationData
     {
         internal Dictionary<string, Type[]> modApprovedAddons;
 
         /// <summary>
-        /// Creates a new instance of <see cref="CollaborationData"/> with specific approved addon types
+        /// Creates a new instance of <see cref="CollaborationData"/> with specific approved addon types.
         /// </summary>
-        /// <param name="modApprovedAddons">The GUIDs for the approved mods and their allowed addon types</param>
+        /// <param name="modApprovedAddons">The GUIDs for the approved mods and their allowed addon types.</param>
         public CollaborationData(Dictionary<string, Type[]> modApprovedAddons)
         {
             this.modApprovedAddons = modApprovedAddons;
         }
 
         /// <summary>
-        /// Creates a new instance of <see cref="CollaborationData"/> with all addon types approved
+        /// Creates a new instance of <see cref="CollaborationData"/> with all addon types approved.
         /// </summary>
-        /// <param name="GUIDs">The GUIDs of the mods to approve</param>
+        /// <param name="GUIDs">The GUIDs of the mods to approve.</param>
         public CollaborationData(string[] GUIDs)
         {
             modApprovedAddons = new();

--- a/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
@@ -9,7 +9,7 @@ public static class TitleScreenHandler
 {
     public static void RegisterTitleScreenObject(string guid, CustomTitleData customTitleData)
     {
-        MainMenuPatcher.TitleObjectDatas.Add(guid, customTitleData);
+        MainMenuPatcher.RegisterTitleObjectData(guid, customTitleData);
     }
 
     public class CustomTitleData

--- a/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using Nautilus.Patchers;
+
+namespace Nautilus.Handlers.TitleScreen;
+
+public static class TitleScreenHandler
+{
+    public static void RegisterTitleScreenObject(string guid, CustomTitleData customTitleData)
+    {
+        MainMenuPatcher.TitleObjectDatas.Add(guid, customTitleData);
+    }
+
+    public class CustomTitleData
+    {
+        public readonly string localizationKey;
+        public readonly Dictionary<Type, TitleAddon> addons;
+        
+        public CustomTitleData(string localizationKey, params TitleAddon[] addons)
+        {
+            this.localizationKey = localizationKey;
+
+            this.addons = new();
+            foreach (var addon in addons)
+            {
+                this.addons.Add(addon.GetType(), addon);
+            }
+        }
+    }
+}

--- a/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
@@ -2,28 +2,54 @@
 using System.Collections.Generic;
 using BepInEx;
 using Nautilus.Patchers;
-using Nautilus.Utility;
-using UnityEngine;
 
 namespace Nautilus.Handlers.TitleScreen;
 
+/// <summary>
+/// Handles custom additions to the main menu (Title screen)
+/// </summary>
 public static class TitleScreenHandler
 {
+    /// <summary>
+    /// Register title screen additions with Nautilus for automatic handling
+    /// </summary>
+    /// <param name="plugin">The plugin for your mod</param>
+    /// <param name="customTitleData">The custom title data for your additions</param>
     public static void RegisterTitleScreenObject(BaseUnityPlugin plugin, CustomTitleData customTitleData)
     {
         MainMenuPatcher.RegisterTitleObjectData(plugin.Info.Metadata.GUID, customTitleData);
     }
 
+    /// <summary>
+    /// Approve another mod to make specific title screen additions when your mod is installed
+    /// </summary>
+    /// <param name="plugin">The plugin for your mod</param>
+    /// <param name="collaborationData">The collaboration data for the plugins you want to approve</param>
     public static void ApproveTitleCollaboration(BaseUnityPlugin plugin, CollaborationData collaborationData)
     {
         MainMenuPatcher.CollaborationData.Add(plugin.Info.Metadata.GUID, collaborationData);
     }
 
+    /// <summary>
+    /// A data class containing additions for Nautilus to add to the main menu when your mod is selected as the current theme
+    /// </summary>
     public class CustomTitleData
     {
+        /// <summary>
+        /// The localization key for the name of your mod. Will be shown in the selectable themes option
+        /// </summary>
         public readonly string localizationKey;
+        
+        /// <summary>
+        /// The additions to the main menu that should be active when your mod is selected
+        /// </summary>
         public readonly TitleAddon[] addons;
         
+        /// <summary>
+        /// Creates a new instance of <see cref="CustomTitleData"/>
+        /// </summary>
+        /// <param name="localizationKey">The localization key for the name of your mod. Will be shown in the selectable themes option</param>
+        /// <param name="addons">The additions to the main menu that should be active when your mod is selected</param>
         public CustomTitleData(string localizationKey, params TitleAddon[] addons)
         {
             this.localizationKey = localizationKey;
@@ -32,15 +58,26 @@ public static class TitleScreenHandler
         }
     }
 
+    /// <summary>
+    /// A data class containing info allowing other mods to add mod-specific additions to the title screen
+    /// </summary>
     public class CollaborationData
     {
-        public Dictionary<string, Type[]> modApprovedAddons;
+        internal Dictionary<string, Type[]> modApprovedAddons;
 
+        /// <summary>
+        /// Creates a new instance of <see cref="CollaborationData"/> with specific approved addon types
+        /// </summary>
+        /// <param name="modApprovedAddons">The GUIDs for the approved mods and their allowed addon types</param>
         public CollaborationData(Dictionary<string, Type[]> modApprovedAddons)
         {
             this.modApprovedAddons = modApprovedAddons;
         }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="CollaborationData"/> with all addon types approved
+        /// </summary>
+        /// <param name="GUIDs">The GUIDs of the mods to approve</param>
         public CollaborationData(string[] GUIDs)
         {
             modApprovedAddons = new();

--- a/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
@@ -1,20 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
+using BepInEx;
 using Nautilus.Patchers;
+using Nautilus.Utility;
 using UnityEngine;
 
 namespace Nautilus.Handlers.TitleScreen;
 
 public static class TitleScreenHandler
 {
-    public static void RegisterTitleScreenObject(string guid, CustomTitleData customTitleData)
+    public static void RegisterTitleScreenObject(BaseUnityPlugin plugin, CustomTitleData customTitleData)
     {
-        MainMenuPatcher.RegisterTitleObjectData(guid, customTitleData);
+        MainMenuPatcher.RegisterTitleObjectData(plugin.Info.Metadata.GUID, customTitleData);
     }
 
-    public static void ApproveTitleCollaboration(string guid, CollaborationData collaborationData)
+    public static void ApproveTitleCollaboration(BaseUnityPlugin plugin, CollaborationData collaborationData)
     {
-        MainMenuPatcher.CollaborationData.Add(guid, collaborationData);
+        MainMenuPatcher.CollaborationData.Add(plugin.Info.Metadata.GUID, collaborationData);
     }
 
     public class CustomTitleData
@@ -30,13 +32,22 @@ public static class TitleScreenHandler
         }
     }
 
-    public struct CollaborationData
+    public class CollaborationData
     {
         public Dictionary<string, Type[]> modApprovedAddons;
 
         public CollaborationData(Dictionary<string, Type[]> modApprovedAddons)
         {
             this.modApprovedAddons = modApprovedAddons;
+        }
+
+        public CollaborationData(string[] GUIDs)
+        {
+            modApprovedAddons = new();
+            foreach (var guid in GUIDs)
+            {
+                modApprovedAddons.Add(guid, new[] { typeof(ApproveAllAddons) });
+            }
         }
     }
 }

--- a/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
@@ -21,7 +21,7 @@ public class WorldObjectTitleAddon : TitleAddon
         _spawnLocation = spawnLocation;
     }
 
-    public override void Initialize()
+    public override void Initialize(GameObject functionalityRoot)
     {
         _worldObject = GameObject.Instantiate(_worldObjectPrefab());
         _worldObject.transform.position = _spawnLocation.Position;

--- a/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
@@ -119,7 +119,11 @@ public class WorldObjectTitleAddon : TitleAddon, IManagedUpdateBehaviour
     /// </summary>
     public virtual void ManagedUpdate()
     {
-        if (!WorldObject) return;
+        if (!WorldObject)
+        {
+            BehaviourUpdateUtils.Deregister(this);
+            return;
+        }
         
         if (_currentFadeInTime < FadeInTime)
         {

--- a/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
@@ -15,7 +15,8 @@ public class WorldObjectTitleAddon : TitleAddon
     /// <summary>
     /// Spawns in the specified <see cref="GameObject"/> when your mod is selected
     /// </summary>
-    /// <param name="spawnObject">A function to get the object to enable. Nautilus expects this object to already be instantiated</param>
+    /// <param name="spawnObject">A function to get the object to enable. It is recommended to spawn your object in this method to ensure
+    /// returning to the main menu from a save does not cause NREs</param>
     /// <param name="requiredGUIDs">The required mod GUIDs for this addon to enable. Each required mod must approve
     /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/></param>
     public WorldObjectTitleAddon(Func<GameObject> spawnObject, params string[] requiredGUIDs) : base (requiredGUIDs)

--- a/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
@@ -4,23 +4,35 @@ using UnityEngine;
 
 namespace Nautilus.Handlers.TitleScreen;
 
+/// <summary>
+/// Enables and disables a custom GameObject in the main menu depending on what mod theme is selected
+/// </summary>
 public class WorldObjectTitleAddon : TitleAddon
 {
     private Func<GameObject> _spawnObject;
     private GameObject _worldObject;
 
+    /// <summary>
+    /// Spawns in the specified <see cref="GameObject"/> when your mod is selected
+    /// </summary>
+    /// <param name="spawnObject">A function to get the object to enable. Nautilus expects this object to already be instantiated</param>
+    /// <param name="requiredGUIDs">The required mod GUIDs for this addon to enable. Each required mod must approve
+    /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/></param>
     public WorldObjectTitleAddon(Func<GameObject> spawnObject, params string[] requiredGUIDs) : base (requiredGUIDs)
     {
         _spawnObject = spawnObject;
     }
 
+    /// <summary>
+    /// Sets the correct sky appliers on the managed object
+    /// </summary>
     public override void Initialize()
     {
         _worldObject = _spawnObject();
         UWE.CoroutineHost.StartCoroutine(SetupObjectSkyAppliers());
     }
 
-    protected virtual IEnumerator SetupObjectSkyAppliers()
+    private IEnumerator SetupObjectSkyAppliers()
     {
         var menuLogo = GameObject.FindObjectOfType<MenuLogo>();
 
@@ -35,11 +47,17 @@ public class WorldObjectTitleAddon : TitleAddon
         }
     }
     
+    /// <summary>
+    /// Enables the managed object
+    /// </summary>
     public override void OnEnable()
     {
         _worldObject.SetActive(true);
     }
 
+    /// <summary>
+    /// Disables the managed object
+    /// </summary>
     public override void OnDisable()
     {
         _worldObject.SetActive(false);

--- a/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
@@ -89,8 +89,11 @@ public class WorldObjectTitleAddon : TitleAddon, IManagedUpdateBehaviour
     /// </summary>
     protected override void OnDisable()
     {
+        if (!_fadingIn)
+            _currentFadeInTime = 0;
+        else
+            _currentFadeInTime = FadeInTime - _currentFadeInTime;
         _fadingIn = false;
-        _currentFadeInTime = 0;
     }
 
     private void UpdateObjectOpacities(float alpha)

--- a/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
@@ -1,32 +1,35 @@
-﻿using System;
-using Nautilus.Assets;
+﻿using System.Collections;
 using UnityEngine;
 
 namespace Nautilus.Handlers.TitleScreen;
 
 public class WorldObjectTitleAddon : TitleAddon
 {
-    private readonly Func<GameObject> _worldObjectPrefab;
-    private readonly SpawnLocation _spawnLocation;
     private GameObject _worldObject;
-    
-    public WorldObjectTitleAddon(Func<GameObject> worldObject, SpawnLocation spawnLocation)
+
+    public WorldObjectTitleAddon(GameObject worldObject)
     {
-        _worldObjectPrefab = worldObject;
-        if (spawnLocation.Scale == default)
-        {
-            spawnLocation = new SpawnLocation(spawnLocation.Position, spawnLocation.EulerAngles, Vector3.one);
-        }
-        
-        _spawnLocation = spawnLocation;
+        _worldObject = worldObject;
     }
 
-    public override void Initialize(GameObject functionalityRoot)
+    public override void Initialize()
     {
-        _worldObject = GameObject.Instantiate(_worldObjectPrefab());
-        _worldObject.transform.position = _spawnLocation.Position;
-        _worldObject.transform.rotation = Quaternion.Euler(_spawnLocation.EulerAngles);
-        _worldObject.transform.localScale = _spawnLocation.Scale;
+        UWE.CoroutineHost.StartCoroutine(SetupObjectSkyAppliers());
+    }
+
+    protected virtual IEnumerator SetupObjectSkyAppliers()
+    {
+        var menuLogo = GameObject.FindObjectOfType<MenuLogo>();
+
+        yield return new WaitUntil(() => menuLogo.logoObject);
+
+        var customSky = menuLogo.logoObject.GetComponent<SkyApplier>().customSkyPrefab;
+        foreach (var applier in _worldObject.GetComponentsInChildren<SkyApplier>(true))
+        {
+            applier.customSkyPrefab = customSky;
+            
+            applier.Start();
+        }
     }
     
     public override void OnEnable()

--- a/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace Nautilus.Handlers.TitleScreen;
 
 /// <summary>
-/// Enables and disables a custom GameObject in the main menu depending on what mod theme is selected
+/// Enables and disables a custom GameObject in the main menu depending on what mod theme is selected.
 /// </summary>
 public class WorldObjectTitleAddon : TitleAddon
 {
@@ -13,19 +13,19 @@ public class WorldObjectTitleAddon : TitleAddon
     private GameObject _worldObject;
 
     /// <summary>
-    /// Spawns in the specified <see cref="GameObject"/> when your mod is selected
+    /// Spawns in the specified <see cref="GameObject"/> when your mod is selected.
     /// </summary>
     /// <param name="spawnObject">A function to get the object to enable. It is recommended to spawn your object in this method to ensure
-    /// returning to the main menu from a save does not cause NREs</param>
+    /// returning to the main menu from a save does not cause NREs.</param>
     /// <param name="requiredGUIDs">The required mod GUIDs for this addon to enable. Each required mod must approve
-    /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/></param>
+    /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/>.</param>
     public WorldObjectTitleAddon(Func<GameObject> spawnObject, params string[] requiredGUIDs) : base (requiredGUIDs)
     {
         _spawnObject = spawnObject;
     }
 
     /// <summary>
-    /// Sets the correct sky appliers on the managed object
+    /// Sets the correct sky appliers on the managed object.
     /// </summary>
     public override void Initialize()
     {
@@ -49,7 +49,7 @@ public class WorldObjectTitleAddon : TitleAddon
     }
     
     /// <summary>
-    /// Enables the managed object
+    /// Enables the managed object.
     /// </summary>
     public override void OnEnable()
     {
@@ -57,7 +57,7 @@ public class WorldObjectTitleAddon : TitleAddon
     }
 
     /// <summary>
-    /// Disables the managed object
+    /// Disables the managed object.
     /// </summary>
     public override void OnDisable()
     {

--- a/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Nautilus.Assets;
+using UnityEngine;
+
+namespace Nautilus.Handlers.TitleScreen;
+
+public class WorldObjectTitleAddon : TitleAddon
+{
+    private readonly Func<GameObject> _worldObjectPrefab;
+    private readonly SpawnLocation _spawnLocation;
+    private GameObject _worldObject;
+    
+    public WorldObjectTitleAddon(Func<GameObject> worldObject, SpawnLocation spawnLocation)
+    {
+        _worldObjectPrefab = worldObject;
+        if (spawnLocation.Scale == default)
+        {
+            spawnLocation = new SpawnLocation(spawnLocation.Position, spawnLocation.EulerAngles, Vector3.one);
+        }
+        
+        _spawnLocation = spawnLocation;
+    }
+
+    public override void Initialize()
+    {
+        _worldObject = GameObject.Instantiate(_worldObjectPrefab());
+        _worldObject.transform.position = _spawnLocation.Position;
+        _worldObject.transform.rotation = Quaternion.Euler(_spawnLocation.EulerAngles);
+        _worldObject.transform.localScale = _spawnLocation.Scale;
+    }
+    
+    public override void OnEnable()
+    {
+        _worldObject.SetActive(true);
+    }
+
+    public override void OnDisable()
+    {
+        _worldObject.SetActive(false);
+    }
+}

--- a/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
@@ -1,36 +1,48 @@
 ﻿using System;
 using System.Collections;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace Nautilus.Handlers.TitleScreen;
 
 /// <summary>
 /// Enables and disables a custom GameObject in the main menu depending on what mod theme is selected.
 /// </summary>
-public class WorldObjectTitleAddon : TitleAddon
+public class WorldObjectTitleAddon : TitleAddon, IManagedUpdateBehaviour
 {
     /// <summary>
-    /// The func to spawn the world object. Set in the constructor
+    /// The func to spawn the world object. Set in the constructor.
     /// </summary>
     protected readonly Func<GameObject> SpawnObject;
     
     /// <summary>
-    /// The object that is spawned in the world and managed
+    /// The duration that it takes for an object to fade in when enabled/disabled.
+    /// </summary>
+    protected readonly float FadeInTime;
+    
+    /// <summary>
+    /// The object that is spawned in the world and managed.
     /// </summary>
     protected GameObject WorldObject;
 
+    private float _currentFadeInTime;
+    private bool _fadingIn;
+    
     /// <summary>
     /// Spawns in the specified <see cref="GameObject"/> when your mod is selected.
     /// </summary>
     /// <param name="spawnObject">A function to get the object to enable. It is recommended to spawn your object in this method to ensure
     /// returning to the main menu from a save does not cause NREs.</param>
+    /// <param name="fadeInTime">The duration of the fade in for enabling/disabling objects.
+    /// The spawnObject must have SN shaders applied for this to work.</param>
     /// <param name="requiredGUIDs">The required mod GUIDs for this addon to enable. Each required mod must approve
     /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/>.</param>
-    public WorldObjectTitleAddon(Func<GameObject> spawnObject, params string[] requiredGUIDs) : base (requiredGUIDs)
+    public WorldObjectTitleAddon(Func<GameObject> spawnObject, float fadeInTime = 1f, params string[] requiredGUIDs) : base (requiredGUIDs)
     {
         SpawnObject = spawnObject;
+        FadeInTime = fadeInTime;
     }
-
+ 
     /// <summary>
     /// Sets the correct sky appliers on the managed object.
     /// </summary>
@@ -38,6 +50,7 @@ public class WorldObjectTitleAddon : TitleAddon
     {
         WorldObject = SpawnObject();
         UWE.CoroutineHost.StartCoroutine(SetupObjectSkyAppliers());
+        WorldObject.SetActive(false);
     }
 
     private IEnumerator SetupObjectSkyAppliers()
@@ -49,6 +62,7 @@ public class WorldObjectTitleAddon : TitleAddon
         var customSky = menuLogo.logoObject.GetComponent<SkyApplier>().customSkyPrefab;
         foreach (var applier in WorldObject.GetComponentsInChildren<SkyApplier>(true))
         {
+            applier.anchorSky = Skies.Custom;
             applier.customSkyPrefab = customSky;
             
             applier.Start();
@@ -62,7 +76,9 @@ public class WorldObjectTitleAddon : TitleAddon
     {
         base.OnEnable();
         
-        WorldObject.SetActive(true);
+        BehaviourUpdateUtils.Register(this);
+        _currentFadeInTime = 0;
+        _fadingIn = true;
     }
 
     /// <summary>
@@ -71,7 +87,59 @@ public class WorldObjectTitleAddon : TitleAddon
     public override void OnDisable()
     {
         base.OnDisable();
-        
-        WorldObject.SetActive(false);
+
+        _fadingIn = false;
+        _currentFadeInTime = 0;
     }
+
+    private void UpdateObjectOpacities(float alpha)
+    {
+        if (!WorldObject) return;
+
+        foreach (var rend in WorldObject.GetComponentsInChildren<Renderer>(true))
+        {
+            rend.SetFadeAmount(alpha);
+        }
+        
+        foreach (var graphic in WorldObject.GetComponentsInChildren<Graphic>(true))
+        {
+            var col = new Color(graphic.color.r, graphic.color.g, graphic.color.b, alpha);
+            graphic.color = col;
+        }
+    }
+
+    string IManagedBehaviour.GetProfileTag()
+    {
+        return "WorldObjectTitleAddon";
+    }
+
+    /// <summary>
+    /// Called every frame while registered.
+    /// </summary>
+    public virtual void ManagedUpdate()
+    {
+        if (!WorldObject) return;
+        
+        if (_currentFadeInTime < FadeInTime)
+        {
+            _currentFadeInTime += Time.deltaTime;
+            float normalizedProgress = _currentFadeInTime / Mathf.Max(FadeInTime, float.Epsilon);
+            UpdateObjectOpacities(_fadingIn ? normalizedProgress : 1 - normalizedProgress);
+
+            if (!_fadingIn && normalizedProgress >= 1)
+            {
+                WorldObject.SetActive(false);
+            }
+            else if (_fadingIn && normalizedProgress > 0)
+            {
+                WorldObject.SetActive(true);
+            }
+        }
+        else if (!_fadingIn)
+        {
+            BehaviourUpdateUtils.Deregister(this);
+        }
+    }
+
+    int IManagedUpdateBehaviour.managedUpdateIndex { get; set; }
 }

--- a/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
@@ -25,6 +25,8 @@ public class WorldObjectTitleAddon : TitleAddon, IManagedUpdateBehaviour
     /// </summary>
     protected GameObject WorldObject;
 
+    private Renderer[] _fadeRenderers;
+    private Graphic[] _fadeGraphics;
     private float _currentFadeInTime;
     private bool _fadingIn;
     
@@ -51,6 +53,9 @@ public class WorldObjectTitleAddon : TitleAddon, IManagedUpdateBehaviour
         WorldObject = SpawnObject();
         UWE.CoroutineHost.StartCoroutine(SetupObjectSkyAppliers());
         WorldObject.SetActive(false);
+
+        _fadeRenderers = WorldObject.GetComponentsInChildren<Renderer>(true);
+        _fadeGraphics = WorldObject.GetComponentsInChildren<Graphic>(true);
     }
 
     private IEnumerator SetupObjectSkyAppliers()
@@ -92,12 +97,12 @@ public class WorldObjectTitleAddon : TitleAddon, IManagedUpdateBehaviour
     {
         if (!WorldObject) return;
 
-        foreach (var rend in WorldObject.GetComponentsInChildren<Renderer>(true))
+        foreach (var rend in _fadeRenderers)
         {
             rend.SetFadeAmount(alpha);
         }
         
-        foreach (var graphic in WorldObject.GetComponentsInChildren<Graphic>(true))
+        foreach (var graphic in _fadeGraphics)
         {
             var col = new Color(graphic.color.r, graphic.color.g, graphic.color.b, alpha);
             graphic.color = col;

--- a/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
@@ -1,19 +1,22 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using UnityEngine;
 
 namespace Nautilus.Handlers.TitleScreen;
 
 public class WorldObjectTitleAddon : TitleAddon
 {
+    private Func<GameObject> _spawnObject;
     private GameObject _worldObject;
 
-    public WorldObjectTitleAddon(GameObject worldObject, params string[] requiredGUIDs) : base (requiredGUIDs)
+    public WorldObjectTitleAddon(Func<GameObject> spawnObject, params string[] requiredGUIDs) : base (requiredGUIDs)
     {
-        _worldObject = worldObject;
+        _spawnObject = spawnObject;
     }
 
     public override void Initialize()
     {
+        _worldObject = _spawnObject();
         UWE.CoroutineHost.StartCoroutine(SetupObjectSkyAppliers());
     }
 

--- a/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
@@ -9,8 +9,15 @@ namespace Nautilus.Handlers.TitleScreen;
 /// </summary>
 public class WorldObjectTitleAddon : TitleAddon
 {
-    private Func<GameObject> _spawnObject;
-    private GameObject _worldObject;
+    /// <summary>
+    /// The func to spawn the world object. Set in the constructor
+    /// </summary>
+    protected readonly Func<GameObject> SpawnObject;
+    
+    /// <summary>
+    /// The object that is spawned in the world and managed
+    /// </summary>
+    protected GameObject WorldObject;
 
     /// <summary>
     /// Spawns in the specified <see cref="GameObject"/> when your mod is selected.
@@ -21,7 +28,7 @@ public class WorldObjectTitleAddon : TitleAddon
     /// this addon by using <see cref="TitleScreenHandler.ApproveTitleCollaboration"/>.</param>
     public WorldObjectTitleAddon(Func<GameObject> spawnObject, params string[] requiredGUIDs) : base (requiredGUIDs)
     {
-        _spawnObject = spawnObject;
+        SpawnObject = spawnObject;
     }
 
     /// <summary>
@@ -29,7 +36,7 @@ public class WorldObjectTitleAddon : TitleAddon
     /// </summary>
     public override void Initialize()
     {
-        _worldObject = _spawnObject();
+        WorldObject = SpawnObject();
         UWE.CoroutineHost.StartCoroutine(SetupObjectSkyAppliers());
     }
 
@@ -40,7 +47,7 @@ public class WorldObjectTitleAddon : TitleAddon
         yield return new WaitUntil(() => menuLogo.logoObject);
 
         var customSky = menuLogo.logoObject.GetComponent<SkyApplier>().customSkyPrefab;
-        foreach (var applier in _worldObject.GetComponentsInChildren<SkyApplier>(true))
+        foreach (var applier in WorldObject.GetComponentsInChildren<SkyApplier>(true))
         {
             applier.customSkyPrefab = customSky;
             
@@ -53,7 +60,9 @@ public class WorldObjectTitleAddon : TitleAddon
     /// </summary>
     public override void OnEnable()
     {
-        _worldObject.SetActive(true);
+        base.OnEnable();
+        
+        WorldObject.SetActive(true);
     }
 
     /// <summary>
@@ -61,6 +70,8 @@ public class WorldObjectTitleAddon : TitleAddon
     /// </summary>
     public override void OnDisable()
     {
-        _worldObject.SetActive(false);
+        base.OnDisable();
+        
+        WorldObject.SetActive(false);
     }
 }

--- a/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
@@ -46,7 +46,7 @@ public class WorldObjectTitleAddon : TitleAddon, IManagedUpdateBehaviour
     /// <summary>
     /// Sets the correct sky appliers on the managed object.
     /// </summary>
-    public override void Initialize()
+    protected override void OnInitialize()
     {
         WorldObject = SpawnObject();
         UWE.CoroutineHost.StartCoroutine(SetupObjectSkyAppliers());
@@ -72,10 +72,8 @@ public class WorldObjectTitleAddon : TitleAddon, IManagedUpdateBehaviour
     /// <summary>
     /// Enables the managed object.
     /// </summary>
-    public override void OnEnable()
+    protected override void OnEnable()
     {
-        base.OnEnable();
-        
         BehaviourUpdateUtils.Register(this);
         _currentFadeInTime = 0;
         _fadingIn = true;
@@ -84,10 +82,8 @@ public class WorldObjectTitleAddon : TitleAddon, IManagedUpdateBehaviour
     /// <summary>
     /// Disables the managed object.
     /// </summary>
-    public override void OnDisable()
+    protected override void OnDisable()
     {
-        base.OnDisable();
-
         _fadingIn = false;
         _currentFadeInTime = 0;
     }

--- a/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/WorldObjectTitleAddon.cs
@@ -7,7 +7,7 @@ public class WorldObjectTitleAddon : TitleAddon
 {
     private GameObject _worldObject;
 
-    public WorldObjectTitleAddon(GameObject worldObject)
+    public WorldObjectTitleAddon(GameObject worldObject, params string[] requiredGUIDs) : base (requiredGUIDs)
     {
         _worldObject = worldObject;
     }

--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -86,6 +86,6 @@ public class Initializer : BaseUnityPlugin
         ModMessageSystem.Patch();
         BiomePatcher.Patch(_harmony);
         DependencyWarningPatcher.Patch(_harmony);
-        MainMenuPatcher.Patch(_harmony);
+        MainMenuPatcher.Patch(_harmony, Config);
     }
 }

--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -86,5 +86,6 @@ public class Initializer : BaseUnityPlugin
         ModMessageSystem.Patch();
         BiomePatcher.Patch(_harmony);
         DependencyWarningPatcher.Patch(_harmony);
+        MainMenuPatcher.Patch(_harmony);
     }
 }

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -196,7 +196,14 @@ internal static class MainMenuPatcher
 
                     if (addon is MusicTitleAddon)
                     {
-                        MainMenuMusic.main.evt.stop(STOP_MODE.ALLOWFADEOUT);
+                        EventInstance musicEvent;
+                        #if SN_STABLE
+                        musicEvent = MainMenuMusic.main.evt;
+                        #elif BZ_STABLE
+                        musicEvent = MainMenuMusic.main.eventMusic;
+                        #endif
+                        
+                        musicEvent.stop(STOP_MODE.ALLOWFADEOUT);
                     }
                 }
             }
@@ -218,10 +225,17 @@ internal static class MainMenuPatcher
             data.addons.Any(addon => addon is MusicTitleAddon && addon.IsEnabled));
         if (!customMusicActive)
         {
-            MainMenuMusic.main.evt.getPlaybackState(out var state);
+            EventInstance musicEvent;
+            #if SN_STABLE
+            musicEvent = MainMenuMusic.main.evt;
+            #elif BZ_STABLE
+            musicEvent = MainMenuMusic.main.eventMusic;
+            #endif
+            
+            musicEvent.getPlaybackState(out var state);
             if (state is PLAYBACK_STATE.PLAYING or PLAYBACK_STATE.SUSTAINING) return;
             
-            MainMenuMusic.main.evt.start();
+            musicEvent.start();
         }
 
         var data = TitleObjectDatas.FirstOrDefault(d => d.Value.localizationKey == choice.options[choice.currentIndex]);

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -190,7 +190,6 @@ internal static class MainMenuPatcher
                     if (!addon.IsEnabled)
                     {
                         addon.OnEnable();
-                        addon.IsEnabled = true;
                     }
 
                     if (addon is MusicTitleAddon)
@@ -206,7 +205,6 @@ internal static class MainMenuPatcher
                     if (addon.IsEnabled)
                     {
                         addon.OnDisable();
-                        addon.IsEnabled = false;
                     }
                 }
             }

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -193,7 +193,8 @@ internal static class MainMenuPatcher
                 break;
             }
 
-            if (!approvedTypes.Contains(addon.GetType()))
+            bool approvesAll = approvedTypes[0] == typeof(ApproveAllAddons);
+            if (!approvesAll && !approvedTypes.Contains(addon.GetType()))
             {
                 InternalLogger.Log(
                     $"{guid} had {addon.modGUID} listed as a collaborator, but {addon.GetType()} was not a whitelisted type. Not allowing addon to be enabled", 
@@ -214,13 +215,12 @@ internal static class MainMenuPatcher
             InternalLogger.Log($"MainMenuPatcher already contain title data for {guid}! Skipping.", LogLevel.Error);
             return;
         }
-
-        InititalizeAddons(guid, data);
         
         TitleObjectDatas.Add(guid, data);
 
         if (!_choiceOption) return;
-
+        
+        InititalizeAddons(guid, data);
         RefreshModOptions(_choiceOption);
     }
 }

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -186,9 +186,12 @@ internal static class MainMenuPatcher
                 foreach (var addon in titleData.Value.addons)
                 {
                     if (!AddonApprovedForCollab(addon)) continue;
-                    
-                    addon.OnEnable();
-                    addon.isEnabled = true;
+
+                    if (!addon.isEnabled)
+                    {
+                        addon.OnEnable();
+                        addon.isEnabled = true;
+                    }
 
                     if (addon is MusicTitleAddon)
                     {
@@ -200,8 +203,11 @@ internal static class MainMenuPatcher
             {
                 foreach (var addon in titleData.Value.addons)
                 {
-                    addon.OnDisable();
-                    addon.isEnabled = false;
+                    if (addon.isEnabled)
+                    {
+                        addon.OnDisable();
+                        addon.isEnabled = false;
+                    }
                 }
             }
             

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -96,6 +96,16 @@ internal static class MainMenuPatcher
         _choiceOption.currentText.raycastTarget = false;
         RefreshModOptions(_choiceOption);
         
+        if (TitleObjectDatas.TryGetValue(_activeModGUID, out var data))
+        {
+            int currentIndex = _choiceOption.options.IndexOf(data.localizationKey);
+            if (currentIndex >= 0)
+            {
+                _choiceOption.value = currentIndex;
+                OnActiveModChanged(_choiceOption);
+            }
+        }
+        
         Language.main.onLanguageChanged += () => UpdateButtonPositions(_choiceOption);
 
         UWE.CoroutineHost.StartCoroutine(AddButtonListeners(_choiceOption));

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -163,6 +163,8 @@ internal static class MainMenuPatcher
         
         nextButtonRect.localPosition = new Vector3(offset, nextButtonRect.localPosition.y, nextButtonRect.localPosition.z);
         prevButtonRect.localPosition = new Vector3(-offset, prevButtonRect.localPosition.y, prevButtonRect.localPosition.z);
+
+        choice.gameObject.SetActive(choice.options.Count > 1);
     }
 
     private static IEnumerator AddButtonListeners(uGUI_Choice choice)

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -150,6 +150,9 @@ internal static class MainMenuPatcher
         var prevButtonRect = choice.previousButton.GetComponent<RectTransform>();
         float offset = maxWidth * 0.5f + nextButtonRect.sizeDelta.x + 10;
         
+        // Stop buttons from going offscreen with really long mod names
+        offset = Mathf.Min(offset, 180);
+        
         nextButtonRect.localPosition = new Vector3(offset, nextButtonRect.localPosition.y, nextButtonRect.localPosition.z);
         prevButtonRect.localPosition = new Vector3(-offset, prevButtonRect.localPosition.y, prevButtonRect.localPosition.z);
     }

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -70,7 +70,7 @@ internal static class MainMenuPatcher
             {
                 if (addon is MusicTitleAddon)
                 {
-                    addon.OnDisable();
+                    addon.Disable();
                 }
             }
         }
@@ -82,7 +82,7 @@ internal static class MainMenuPatcher
         {
             addon.ModGuid = guid;
             addon.Initialize();
-            addon.OnDisable();
+            addon.Disable();
         }
     }
 
@@ -191,7 +191,7 @@ internal static class MainMenuPatcher
 
                     if (!addon.IsEnabled)
                     {
-                        addon.OnEnable();
+                        addon.Enable();
                     }
 
                     if (addon is MusicTitleAddon)
@@ -206,7 +206,7 @@ internal static class MainMenuPatcher
                 {
                     if (addon.IsEnabled)
                     {
-                        addon.OnDisable();
+                        addon.Disable();
                     }
                 }
             }

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -116,6 +116,8 @@ internal static class MainMenuPatcher
             {
                 foreach (var addon in titleData.Value.addons.Values)
                 {
+                    if (!ModsInstalledForAddon(addon)) continue;
+                    
                     addon.OnEnable();
                     addon.isEnabled = true;
 
@@ -133,16 +135,32 @@ internal static class MainMenuPatcher
                     addon.isEnabled = false;
                 }
             }
-
-            bool customMusicActive = TitleObjectDatas.Values.Any(data =>
-                data.addons.Any(addon => addon.Value is MusicTitleAddon && addon.Value.isEnabled));
-            if (!customMusicActive)
-            {
-                MainMenuMusic.main.evt.start();
-            }
             
             index++;
         }
+        
+        bool customMusicActive = TitleObjectDatas.Values.Any(data =>
+            data.addons.Any(addon => addon.Value is MusicTitleAddon && addon.Value.isEnabled));
+        if (!customMusicActive)
+        {
+            MainMenuMusic.main.evt.start();
+        }
+    }
+
+    private static bool ModsInstalledForAddon(TitleAddon addon)
+    {
+        bool hasRequiredMods = true;
+        foreach (var guid in addon.requiredGUIDs)
+        {
+            bool hasGUID = BepInEx.Bootstrap.Chainloader.PluginInfos.Keys.Contains(guid);
+            if (!hasGUID)
+            {
+                hasRequiredMods = false;
+                break;
+            }
+        }
+
+        return hasRequiredMods;
     }
 
     internal static void RegisterTitleObjectData(string guid, TitleScreenHandler.CustomTitleData data)

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -197,9 +197,9 @@ internal static class MainMenuPatcher
                     if (addon is MusicTitleAddon)
                     {
                         EventInstance musicEvent;
-                        #if SN_STABLE
+                        #if SUBNAUTICA
                         musicEvent = MainMenuMusic.main.evt;
-                        #elif BZ_STABLE
+                        #elif BELOWZERO
                         musicEvent = MainMenuMusic.main.eventMusic;
                         #endif
                         
@@ -226,9 +226,9 @@ internal static class MainMenuPatcher
         if (!customMusicActive)
         {
             EventInstance musicEvent;
-            #if SN_STABLE
+            #if SUBNAUTICA
             musicEvent = MainMenuMusic.main.evt;
-            #elif BZ_STABLE
+            #elif BELOWZERO
             musicEvent = MainMenuMusic.main.eventMusic;
             #endif
             

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -80,7 +80,7 @@ internal static class MainMenuPatcher
     {
         foreach (var addon in titleData.addons)
         {
-            addon.modGUID = guid;
+            addon.ModGuid = guid;
             addon.Initialize();
             addon.OnDisable();
         }
@@ -187,10 +187,10 @@ internal static class MainMenuPatcher
                 {
                     if (!AddonApprovedForCollab(addon)) continue;
 
-                    if (!addon.isEnabled)
+                    if (!addon.IsEnabled)
                     {
                         addon.OnEnable();
-                        addon.isEnabled = true;
+                        addon.IsEnabled = true;
                     }
 
                     if (addon is MusicTitleAddon)
@@ -203,10 +203,10 @@ internal static class MainMenuPatcher
             {
                 foreach (var addon in titleData.Value.addons)
                 {
-                    if (addon.isEnabled)
+                    if (addon.IsEnabled)
                     {
                         addon.OnDisable();
-                        addon.isEnabled = false;
+                        addon.IsEnabled = false;
                     }
                 }
             }
@@ -215,7 +215,7 @@ internal static class MainMenuPatcher
         }
         
         bool customMusicActive = TitleObjectDatas.Values.Any(data =>
-            data.addons.Any(addon => addon is MusicTitleAddon && addon.isEnabled));
+            data.addons.Any(addon => addon is MusicTitleAddon && addon.IsEnabled));
         if (!customMusicActive)
         {
             MainMenuMusic.main.evt.getPlaybackState(out var state);
@@ -233,22 +233,22 @@ internal static class MainMenuPatcher
     private static bool AddonApprovedForCollab(TitleAddon addon)
     {
         bool hasRequiredMods = true;
-        foreach (var guid in addon.requiredGUIDs)
+        foreach (var guid in addon.RequiredGUIDs)
         {
             hasRequiredMods = false;
 
             if (!CollaborationData.TryGetValue(guid, out var collabData))
             {
                 InternalLogger.Log(
-                    $"{guid} was not installed/registered for the addon {addon.GetType()} from {addon.modGUID}. Not allowing addon to be enabled", 
+                    $"{guid} was not installed/registered for the addon {addon.GetType()} from {addon.ModGuid}. Not allowing addon to be enabled", 
                     LogLevel.Debug);
                 break;
             }
 
-            if (!collabData.modApprovedAddons.TryGetValue(addon.modGUID, out var approvedTypes))
+            if (!collabData.modApprovedAddons.TryGetValue(addon.ModGuid, out var approvedTypes))
             {
                 InternalLogger.Log(
-                    $"{guid} did not have {addon.modGUID} listed as a collaborator. Not allowing {addon.GetType()} to be enabled", 
+                    $"{guid} did not have {addon.ModGuid} listed as a collaborator. Not allowing {addon.GetType()} to be enabled", 
                     LogLevel.Debug);
                 break;
             }
@@ -257,7 +257,7 @@ internal static class MainMenuPatcher
             if (!approvesAll && !approvedTypes.Contains(addon.GetType()))
             {
                 InternalLogger.Log(
-                    $"{guid} had {addon.modGUID} listed as a collaborator, but {addon.GetType()} was not a whitelisted type. Not allowing addon to be enabled", 
+                    $"{guid} had {addon.ModGuid} listed as a collaborator, but {addon.GetType()} was not a whitelisted type. Not allowing addon to be enabled", 
                     LogLevel.Debug);
                 break;
             }

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -1,0 +1,121 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using BepInEx.Logging;
+using HarmonyLib;
+using Nautilus.Handlers.TitleScreen;
+using Nautilus.Utility;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Nautilus.Patchers;
+
+internal static class MainMenuPatcher
+{
+    internal static readonly SelfCheckingDictionary<string, TitleScreenHandler.CustomTitleData> TitleObjectDatas = new("TitleObjectData");
+
+    private static string _activeModGUID;
+    
+    internal static void Patch(Harmony harmony)
+    {
+        harmony.Patch(AccessTools.Method(typeof(uGUI_MainMenu), nameof(uGUI_MainMenu.Awake)),
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(MainMenuPatcher), nameof(MainMenuPatcher.AwakePostfix))));
+
+        harmony.Patch(AccessTools.Method(typeof(uGUI_MainMenu), nameof(uGUI_MainMenu.Start)),
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(MainMenuPatcher), nameof(MainMenuPatcher.StartPostfix))));
+        
+        InternalLogger.Log("MainMenuPatcher is done.", LogLevel.Debug);
+    }
+
+    private static void AwakePostfix()
+    {
+        foreach (var titleObjectData in TitleObjectDatas.Values)
+        {
+            foreach (var addon in titleObjectData.addons)
+            {
+                addon.Value.Initialize();
+                addon.Value.OnDisable();
+            }
+        }
+    }
+
+    private static void StartPostfix(uGUI_MainMenu __instance)
+    {
+        CreateSelectionUI(__instance);
+    }
+
+    private static void CreateSelectionUI(uGUI_MainMenu mainMenu)
+    {
+        var optionsMenu = mainMenu.GetComponentInChildren<uGUI_OptionsPanel>(true);
+        var background = optionsMenu.choiceOptionPrefab.transform.Find("Choice/Background");
+        
+        var selector = GameObject.Instantiate(background, mainMenu.transform, false);
+        selector.gameObject.name = "ActiveModSelector";
+        selector.localPosition = new Vector3(-750, -450, 0);
+
+        var choice = selector.GetComponent<uGUI_Choice>();
+        List<string> options = new() { "Subnautica" };
+        foreach (var titleData in TitleObjectDatas.Values)
+        {
+            options.Add(titleData.localizationKey);
+        }
+        
+        choice.SetOptions(options.ToArray());
+
+        float maxWidth = float.MinValue;
+        choice.currentText.transform.localPosition = Vector3.zero;
+        for (int i = 0; i <= choice.options.Count; i++)
+        {
+            if (choice.currentText.preferredWidth > maxWidth)
+            {
+                maxWidth = choice.currentText.preferredWidth;
+            }
+
+            choice.NextChoice();
+        }
+        
+        var nextButtonRect = choice.nextButton.GetComponent<RectTransform>();
+        var prevButtonRect = choice.previousButton.GetComponent<RectTransform>();
+        float offset = maxWidth * 0.5f + nextButtonRect.sizeDelta.x + 10;
+        
+        nextButtonRect.localPosition = new Vector3(offset, nextButtonRect.localPosition.y, nextButtonRect.localPosition.z);
+        prevButtonRect.localPosition = new Vector3(-offset, prevButtonRect.localPosition.y, prevButtonRect.localPosition.z);
+
+        UWE.CoroutineHost.StartCoroutine(AddButtonListeners(choice));
+    }
+
+    private static IEnumerator AddButtonListeners(uGUI_Choice choice)
+    {
+        yield return new WaitForEndOfFrame();
+        
+        var nextButton = choice.nextButton.GetComponent<Button>();
+        var prevButton = choice.previousButton.GetComponent<Button>();
+        
+        nextButton.onClick.AddListener(() => OnActiveModChanged(choice));
+        prevButton.onClick.AddListener(() => OnActiveModChanged(choice));
+    }
+
+    internal static void OnActiveModChanged(uGUI_Choice choice)
+    {
+        int index = 0;
+        foreach (var titleData in TitleObjectDatas)
+        {
+            if (index == choice.currentIndex - 1)
+            {
+                foreach (var addon in titleData.Value.addons.Values)
+                {
+                    addon.OnEnable();
+                }
+            }
+            else
+            {
+                foreach (var addon in titleData.Value.addons.Values)
+                {
+                    addon.OnDisable();
+                }
+            }
+            
+            index++;
+        }
+    }
+}


### PR DESCRIPTION
### Changes made in this pull request

  - Allows mods to add custom additions to the main menu, such as custom objects and music, which are only enabled when that mod is selected as the current "theme"
  - Add a theme selection option in the bottom left of the main menu
  - Allow mods to add custom loading screens, with story goal or custom requirements that are enabled when the mod registering the screens is the current theme
  - Allow mods to only have certain main menu additions appear when another mod is installed, and that mod approves the additions

### Breaking changes

  - None