### PR TITLE
Very important feature: EggGadget pickup sound support

### DIFF
--- a/Nautilus/Assets/Gadgets/EggGadget.cs
+++ b/Nautilus/Assets/Gadgets/EggGadget.cs
@@ -1,4 +1,5 @@
 ﻿using Nautilus.Extensions;
+using Nautilus.Handlers;
 using Nautilus.Patchers;
 using Nautilus.Utility;
 
@@ -23,6 +24,11 @@ public class EggGadget : Gadget
     /// makes the egg immune to the Lost River's Acidic Brine.
     /// </summary>
     public bool AcidImmune { get; set; } = true;
+
+    /// <summary>
+    /// The sound that plays when picking up the egg.
+    /// </summary>
+    public string PickupSound { get; set; } = "event:/loot/pickup_egg";
 
     /// <summary>
     /// Constructs a Creature egg gadget instance.
@@ -70,6 +76,18 @@ public class EggGadget : Gadget
 
         return this;
     }
+    
+    /// <summary>
+    /// Sets the pickup sound for the egg.
+    /// </summary>
+    /// <param name="pickupSound">The sound that plays when picking up the egg.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public EggGadget SetPickupSound(string pickupSound)
+    {
+        PickupSound = pickupSound;
+
+        return this;
+    }
 
     /// <inheritdoc/>
     protected internal override void Build()
@@ -82,6 +100,9 @@ public class EggGadget : Gadget
         
         if (AcidImmune)
             DamageSystem.acidImmune.Add(prefab.Info.TechType);
+
+        if (!string.IsNullOrEmpty(PickupSound))
+            CraftDataHandler.SetPickupSound(prefab.Info.TechType, PickupSound);
 
         WaterParkPatcher.requiredAcuSize[prefab.Info.TechType] = this;
     }

--- a/Nautilus/Assets/Gadgets/EggGadget.cs
+++ b/Nautilus/Assets/Gadgets/EggGadget.cs
@@ -80,7 +80,7 @@ public class EggGadget : Gadget
     /// <summary>
     /// Sets the pickup sound for the egg.
     /// </summary>
-    /// <param name="pickupSound">The sound that plays when picking up the egg.</param>
+    /// <param name="pickupSound">The FMOD sound event path that plays when picking up the egg.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
     public EggGadget SetPickupSound(string pickupSound)
     {


### PR DESCRIPTION
### Changes made in this pull request

  - Added the `PickupSound` property and `SetPickupSound` fluent syntax method to the EggGadget.
  - Eggs now have the `event:/loot/pickup_egg` pickup sound by default.

### Breaking changes

  - This is only a breaking change for those who prefer the default item pickup sound over the egg pickup sound