### PR TITLE
fix: async saved JSON files weren't overwritten...

### DIFF
--- a/Nautilus/Utility/JsonUtils.cs
+++ b/Nautilus/Utility/JsonUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -309,7 +309,7 @@ public static class JsonUtils
 
         FileInfo fileInfo = new(path);
         fileInfo.Directory.Create();
-        using var writer = new StreamWriter(File.OpenWrite(path));
+        using var writer = new StreamWriter(File.Open(path, FileMode.Create, FileAccess.Write, FileShare.Read));
         await writer.WriteAsync(json);
     }
 


### PR DESCRIPTION
...but rather, the contents were replaced - which meant old data could still exist in the file post-save.   Not an issue with the parser used, but leads to excessive file size as well as confusion for mod creators.

### Changes made in this pull request

  - `JsonUtils.SaveAsync<T>(...)`: Changed `File.OpenWrite(path)` to `File.Open(path, FileMode.Create, FileAccess.Write, FileShare.Read)`, which completely overwrites the JSON file instead of replacing its data (and leaving old data in, if the new data is smaller than the old data). ([`File.OpenWrite`](https://learn.microsoft.com/en-us/dotnet/api/system.io.file.openwrite?view=net-9.0) is equivalent to using [`FileMode.OpenOrCreate`](https://learn.microsoft.com/en-us/dotnet/api/system.io.filemode?view=net-9.0))

### Breaking changes

  - Old data is no longer stored in the file, which has been happening for exactly one release (`pre39`) and probably not used by anything