### PR TITLE
Fix custom background icons not being circular

### DIFF
--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_BackgroundType.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_BackgroundType.cs
@@ -18,9 +18,7 @@ public static partial class EnumExtensions
     /// <remarks>This overload always registers background icons with a circular background.</remarks>
     public static EnumBuilder<CraftData.BackgroundType> WithBackground(this EnumBuilder<CraftData.BackgroundType> builder, Sprite backgroundSprite)
     {
-        BackgroundSprites[builder] = backgroundSprite;
-        Splice9GridBackgroundSprites.Add(backgroundSprite);
-        return builder;
+        return WithBackground(builder, backgroundSprite, true);
     }
     
     /// <summary>

--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_BackgroundType.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_BackgroundType.cs
@@ -7,6 +7,7 @@ namespace Nautilus.Handlers;
 public static partial class EnumExtensions
 {
     internal static readonly Dictionary<CraftData.BackgroundType, Sprite> BackgroundSprites = new();
+    internal static readonly HashSet<Sprite> Splice9GridBackgroundSprites = new();
 
     /// <summary>
     /// Adds a sprite for this instance.
@@ -14,9 +15,29 @@ public static partial class EnumExtensions
     /// <param name="builder">The current custom enum object instance</param>
     /// <param name="backgroundSprite">The sprite to add for this instance.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <remarks>This overload always registers background icons with a circular background.</remarks>
     public static EnumBuilder<CraftData.BackgroundType> WithBackground(this EnumBuilder<CraftData.BackgroundType> builder, Sprite backgroundSprite)
     {
         BackgroundSprites[builder] = backgroundSprite;
+        Splice9GridBackgroundSprites.Add(backgroundSprite);
+        return builder;
+    }
+    
+    /// <summary>
+    /// Adds a sprite for this instance.
+    /// </summary>
+    /// <param name="builder">The current custom enum object instance</param>
+    /// <param name="backgroundSprite">The sprite to add for this instance.</param>
+    /// <param name="useCircularIcon">If true, the 'splice 9' setting will be applied, allowing tall rectangular
+    /// sprites (usually 2x23) to become circular.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static EnumBuilder<CraftData.BackgroundType> WithBackground(this EnumBuilder<CraftData.BackgroundType> builder, Sprite backgroundSprite, bool useCircularIcon)
+    {
+        BackgroundSprites[builder] = backgroundSprite;
+        if (useCircularIcon)
+        {
+            Splice9GridBackgroundSprites.Add(backgroundSprite);   
+        }
         return builder;
     }
 }

--- a/Nautilus/Patchers/SpritePatcher.cs
+++ b/Nautilus/Patchers/SpritePatcher.cs
@@ -38,10 +38,14 @@ internal class SpritePatcher
         MethodInfo spriteManagerGet = AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.Get), new Type[] { typeof(SpriteManager.Group), typeof(string), typeof(Sprite) });
         MethodInfo spriteManagerGetBackground = AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.GetBackground), new Type[] { typeof(CraftData.BackgroundType) });
 
-        HarmonyMethod patchCheck = new(AccessTools.Method(typeof(SpritePatcher), nameof(SpritePatcher.PatchCheck)));
+        HarmonyMethod patchCheck = new(AccessTools.Method(typeof(SpritePatcher), nameof(PatchCheck)));
         HarmonyMethod patchBackgrounds = new(AccessTools.Method(typeof(SpritePatcher), nameof(PatchBackgrounds)));
         harmony.Patch(spriteManagerGet, prefix: patchCheck);
         harmony.Patch(spriteManagerGetBackground, prefix: patchBackgrounds);
+        
+        MethodInfo originalSplice9Method = AccessTools.Method(typeof(SpriteManager), nameof(SpriteManager.GetProceduralSlice9Grid));
+        HarmonyMethod patchSplice9 = new(AccessTools.Method(typeof(SpritePatcher), nameof(PatchGetProceduralSlice9Grid)));
+        harmony.Patch(originalSplice9Method, postfix: patchSplice9);
     }
 
     private static void PatchSprites()
@@ -82,6 +86,14 @@ internal class SpritePatcher
             return false;
         }
         return true;
+    }
+    
+    private static void PatchGetProceduralSlice9Grid(Sprite sprite, ref bool __result)
+    {
+        if (!__result && EnumExtensions.Splice9GridBackgroundSprites.Contains(sprite))
+        {
+            __result = true;
+        }
     }
 
     private static Dictionary<string, Sprite> GetSpriteAtlas(SpriteManager.Group groupKey)


### PR DESCRIPTION
### Changes made in this pull request

  - Custom background type icons are now circular by default for both games.
  - Added a new overload to `BackgroundType.WithBackground` that allows for non-circular background type icons.

### Breaking changes

  - Non-circular background sprites are circular now until the new overload is used.