### PR TITLE
Title registration rework

### DIFF
--- a/Nautilus/Handlers/LoadingScreen/LoadingScreenHandler.cs
+++ b/Nautilus/Handlers/LoadingScreen/LoadingScreenHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using BepInEx;
 using UnityEngine;
 
@@ -12,11 +13,11 @@ public static class LoadingScreenHandler
     /// <summary>
     /// Register loading screens with Nautilus. Note that custom loading screens will only appear when your mod is selected as the current theme
     /// </summary>
-    /// <param name="plugin">The plugin registering the loading screens</param>
+    /// <param name="titleAddonKey">The key used when registering the TitleScreenHandler.CollaborationData that should control this loading screen</param>
     /// <param name="loadingScreenDatas">The loading screens to register</param>
-    public static void RegisterLoadingScreen(BaseUnityPlugin plugin, LoadingScreenData[] loadingScreenDatas)
+    public static void RegisterLoadingScreen(string titleAddonKey, LoadingScreenData[] loadingScreenDatas)
     {
-        LoadingScreenSetter.LoadingScreenDatas.Add(plugin.Info.Metadata.GUID, loadingScreenDatas);
+        LoadingScreenSetter.LoadingScreenDatas.Add($"{Assembly.GetCallingAssembly().FullName}_{titleAddonKey}", loadingScreenDatas);
     }
 
     /// <summary>

--- a/Nautilus/Handlers/LoadingScreen/LoadingScreenHandler.cs
+++ b/Nautilus/Handlers/LoadingScreen/LoadingScreenHandler.cs
@@ -17,7 +17,7 @@ public static class LoadingScreenHandler
     /// <param name="loadingScreenDatas">The loading screens to register</param>
     public static void RegisterLoadingScreen(string titleAddonKey, LoadingScreenData[] loadingScreenDatas)
     {
-        LoadingScreenSetter.LoadingScreenDatas.Add($"{Assembly.GetCallingAssembly().FullName}_{titleAddonKey}", loadingScreenDatas);
+        LoadingScreenSetter.LoadingScreenDatas.Add($"{Assembly.GetCallingAssembly().GetName().Name}_{titleAddonKey}", loadingScreenDatas);
     }
 
     /// <summary>

--- a/Nautilus/Handlers/TitleScreen/SkyChangeTitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/SkyChangeTitleAddon.cs
@@ -71,6 +71,19 @@ public class SkyChangeTitleAddon : TitleAddon, IManagedUpdateBehaviour
         }
     }
 
+    protected override void OnEnterLoadScreen()
+    {
+        _transitionActive = false;
+        var skyManager = uSkyManager.main;
+        if (skyManager == null)
+            return;
+
+        skyManager.Timeline = _defaultSettings.Value.TimeOfDay;
+        skyManager.Exposure = _defaultSettings.Value.Exposure;
+        skyManager.RayleighScattering = _defaultSettings.Value.RayleighScattering;
+        skyManager.skyFogDensity = _defaultSettings.Value.FogDensity;
+    }
+
     /// <summary>
     /// Called every frame while registered.
     /// </summary>

--- a/Nautilus/Handlers/TitleScreen/TitleAddon.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleAddon.cs
@@ -54,6 +54,11 @@ public abstract class TitleAddon
         IsEnabled = false;
         OnDisable();
     }
+
+    internal void CleanupUponLoadScreen()
+    {
+        OnEnterLoadScreen();
+    }
     
     /// <summary>
     /// Runs initialization code once before the main menu is loaded to set up required fields.
@@ -64,6 +69,11 @@ public abstract class TitleAddon
     /// Called when the addon is enabled. This occurs when your mod is selected as the current theme.
     /// </summary>
     protected abstract void OnEnable();
+
+    /// <summary>
+    /// Is called when the player clicks on a save, and the loading screen is enabled.
+    /// </summary>
+    protected virtual void OnEnterLoadScreen() { }
 
     /// <summary>
     /// Called when the addon is disabled. This occurs when your mod is deselected as the current theme, or

--- a/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
@@ -18,7 +18,7 @@ public static class TitleScreenHandler
     /// <param name="customTitleData">The custom title data for your additions.</param>
     public static void RegisterTitleScreenObject(string key, CustomTitleData customTitleData)
     {
-        MainMenuPatcher.RegisterTitleObjectData($"{Assembly.GetCallingAssembly().FullName}_{key}", customTitleData);
+        MainMenuPatcher.RegisterTitleObjectData($"{Assembly.GetCallingAssembly().GetName().Name}_{key}", customTitleData);
     }
 
     /// <summary>

--- a/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
+++ b/Nautilus/Handlers/TitleScreen/TitleScreenHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using BepInEx;
 using Nautilus.Patchers;
 
@@ -13,11 +14,11 @@ public static class TitleScreenHandler
     /// <summary>
     /// Register title screen additions with Nautilus for automatic handling.
     /// </summary>
-    /// <param name="plugin">The plugin for your mod.</param>
+    /// <param name="key">The key for your custom title data. Must be unique.</param>
     /// <param name="customTitleData">The custom title data for your additions.</param>
-    public static void RegisterTitleScreenObject(BaseUnityPlugin plugin, CustomTitleData customTitleData)
+    public static void RegisterTitleScreenObject(string key, CustomTitleData customTitleData)
     {
-        MainMenuPatcher.RegisterTitleObjectData(plugin.Info.Metadata.GUID, customTitleData);
+        MainMenuPatcher.RegisterTitleObjectData($"{Assembly.GetCallingAssembly().FullName}_{key}", customTitleData);
     }
 
     /// <summary>

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -38,6 +38,9 @@ internal static class MainMenuPatcher
 
         harmony.Patch(AccessTools.Method(typeof(uGUI_MainMenu), nameof(uGUI_MainMenu.Start)),
             postfix: new HarmonyMethod(AccessTools.Method(typeof(MainMenuPatcher), nameof(StartPostfix))));
+        
+        harmony.Patch(AccessTools.Method(typeof(uGUI_MainMenu), nameof(uGUI_MainMenu.StartNewGame)),
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(MainMenuPatcher), nameof(StartNewGamePostfix))));
 
         harmony.Patch(AccessTools.Method(typeof(uGUI_SceneLoading), nameof(uGUI_SceneLoading.Awake)),
             postfix: new HarmonyMethod(AccessTools.Method(typeof(MainMenuPatcher), nameof(SceneLoadingAwakePostfix))));
@@ -89,6 +92,14 @@ internal static class MainMenuPatcher
     private static void StartPostfix(uGUI_MainMenu __instance)
     {
         CreateSelectionUI(__instance);
+    }
+
+    private static void StartNewGamePostfix()
+    {
+        foreach (var addon in TitleObjectDatas[_activeModGuid.Value].addons)
+        {
+            addon.CleanupUponLoadScreen();
+        }
     }
 
     private static void CreateSelectionUI(uGUI_MainMenu mainMenu)

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -282,19 +282,19 @@ internal static class MainMenuPatcher
         return hasRequiredMods;
     }
 
-    internal static void RegisterTitleObjectData(string guid, TitleScreenHandler.CustomTitleData data)
+    internal static void RegisterTitleObjectData(string key, TitleScreenHandler.CustomTitleData data)
     {
-        if (TitleObjectDatas.ContainsKey(guid))
+        if (TitleObjectDatas.ContainsKey(key))
         {
-            InternalLogger.Log($"MainMenuPatcher already contain title data for {guid}! Skipping.", LogLevel.Error);
+            InternalLogger.Log($"MainMenuPatcher already contain title data for {key}! Skipping.", LogLevel.Error);
             return;
         }
         
-        TitleObjectDatas.Add(guid, data);
+        TitleObjectDatas.Add(key, data);
 
         if (!_choiceOption) return;
         
-        InitializeAddons(guid, data);
+        InitializeAddons(key, data);
         RefreshModOptions(_choiceOption);
     }
 

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -40,7 +40,10 @@ internal static class MainMenuPatcher
             postfix: new HarmonyMethod(AccessTools.Method(typeof(MainMenuPatcher), nameof(StartPostfix))));
         
         harmony.Patch(AccessTools.Method(typeof(uGUI_MainMenu), nameof(uGUI_MainMenu.StartNewGame)),
-            postfix: new HarmonyMethod(AccessTools.Method(typeof(MainMenuPatcher), nameof(StartNewGamePostfix))));
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(MainMenuPatcher), nameof(CallAddonCleanups))));
+        
+        harmony.Patch(AccessTools.Method(typeof(uGUI_MainMenu), nameof(uGUI_MainMenu.LoadGameAsync)),
+            postfix: new HarmonyMethod(AccessTools.Method(typeof(MainMenuPatcher), nameof(CallAddonCleanups))));
 
         harmony.Patch(AccessTools.Method(typeof(uGUI_SceneLoading), nameof(uGUI_SceneLoading.Awake)),
             postfix: new HarmonyMethod(AccessTools.Method(typeof(MainMenuPatcher), nameof(SceneLoadingAwakePostfix))));
@@ -94,9 +97,11 @@ internal static class MainMenuPatcher
         CreateSelectionUI(__instance);
     }
 
-    private static void StartNewGamePostfix()
+    private static void CallAddonCleanups()
     {
-        foreach (var addon in TitleObjectDatas[_activeModGuid.Value].addons)
+        if (!TitleObjectDatas.TryGetValue(_activeModGuid.Value, out var titleData)) return;
+        
+        foreach (var addon in titleData.addons)
         {
             addon.CleanupUponLoadScreen();
         }


### PR DESCRIPTION
### Changes made in this pull request

  - Change title addon registration system to allow mods to register more than one "CustomTitleData" per mod
  - Add method for cleaning up addons when the loading screen appears
  - Make the SkyChangeTitleAddon reset the sky when entering the loading screen

### Breaking changes

  - Mods that use the current registration system will need to update their mods to work with the new system
  E.g. `TitleScreenHandler.RegisterTitleScreenObject("this, customData);` => `TitleScreenHandler.RegisterTitleScreenObject("MyTitleData", customData);`