### PR TITLE
Unity input system support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
             - name: .NET Setup
               uses: actions/setup-dotnet@v3
               with:
-                  dotnet-version: 7.x
+                  dotnet-version: 8.x
               
             - name: Build Project
               run: dotnet build Nautilus.sln -c SN.STABLE         
@@ -28,7 +28,7 @@ jobs:
             -   name: .NET Setup
                 uses: actions/setup-dotnet@v3
                 with:
-                    dotnet-version: 7.x
+                    dotnet-version: 8.x
 
             -   name: Build Project
                 run: dotnet build Nautilus.sln -c BZ.STABLE

--- a/Example mod/ConfigExamples.cs
+++ b/Example mod/ConfigExamples.cs
@@ -185,6 +185,7 @@ public class Config : ConfigFile
     [Choice("My customised enum-based choice", "1", "2", "3"), OnChange(nameof(MyChoiceValueChangedEvent))]
     public CustomChoice ChoiceCustomEnum;
 
+#if BELOWZERO
     /// <summary>
     /// <para>A <see cref="KeybindAttribute"/> is represented in the mod options menu as a customistable keybind, where the
     /// user clicks the box to set the binding, stored as a <see cref="KeyCode"/>.</para>
@@ -193,6 +194,7 @@ public class Config : ConfigFile
     /// </summary>
     [Keybind("My keybind"), OnChange(nameof(MyKeybindValueChangedEvent))]
     public KeyCode KeybindKey;
+#endif
 
     /// <summary>
     /// <para>A <see cref="SliderAttribute"/> is used to represent a numeric value as a slider in the options menu, with a
@@ -279,12 +281,13 @@ public class Config : ConfigFile
         ConfigExamples.LogSource.LogInfo($"Choice value {e.Id} was changed: {choice}");
     }
 
+#if BELOWZERO
     private void MyKeybindValueChangedEvent(KeybindChangedEventArgs e)
     {
         KeyCode keyCode = e.Value;
         ConfigExamples.LogSource.LogInfo($"Keybind value {e.Id} was changed: {keyCode}");
     }
-
+#endif
     private void MySliderValueChangedEvent(SliderChangedEventArgs e)
     {
         float floatValue = e.Value;

--- a/Example mod/InputExample.cs
+++ b/Example mod/InputExample.cs
@@ -33,6 +33,12 @@ public class InputExample : BaseUnityPlugin
         .AvoidConflicts(GameInput.Device.Keyboard)
         .WithCategory("NautilusExampleLogCategory");
 
+    private GameInput.Button UncategorizedButton = EnumHandler.AddEntry<GameInput.Button>("UncategorizedButton")
+        .CreateInput()
+        .WithKeyboardBinding("<Keyboard>/i")
+        .WithControllerBinding("<Gamepad>/dpad/down")
+        .AvoidConflicts(GameInput.Device.Keyboard);
+
     private void Awake()
     {
         LanguageHandler.RegisterLocalizationFolder();

--- a/Example mod/InputExample.cs
+++ b/Example mod/InputExample.cs
@@ -1,0 +1,39 @@
+﻿#if SUBNAUTICA
+using System;
+using System.IO;
+using BepInEx;
+using Nautilus.Handlers;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace Nautilus.Examples;
+
+[BepInPlugin("com.snmodding.nautilus.inputexample", "Nautilus Input Example Mod", Nautilus.PluginInfo.PLUGIN_VERSION)]
+[BepInDependency("com.snmodding.nautilus")]
+public class InputExample : BaseUnityPlugin
+{
+    private GameInput.Button PrintButton = EnumHandler.AddEntry<GameInput.Button>("MyPrint")
+        .CreateInput()
+        .WithKeyboardBinding("<Keyboard>/l", "<Keyboard>/z")
+        .WithControllerBinding("<Gamepad>/dpad/right")
+        .SetAsBindable(GameInput.Device.Keyboard, GameInput.Device.Controller);
+
+    private void Awake()
+    {
+        LanguageHandler.RegisterLocalizationFolder();
+    }
+
+    private void Update()
+    {
+        if (!GameInput.IsInitialized)
+        {
+            return;
+        }
+        
+        if (GameInput.GetButtonDown(PrintButton))
+        {
+            ErrorMessage.AddDebug("Button was pressed!");
+        }
+    }
+}
+#endif

--- a/Example mod/InputExample.cs
+++ b/Example mod/InputExample.cs
@@ -16,7 +16,22 @@ public class InputExample : BaseUnityPlugin
         .CreateInput()
         .WithKeyboardBinding("<Keyboard>/l", "<Keyboard>/z")
         .WithControllerBinding("<Gamepad>/dpad/right")
-        .AvoidConflicts(GameInput.Device.Keyboard);
+        .AvoidConflicts(GameInput.Device.Keyboard)
+        .WithCategory("NautilusExamplePrintCategory");
+    
+    private GameInput.Button PrintHelloButton = EnumHandler.AddEntry<GameInput.Button>("PrintHello")
+        .CreateInput()
+        .WithKeyboardBinding("<Keyboard>/r")
+        .WithControllerBinding("<Gamepad>/dpad/left")
+        .AvoidConflicts(GameInput.Device.Keyboard)
+        .WithCategory("NautilusExamplePrintCategory");
+
+    private GameInput.Button LogButton = EnumHandler.AddEntry<GameInput.Button>("MyLog")
+        .CreateInput()
+        .WithKeyboardBinding("<Keyboard>/l")
+        .WithControllerBinding("<Gamepad>/dpad/up")
+        .AvoidConflicts(GameInput.Device.Keyboard)
+        .WithCategory("NautilusExampleLogCategory");
 
     private void Awake()
     {
@@ -32,7 +47,17 @@ public class InputExample : BaseUnityPlugin
         
         if (GameInput.GetButtonDown(PrintButton))
         {
-            ErrorMessage.AddDebug("Button was pressed!");
+            ErrorMessage.AddDebug("Button 1 was pressed!");
+        }
+        
+        if (GameInput.GetButtonDown(PrintHelloButton))
+        {
+            ErrorMessage.AddDebug("Button 2 was pressed!");
+        }
+        
+        if (GameInput.GetButtonDown(LogButton))
+        {
+            Logger.LogMessage("Log button was pressed!");
         }
     }
 }

--- a/Example mod/InputExample.cs
+++ b/Example mod/InputExample.cs
@@ -15,7 +15,8 @@ public class InputExample : BaseUnityPlugin
     private GameInput.Button PrintButton = EnumHandler.AddEntry<GameInput.Button>("MyPrint")
         .CreateInput()
         .WithKeyboardBinding("<Keyboard>/l", "<Keyboard>/z")
-        .WithControllerBinding("<Gamepad>/dpad/right");
+        .WithControllerBinding("<Gamepad>/dpad/right")
+        .AvoidConflicts(GameInput.Device.Keyboard);
 
     private void Awake()
     {

--- a/Example mod/InputExample.cs
+++ b/Example mod/InputExample.cs
@@ -15,8 +15,7 @@ public class InputExample : BaseUnityPlugin
     private GameInput.Button PrintButton = EnumHandler.AddEntry<GameInput.Button>("MyPrint")
         .CreateInput()
         .WithKeyboardBinding("<Keyboard>/l", "<Keyboard>/z")
-        .WithControllerBinding("<Gamepad>/dpad/right")
-        .SetAsBindable(GameInput.Device.Keyboard, GameInput.Device.Controller);
+        .WithControllerBinding("<Gamepad>/dpad/right");
 
     private void Awake()
     {

--- a/Example mod/InputExample.cs
+++ b/Example mod/InputExample.cs
@@ -21,8 +21,8 @@ public class InputExample : BaseUnityPlugin
     
     private GameInput.Button PrintHelloButton = EnumHandler.AddEntry<GameInput.Button>("PrintHello")
         .CreateInput()
-        .WithKeyboardBinding("<Keyboard>/r")
-        .WithControllerBinding("<Gamepad>/dpad/left")
+        .WithKeyboardBinding(GameInputHandler.Paths.Keyboard.R)
+        .WithControllerBinding(GameInputHandler.Paths.Gamepad.DpadLeft)
         .AvoidConflicts(GameInput.Device.Keyboard)
         .WithCategory("NautilusExamplePrintCategory");
 

--- a/Example mod/Localization/English.json
+++ b/Example mod/Localization/English.json
@@ -5,5 +5,6 @@
   "OptionPrintHello": "Print hello",
   "OptionMyLog": "Print to log",
   "NautilusExamplePrintCategory": "Print binds",
-  "NautilusExampleLogCategory": "Log binds"
+  "NautilusExampleLogCategory": "Log binds",
+  "UncategorizedButton": "Useless button"
 }

--- a/Example mod/Localization/English.json
+++ b/Example mod/Localization/English.json
@@ -1,4 +1,5 @@
 ﻿{
   "TitaniumClone": "Titanium Clone",
-  "Tooltip_TitaniumClone": "Titanium clone that makes me go yes."
+  "Tooltip_TitaniumClone": "Titanium clone that makes me go yes.",
+  "OptionMyPrint": "My Print"
 }

--- a/Example mod/Localization/English.json
+++ b/Example mod/Localization/English.json
@@ -1,5 +1,9 @@
 ﻿{
   "TitaniumClone": "Titanium Clone",
   "Tooltip_TitaniumClone": "Titanium clone that makes me go yes.",
-  "OptionMyPrint": "My Print"
+  "OptionMyPrint": "My Print",
+  "OptionPrintHello": "Print hello",
+  "OptionMyLog": "Print to log",
+  "NautilusExamplePrintCategory": "Print binds",
+  "NautilusExampleLogCategory": "Log binds"
 }

--- a/Example mod/Localization/English.json
+++ b/Example mod/Localization/English.json
@@ -6,5 +6,5 @@
   "OptionMyLog": "Print to log",
   "NautilusExamplePrintCategory": "Print binds",
   "NautilusExampleLogCategory": "Log binds",
-  "UncategorizedButton": "Useless button"
+  "OptionUncategorizedButton": "Useless button"
 }

--- a/Example mod/Localization/Spanish.json
+++ b/Example mod/Localization/Spanish.json
@@ -1,4 +1,5 @@
 ﻿{
   "TitaniumClone": "Clon de Titanio",
-  "Tooltip_TitaniumClone": "Clon de Titanio que me hace decir que sí"
+  "Tooltip_TitaniumClone": "Clon de Titanio que me hace decir que sí",
+  "OptionMyPrint": "Mi impresión"
 }

--- a/Example mod/Localization/Spanish.json
+++ b/Example mod/Localization/Spanish.json
@@ -1,5 +1,10 @@
 ﻿{
   "TitaniumClone": "Clon de Titanio",
   "Tooltip_TitaniumClone": "Clon de Titanio que me hace decir que sí",
-  "OptionMyPrint": "Mi impresión"
+  "OptionMyPrint": "Mi impresión",
+  "OptionPrintHello": "Imprimir 'hello'",
+  "OptionMyLog": "Escribir en el log",
+  "NautilusExamplePrintCategory": "Imprimir",
+  "NautilusExampleLogCategory": "Log",
+  "OptionUncategorizedButton": "Botón inútil"
 }

--- a/Nautilus/Handlers/Enums/EnumBuilder.cs
+++ b/Nautilus/Handlers/Enums/EnumBuilder.cs
@@ -67,30 +67,11 @@ public sealed class EnumBuilder<TEnum> where TEnum : Enum
         var builder = new EnumBuilder<TEnum>();
         if(builder.TryAddEnum(name, addedBy, out TEnum enumValue))
         {
-            ProcessExtraActions(builder);
             return builder;
         }
 
         InternalLogger.Announce($"{name} already exists in {nameof(TEnum)}!", LogLevel.Error, true);
         return null;
-    }
-
-    private static void ProcessExtraActions(EnumBuilder<TEnum> builder)
-    {
-        switch(builder)
-        {
-            case EnumBuilder<TechType> techTypeBuilder:
-                var techType = techTypeBuilder.Value;
-                var name = techType.ToString();
-                var intKey = ((int)techType).ToString();
-                TechTypeExtensions.stringsNormal[techType] = name;
-                TechTypeExtensions.stringsLowercase[techType] = name.ToLowerInvariant();
-                TechTypeExtensions.techTypesNormal[name] = techType;
-                TechTypeExtensions.techTypesIgnoreCase[name] = techType;
-                TechTypeExtensions.techTypeKeys[techType] = intKey;
-                TechTypeExtensions.keyTechTypes[intKey] = techType;
-                break;
-        }
     }
 
     private bool TryAddEnum(string name, Assembly addedBy, out TEnum enumValue)

--- a/Nautilus/Handlers/Enums/EnumHandler.cs
+++ b/Nautilus/Handlers/Enums/EnumHandler.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using Nautilus.Utility;
 
-// Resharper
+// ReSharper disable once CheckNamespace
 namespace Nautilus.Handlers;
 
 /// <summary>

--- a/Nautilus/Handlers/Enums/EnumHandler.cs
+++ b/Nautilus/Handlers/Enums/EnumHandler.cs
@@ -37,7 +37,13 @@ public static class EnumHandler
     /// <returns>A reference to the created custom enum object or if the name is already in use it will return null</returns>
     public static EnumBuilder<TEnum> AddEntry<TEnum>(string name, Assembly ownerAssembly) where TEnum : Enum
     {
-        return EnumBuilder<TEnum>.CreateInstance(name, ownerAssembly);
+        var builder =  EnumBuilder<TEnum>.CreateInstance(name, ownerAssembly);
+        if (builder is not null)
+        {
+            Events<TEnum>.NotifyOnEnumRegistered(builder);
+        }
+
+        return builder;
     }
 
     /// <summary>
@@ -55,10 +61,6 @@ public static class EnumHandler
             : callingAssembly;
         
         var builder = AddEntry<TEnum>(name, callingAssembly);
-        if (builder is not null)
-        {
-            Events<TEnum>.NotifyOnEnumRegistered(builder);
-        }
 
         return builder;
     }

--- a/Nautilus/Handlers/Enums/EnumHandler.cs
+++ b/Nautilus/Handlers/Enums/EnumHandler.cs
@@ -1,15 +1,32 @@
 ﻿using System;
 using System.Reflection;
+using System.Reflection.Emit;
 using Nautilus.Utility;
 
 // Resharper
 namespace Nautilus.Handlers;
 
 /// <summary>
+/// Delegate used when a custom enum is registered via <see cref="EnumHandler.AddEntry{TEnum}(string,System.Reflection.Assembly)"/>.
+/// </summary>
+/// <typeparam name="TEnum">The type of the enum to process.</typeparam>
+public delegate void OnEnumRegistered<TEnum>(EnumBuilder<TEnum> builder) where TEnum : Enum;
+
+/// <summary>
 /// Class responsible to resolve anything related to adding custom enum objects.
 /// </summary>
 public static class EnumHandler
 {
+    internal static class Events<TEnum> where TEnum : Enum
+    {
+        public static event OnEnumRegistered<TEnum> OnEnumRegistered;
+
+        public static void NotifyOnEnumRegistered(EnumBuilder<TEnum> builder)
+        {
+            OnEnumRegistered?.Invoke(builder);
+        }
+    }
+    
     /// <summary>
     /// Adds a new custom enum object instance.
     /// </summary>
@@ -37,7 +54,13 @@ public static class EnumHandler
             ? ReflectionHelper.CallingAssemblyByStackTrace()
             : callingAssembly;
         
-        return AddEntry<TEnum>(name, callingAssembly);
+        var builder = AddEntry<TEnum>(name, callingAssembly);
+        if (builder is not null)
+        {
+            Events<TEnum>.NotifyOnEnumRegistered(builder);
+        }
+
+        return builder;
     }
 
     /// <summary>
@@ -160,5 +183,24 @@ public static class EnumHandler
     public static bool ModdedEnumExists<TEnum>(string name) where TEnum : Enum
     {
         return TryGetValue<TEnum>(name, out _);
-    }    
+    }
+
+    /// <summary>
+    /// Adds a callback that's executed every time a custom enum of a certain type is created.
+    /// </summary>
+    /// <param name="callback">The callback that will be executed.</param>
+    /// <typeparam name="TEnum">The type of the enum this callback is for.</typeparam>
+    public static void AddOnEnumRegistered<TEnum>(OnEnumRegistered<TEnum> callback) where TEnum : Enum
+    {
+        Events<TEnum>.OnEnumRegistered +=  callback;
+    }
+    
+    /// <summary>
+    /// Removes a callback that was previously added to the OnEnumRegistered event.
+    /// </summary>
+    /// <param name="callback">The callback to remove.</param>
+    public static void RemoveOnEnumRegistered<TEnum>(OnEnumRegistered<TEnum> callback) where TEnum : Enum
+    {
+        Events<TEnum>.OnEnumRegistered -=  callback;
+    }
 }

--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
@@ -1,0 +1,141 @@
+﻿#if SUBNAUTICA
+using System;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using Nautilus.Extensions;
+using Nautilus.Handlers.Internals;
+using Nautilus.Patchers;
+using Nautilus.Utility;
+using Newtonsoft.Json.Utilities;
+using UnityEngine.InputSystem;
+
+namespace Nautilus.Handlers;
+
+using Button = GameInput.Button;
+
+public static partial class EnumExtensions
+{
+    [OnEnumRegister<Button>]
+    private static void OnButtonRegistered(EnumBuilder<Button> builder)
+    {
+        Button button = builder;
+        var name = button.ToString();
+        GameInputSystem.nameToAction[name] = button;
+        if (!GameInput.ActionNames.valueToString.ContainsKey(button))
+        {
+            GameInput.ActionNames.valueToString.Add(button, name);
+        }
+    }
+    
+    /// <summary>
+    /// Initializes the action input for this button.
+    /// </summary>
+    /// <param name="builder">The current custom enum object instance.</param>
+    /// <param name="actionType">Determines the behavior with which an <see cref="InputAction"/> triggers.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <seealso href="https://docs.unity3d.com/Packages/com.unity.inputsystem@1.0/api/UnityEngine.InputSystem.InputActionType.html"/>
+    public static EnumBuilder<Button> CreateInput(this EnumBuilder<Button> builder, InputActionType actionType = InputActionType.Button)
+    {
+        Button button = builder;
+        GameInputPatcher.CustomButtons[button] = new InputAction(button.ToString(), actionType);
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets the default bindings for this button.
+    /// </summary>
+    /// <param name="builder">The current custom enum object instance.</param>
+    /// <param name="device">The device this binding is for.</param>
+    /// <param name="bindingSet">Whether this is the primary binding or the secondary binding.</param>
+    /// <param name="bindingPath">The binding path to bind this button to.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// /// <seealso href="https://docs.unity3d.com/Packages/com.unity.inputsystem@1.2/api/UnityEngine.InputSystem.InputControlPath.html"/>
+    public static EnumBuilder<Button> WithBinding(this EnumBuilder<Button> builder, GameInput.Device device,
+        GameInput.BindingSet bindingSet, string bindingPath)
+    {
+        Button button = builder;
+        GameInputPatcher.Bindings.GetOrAddNew(button).Add(new(device, bindingSet, bindingPath));
+        if (device == GameInput.Device.Keyboard)
+        {
+            GameInputSystem.bindingsKeyboard[(button, bindingSet)] = bindingPath;
+        }
+        else
+        {
+            GameInputSystem.bindingsController[(button, bindingSet)] = bindingPath;
+        }
+        
+        return builder;
+    }
+    
+    /// <summary>
+    /// Sets the default bindings for this button.
+    /// </summary>
+    /// <param name="builder">The current custom enum object instance.</param>
+    /// <param name="device">The device this binding is for.</param>
+    /// <param name="primaryBindingPath">The binding path to bind the primary hotkey of this button.</param>
+    /// <param name="secondaryBindingPath">The binding path to bind the secondary hotkey of this button. If null or empty, the button will have an empty secondary binding.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <seealso href="https://docs.unity3d.com/Packages/com.unity.inputsystem@1.2/api/UnityEngine.InputSystem.InputControlPath.html"/>
+    public static EnumBuilder<Button> WithBinding(this EnumBuilder<Button> builder, GameInput.Device device,
+        string primaryBindingPath, string secondaryBindingPath = null)
+    {
+        Button button = builder;
+        
+        if (string.IsNullOrWhiteSpace(primaryBindingPath))
+        {
+            InternalLogger.Error($"Primary binding path cannot be empty for button: '{button.AsString()}'");
+            return builder;
+        }
+        
+        GameInputPatcher.Bindings.GetOrAddNew(button).Add(new(device, GameInput.BindingSet.Primary, primaryBindingPath));
+        SetBindingDefinition(button, device, GameInput.BindingSet.Primary, secondaryBindingPath);
+
+        if (!string.IsNullOrWhiteSpace(secondaryBindingPath))
+        {
+            GameInputPatcher.Bindings.GetOrAddNew(button).Add(new(device,  GameInput.BindingSet.Secondary, secondaryBindingPath));
+            SetBindingDefinition(button, device, GameInput.BindingSet.Secondary, secondaryBindingPath);
+        }
+        
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets the default bindings for keyboard controls for this button.
+    /// </summary>
+    /// <param name="builder">The current custom enum object instance.</param>
+    /// <param name="primaryBindingPath">The binding path to bind the primary hotkey of this button.</param>
+    /// <param name="secondaryBindingPath">The binding path to bind the secondary hotkey of this button. If null or empty, the button will have an empty secondary binding.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// /// <seealso href="https://docs.unity3d.com/Packages/com.unity.inputsystem@1.2/api/UnityEngine.InputSystem.InputControlPath.html"/>
+    public static EnumBuilder<Button> WithKeyboardBinding(this EnumBuilder<Button> builder, string primaryBindingPath, string secondaryBindingPath = null)
+    {
+        return WithBinding(builder, GameInput.Device.Keyboard, primaryBindingPath, secondaryBindingPath);
+    }
+    
+    /// <summary>
+    /// Sets the default bindings for controller controls for this button.
+    /// </summary>
+    /// <param name="builder">The current custom enum object instance.</param>
+    /// <param name="primaryBindingPath">The binding path to bind the primary hotkey of this button.</param>
+    /// <param name="secondaryBindingPath">The binding path to bind the secondary hotkey of this button. If null or empty, the button will have an empty secondary binding.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// /// <seealso href="https://docs.unity3d.com/Packages/com.unity.inputsystem@1.2/api/UnityEngine.InputSystem.InputControlPath.html"/>
+    public static EnumBuilder<Button> WithControllerBinding(this EnumBuilder<Button> builder, string primaryBindingPath, string secondaryBindingPath = null)
+    {
+        return WithBinding(builder, GameInput.Device.Controller, primaryBindingPath, secondaryBindingPath);
+    }
+
+    private static void SetBindingDefinition(Button button, GameInput.Device device, GameInput.BindingSet bindingSet, string bindingPath)
+    {
+        if (device == GameInput.Device.Keyboard)
+        {
+            GameInputSystem.bindingsKeyboard[(button, bindingSet)] = bindingPath;
+        }
+        else
+        {
+            GameInputSystem.bindingsController[(button, bindingSet)] = bindingPath;
+        }
+    }
+}
+#endif

--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
@@ -132,6 +132,8 @@ public static partial class EnumExtensions
     /// <param name="builder">The current custom enum object instance.</param>
     /// <param name="devices">The devices that will have customized bindings.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <remarks>By default, all custom buttons are bindable, unless explicitly set as unbindable by calling <see cref="SetUnbindable"/>.</remarks>
+    /// <seealso cref="SetUnbindable"/>
     public static EnumBuilder<Button> SetBindable(this EnumBuilder<Button> builder, params GameInput.Device[] devices)
     {
         foreach (var device in devices)
@@ -153,6 +155,22 @@ public static partial class EnumExtensions
         foreach (var device in devices)
         {
             GameInputPatcher.BindableButtons.Remove((builder, device));
+        }
+        
+        return builder;
+    }
+
+    /// <summary>
+    /// Assigns this button to force its bindings to work regardless of whether another vanilla button or custom button have similar bindings.
+    /// </summary>
+    /// <param name="builder">The current custom enum object instance.</param>
+    /// <param name="devices">The devices in which this button avoids conflicts.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static EnumBuilder<Button> AvoidConflicts(this EnumBuilder<Button> builder, params GameInput.Device[] devices)
+    {
+        foreach (var device in devices)
+        {
+            GameInputPatcher.ConflictEvaders.Add((builder, device));
         }
         
         return builder;

--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
@@ -89,7 +89,7 @@ public static partial class EnumExtensions
         }
         
         GameInputPatcher.Bindings.GetOrAddNew(button).Add(new(device, GameInput.BindingSet.Primary, primaryBindingPath));
-        SetBindingDefinition(button, device, GameInput.BindingSet.Primary, secondaryBindingPath);
+        SetBindingDefinition(button, device, GameInput.BindingSet.Primary, primaryBindingPath);
 
         if (!string.IsNullOrWhiteSpace(secondaryBindingPath))
         {

--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
@@ -149,8 +149,8 @@ public static partial class EnumExtensions
     /// </summary>
     /// <param name="builder">The current custom enum object instance.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
-    /// <remarks>By default, all custom buttons are bindable, unless explicitly set as unbindable by calling <see cref="SetUnbindable"/>.</remarks>
-    /// <seealso cref="SetUnbindable"/>
+    /// <remarks>By default, all custom buttons are bindable, unless explicitly set as unbindable by calling <see cref="SetUnbindable(EnumBuilder{Button})"/>.</remarks>
+    /// <seealso cref="SetBindable(EnumBuilder{Button}, GameInput.Device)"/>
     public static EnumBuilder<Button> SetBindable(this EnumBuilder<Button> builder)
     {
         foreach (var device in GameInput.AllDevices)
@@ -167,8 +167,8 @@ public static partial class EnumExtensions
     /// <param name="builder">The current custom enum object instance.</param>
     /// <param name="device">The device that was set to be bindable.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
-    /// <remarks>By default, all custom buttons are bindable, unless explicitly set as unbindable by calling <see cref="SetUnbindable"/>.</remarks>
-    /// <seealso cref="SetUnbindable"/>
+    /// <remarks>By default, all custom buttons are bindable, unless explicitly set as unbindable by calling <see cref="SetUnbindable(EnumBuilder{Button}, GameInput.Device)"/>.</remarks>
+    /// <seealso cref="SetBindable(EnumBuilder{Button})"/>
     public static EnumBuilder<Button> SetBindable(this EnumBuilder<Button> builder, GameInput.Device device)
     {
         GameInputPatcher.BindableButtons.Add((builder, device));
@@ -180,6 +180,7 @@ public static partial class EnumExtensions
     /// </summary>
     /// <param name="builder">The current custom enum object instance.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <seealso cref="SetUnbindable(EnumBuilder{Button}, GameInput.Device)"/>
     public static EnumBuilder<Button> SetUnbindable(this EnumBuilder<Button> builder)
     {
         foreach (var device in GameInput.AllDevices)
@@ -196,6 +197,7 @@ public static partial class EnumExtensions
     /// <param name="builder">The current custom enum object instance.</param>
     /// <param name="device">The device in which this button cannot be bound.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <seealso cref="SetUnbindable(EnumBuilder{Button})"/>
     public static EnumBuilder<Button> SetUnbindable(this EnumBuilder<Button> builder, GameInput.Device device)
     {
         GameInputPatcher.BindableButtons.Remove((builder, device));
@@ -207,6 +209,7 @@ public static partial class EnumExtensions
     /// </summary>
     /// <param name="builder">The current custom enum object instance.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <seealso cref="AvoidConflicts(EnumBuilder{Button}, GameInput.Device)"/>
     public static EnumBuilder<Button> AvoidConflicts(this EnumBuilder<Button> builder)
     {
         foreach (var device in GameInput.AllDevices)
@@ -223,6 +226,7 @@ public static partial class EnumExtensions
     /// <param name="builder">The current custom enum object instance.</param>
     /// <param name="device">The devices in which this button avoids conflicts.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <seealso cref="AvoidConflicts(EnumBuilder{Button})"/>
     public static EnumBuilder<Button> AvoidConflicts(this EnumBuilder<Button> builder, GameInput.Device device)
     {
         GameInputPatcher.ConflictEvaders.Add((builder, device));

--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
@@ -27,18 +27,34 @@ public static partial class EnumExtensions
             GameInput.ActionNames.valueToString.Add(button, name);
         }
     }
-    
+
     /// <summary>
     /// Initializes the action input for this button.
     /// </summary>
     /// <param name="builder">The current custom enum object instance.</param>
+    /// <param name="tooltip">The display name of the button, can be anything. If null or empty, this will use the language line "Option{enumName}" instead.</param>
+    /// <param name="language">The language for the display name. Defaults to English.</param>
     /// <param name="actionType">Determines the behavior with which an <see cref="InputAction"/> triggers.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
     /// <seealso href="https://docs.unity3d.com/Packages/com.unity.inputsystem@1.0/api/UnityEngine.InputSystem.InputActionType.html"/>
-    public static EnumBuilder<Button> CreateInput(this EnumBuilder<Button> builder, InputActionType actionType = InputActionType.Button)
+    public static EnumBuilder<Button> CreateInput(this EnumBuilder<Button> builder, string tooltip = "", string language = "English", InputActionType actionType = InputActionType.Button)
     {
         Button button = builder;
-        GameInputPatcher.CustomButtons[button] = new InputAction(button.ToString(), actionType);
+        var buttonName = button.AsString();
+        var fullName = $"Option{buttonName}";
+        GameInputPatcher.CustomButtons[button] = new InputAction(buttonName, actionType);
+        if (!string.IsNullOrEmpty(tooltip))
+        {
+            LanguageHandler.SetLanguageLine(fullName, tooltip, language);
+            return builder;
+        }
+        
+        var friendlyName = Language.main.Get(fullName);
+        if (string.IsNullOrEmpty(friendlyName))
+        {
+            InternalLogger.Warn($"Display name for Button '{buttonName}' is not specified and no language key has been found. Setting display name to 'Option{buttonName}'.");
+        }
+        
         return builder;
     }
 

--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
@@ -50,20 +50,15 @@ public static partial class EnumExtensions
     /// <param name="bindingSet">Whether this is the primary binding or the secondary binding.</param>
     /// <param name="bindingPath">The binding path to bind this button to.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
-    /// /// <seealso href="https://docs.unity3d.com/Packages/com.unity.inputsystem@1.2/api/UnityEngine.InputSystem.InputControlPath.html"/>
+    /// <remarks>By default, the binding will be bindable in the Mod Input tab. If you wish to make the button unbindable, consider using <see cref="SetUnbindable"/>.</remarks>
+    /// <seealso href="https://docs.unity3d.com/Packages/com.unity.inputsystem@1.2/api/UnityEngine.InputSystem.InputControlPath.html"/>
     public static EnumBuilder<Button> WithBinding(this EnumBuilder<Button> builder, GameInput.Device device,
         GameInput.BindingSet bindingSet, string bindingPath)
     {
         Button button = builder;
         GameInputPatcher.Bindings.GetOrAddNew(button).Add(new(device, bindingSet, bindingPath));
-        if (device == GameInput.Device.Keyboard)
-        {
-            GameInputSystem.bindingsKeyboard[(button, bindingSet)] = bindingPath;
-        }
-        else
-        {
-            GameInputSystem.bindingsController[(button, bindingSet)] = bindingPath;
-        }
+        SetBindingDefinition(button, device, bindingSet, bindingPath);
+        SetBindable(builder, device);
         
         return builder;
     }
@@ -76,6 +71,7 @@ public static partial class EnumExtensions
     /// <param name="primaryBindingPath">The binding path to bind the primary hotkey of this button.</param>
     /// <param name="secondaryBindingPath">The binding path to bind the secondary hotkey of this button. If null or empty, the button will have an empty secondary binding.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <remarks>By default, the binding will be bindable in the Mod Input tab. If you wish to make the button unbindable, consider using <see cref="SetUnbindable"/>.</remarks>
     /// <seealso href="https://docs.unity3d.com/Packages/com.unity.inputsystem@1.2/api/UnityEngine.InputSystem.InputControlPath.html"/>
     public static EnumBuilder<Button> WithBinding(this EnumBuilder<Button> builder, GameInput.Device device,
         string primaryBindingPath, string secondaryBindingPath = null)
@@ -96,10 +92,12 @@ public static partial class EnumExtensions
             GameInputPatcher.Bindings.GetOrAddNew(button).Add(new(device,  GameInput.BindingSet.Secondary, secondaryBindingPath));
             SetBindingDefinition(button, device, GameInput.BindingSet.Secondary, secondaryBindingPath);
         }
+
+        SetBindable(builder, device);
         
         return builder;
     }
-
+    
     /// <summary>
     /// Sets the default bindings for keyboard controls for this button.
     /// </summary>
@@ -107,7 +105,8 @@ public static partial class EnumExtensions
     /// <param name="primaryBindingPath">The binding path to bind the primary hotkey of this button.</param>
     /// <param name="secondaryBindingPath">The binding path to bind the secondary hotkey of this button. If null or empty, the button will have an empty secondary binding.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
-    /// /// <seealso href="https://docs.unity3d.com/Packages/com.unity.inputsystem@1.2/api/UnityEngine.InputSystem.InputControlPath.html"/>
+    /// <remarks>By default, the binding will be bindable in the Mod Input tab. If you wish to make the button unbindable, consider using <see cref="SetUnbindable"/>.</remarks>
+    /// <seealso href="https://docs.unity3d.com/Packages/com.unity.inputsystem@1.2/api/UnityEngine.InputSystem.InputControlPath.html"/>
     public static EnumBuilder<Button> WithKeyboardBinding(this EnumBuilder<Button> builder, string primaryBindingPath, string secondaryBindingPath = null)
     {
         return WithBinding(builder, GameInput.Device.Keyboard, primaryBindingPath, secondaryBindingPath);
@@ -120,7 +119,8 @@ public static partial class EnumExtensions
     /// <param name="primaryBindingPath">The binding path to bind the primary hotkey of this button.</param>
     /// <param name="secondaryBindingPath">The binding path to bind the secondary hotkey of this button. If null or empty, the button will have an empty secondary binding.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
-    /// /// <seealso href="https://docs.unity3d.com/Packages/com.unity.inputsystem@1.2/api/UnityEngine.InputSystem.InputControlPath.html"/>
+    /// <remarks>By default, the binding will be bindable in the Mod Input tab. If you wish to make the button unbindable, consider using <see cref="SetUnbindable"/>.</remarks>
+    /// <seealso href="https://docs.unity3d.com/Packages/com.unity.inputsystem@1.2/api/UnityEngine.InputSystem.InputControlPath.html"/>
     public static EnumBuilder<Button> WithControllerBinding(this EnumBuilder<Button> builder, string primaryBindingPath, string secondaryBindingPath = null)
     {
         return WithBinding(builder, GameInput.Device.Controller, primaryBindingPath, secondaryBindingPath);
@@ -132,11 +132,27 @@ public static partial class EnumExtensions
     /// <param name="builder">The current custom enum object instance.</param>
     /// <param name="devices">The devices that will have customized bindings.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
-    public static EnumBuilder<Button> SetAsBindable(this EnumBuilder<Button> builder, params GameInput.Device[] devices)
+    public static EnumBuilder<Button> SetBindable(this EnumBuilder<Button> builder, params GameInput.Device[] devices)
     {
         foreach (var device in devices)
         {
             GameInputPatcher.BindableButtons.Add((builder, device));
+        }
+        
+        return builder;
+    }
+
+    /// <summary>
+    /// Removes this button from being bindable in the Mod Input tab.
+    /// </summary>
+    /// <param name="builder">The current custom enum object instance.</param>
+    /// <param name="devices">The devices in which this button cannot be bound.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static EnumBuilder<Button> SetUnbindable(this EnumBuilder<Button> builder, params GameInput.Device[] devices)
+    {
+        foreach (var device in devices)
+        {
+            GameInputPatcher.BindableButtons.Remove((builder, device));
         }
         
         return builder;

--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
@@ -72,10 +72,6 @@ public static partial class EnumExtensions
         GameInput.BindingSet bindingSet, string bindingPath)
     {
         Button button = builder;
-        if (!IsBindingPathValid(builder, bindingPath, device))
-        {
-            return null;
-        }
         GameInputPatcher.Bindings.GetOrAddNew(button).Add(new(device, bindingSet, bindingPath));
         SetBindingDefinition(button, device, bindingSet, bindingPath);
         SetBindable(builder, device);
@@ -103,20 +99,12 @@ public static partial class EnumExtensions
             InternalLogger.Error($"Primary binding path cannot be empty for button: '{button.AsString()}'");
             return builder;
         }
-
-        if (!IsBindingPathValid(builder, primaryBindingPath, device))
-        {
-            return null;
-        }
+        
         GameInputPatcher.Bindings.GetOrAddNew(button).Add(new(device, GameInput.BindingSet.Primary, primaryBindingPath));
         SetBindingDefinition(button, device, GameInput.BindingSet.Primary, primaryBindingPath);
 
         if (!string.IsNullOrWhiteSpace(secondaryBindingPath))
         {
-            if (!IsBindingPathValid(builder, primaryBindingPath, device))
-            {
-                return null;
-            }
             GameInputPatcher.Bindings.GetOrAddNew(button).Add(new(device,  GameInput.BindingSet.Secondary, secondaryBindingPath));
             SetBindingDefinition(button, device, GameInput.BindingSet.Secondary, secondaryBindingPath);
         }
@@ -216,72 +204,6 @@ public static partial class EnumExtensions
         {
             GameInputSystem.bindingsController[(button, bindingSet)] = bindingPath;
         }
-    }
-    
-    private static bool IsBindingPathValid(EnumBuilder<Button> builder, string bindingPath, GameInput.Device device)
-    {
-        Button button = builder;
-        var deviceName = device.AsString();
-        
-        if (string.IsNullOrWhiteSpace(bindingPath))
-        {
-            InternalLogger.Error($"Binding cannot be empty or null for button: '{button}'.");
-            return false;
-        }
-
-        var controlsForBinding = InputSystem.FindControls(bindingPath);
-        if (controlsForBinding.Count <= 0)
-        {
-            InternalLogger.Error($"Binding path '{bindingPath}' is invalid for button: '{button}'.");
-            return false;
-        }
-
-        var actionType = GameInputPatcher.CustomButtons[button].type;
-
-        // pass through buttons can have any binding
-        if (actionType == InputActionType.PassThrough)
-        {
-            if (controlsForBinding.Any(c => !IsDeviceValid(c, device)))
-            {
-                InternalLogger.Error(
-                    $"Binding path '{bindingPath}' represents more than one binding, which is invalid for input action type '{actionType} for pass through button: '{button}'.");
-                return false;
-            }
-            return true;
-        }
-
-        if (controlsForBinding.Count > 1)
-        {
-            InternalLogger.Error($"Binding path '{bindingPath}' represents more than one binding, which is invalid for input action type '{actionType} for button: '{button}'.");
-            return false;
-        }
-
-        foreach (var inputControl in controlsForBinding)
-        {
-            if (!IsDeviceValid(inputControl, device))
-            {
-                InternalLogger.Error($"Binding path '{bindingPath}' is not compatible with device: '{device}' for button: '{button}'.");
-                return false;
-            }
-
-            if (inputControl is InputDevice)
-            {
-                InternalLogger.Error($"Binding path '{bindingPath}' cannot be a device for button: '{button}'.");
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static bool IsDeviceValid(InputControl inputControl, GameInput.Device device)
-    {
-        return device switch
-        {
-            GameInput.Device.Keyboard => inputControl.device is Keyboard or Mouse,
-            GameInput.Device.Controller => inputControl.device is Gamepad,
-            _ => throw new ArgumentOutOfRangeException(nameof(device), device, null)
-        };
     }
 }
 #endif

--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
@@ -145,6 +145,19 @@ public static partial class EnumExtensions
     }
 
     /// <summary>
+    /// Defines a custom category in which this button will appear in the Mod Input tab.
+    /// </summary>
+    /// <param name="builder">The current custom enum object instance.</param>
+    /// <param name="category">The category name.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <remarks>If the specified category was already added by another mod, both buttons will be merged under one category.</remarks>
+    public static EnumBuilder<Button> WithCategory(this EnumBuilder<Button> builder, string category)
+    {
+        GameInputPatcher.Categories.GetOrAddNew(category).Add(builder);
+        return builder;
+    }
+
+    /// <summary>
     /// Assigns this button to be bindable for all devices in the Mod Input tab.
     /// </summary>
     /// <param name="builder">The current custom enum object instance.</param>

--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
@@ -145,20 +145,33 @@ public static partial class EnumExtensions
     }
 
     /// <summary>
-    /// Assigns this button to be bindable in the Mod Input tab.
+    /// Assigns this button to be bindable for all devices in the Mod Input tab.
     /// </summary>
     /// <param name="builder">The current custom enum object instance.</param>
-    /// <param name="devices">The devices that will have customized bindings.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
     /// <remarks>By default, all custom buttons are bindable, unless explicitly set as unbindable by calling <see cref="SetUnbindable"/>.</remarks>
     /// <seealso cref="SetUnbindable"/>
-    public static EnumBuilder<Button> SetBindable(this EnumBuilder<Button> builder, params GameInput.Device[] devices)
+    public static EnumBuilder<Button> SetBindable(this EnumBuilder<Button> builder)
     {
-        foreach (var device in devices)
+        foreach (var device in GameInput.AllDevices)
         {
-            GameInputPatcher.BindableButtons.Add((builder, device));
+            SetBindable(builder, device);
         }
         
+        return builder;
+    }
+
+    /// <summary>
+    /// Assigns this button to be bindable for a device in the Mod Input tab.
+    /// </summary>
+    /// <param name="builder">The current custom enum object instance.</param>
+    /// <param name="device">The device that was set to be bindable.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <remarks>By default, all custom buttons are bindable, unless explicitly set as unbindable by calling <see cref="SetUnbindable"/>.</remarks>
+    /// <seealso cref="SetUnbindable"/>
+    public static EnumBuilder<Button> SetBindable(this EnumBuilder<Button> builder, GameInput.Device device)
+    {
+        GameInputPatcher.BindableButtons.Add((builder, device));
         return builder;
     }
 
@@ -166,15 +179,26 @@ public static partial class EnumExtensions
     /// Removes this button from being bindable in the Mod Input tab.
     /// </summary>
     /// <param name="builder">The current custom enum object instance.</param>
-    /// <param name="devices">The devices in which this button cannot be bound.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
-    public static EnumBuilder<Button> SetUnbindable(this EnumBuilder<Button> builder, params GameInput.Device[] devices)
+    public static EnumBuilder<Button> SetUnbindable(this EnumBuilder<Button> builder)
     {
-        foreach (var device in devices)
+        foreach (var device in GameInput.AllDevices)
         {
-            GameInputPatcher.BindableButtons.Remove((builder, device));
+            SetUnbindable(builder, device);
         }
         
+        return builder;
+    }
+
+    /// <summary>
+    /// Removes this button from being bindable for a specific device in the Mod Input tab.
+    /// </summary>
+    /// <param name="builder">The current custom enum object instance.</param>
+    /// <param name="device">The device in which this button cannot be bound.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static EnumBuilder<Button> SetUnbindable(this EnumBuilder<Button> builder, GameInput.Device device)
+    {
+        GameInputPatcher.BindableButtons.Remove((builder, device));
         return builder;
     }
 
@@ -182,15 +206,26 @@ public static partial class EnumExtensions
     /// Assigns this button to force its bindings to work regardless of whether another vanilla button or custom button have similar bindings.
     /// </summary>
     /// <param name="builder">The current custom enum object instance.</param>
-    /// <param name="devices">The devices in which this button avoids conflicts.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
-    public static EnumBuilder<Button> AvoidConflicts(this EnumBuilder<Button> builder, params GameInput.Device[] devices)
+    public static EnumBuilder<Button> AvoidConflicts(this EnumBuilder<Button> builder)
     {
-        foreach (var device in devices)
+        foreach (var device in GameInput.AllDevices)
         {
-            GameInputPatcher.ConflictEvaders.Add((builder, device));
+            AvoidConflicts(builder, device);
         }
         
+        return builder;
+    }
+    
+    /// <summary>
+    /// Assigns this button to force its bindings to work regardless of whether another vanilla button or custom button have similar bindings in a device.
+    /// </summary>
+    /// <param name="builder">The current custom enum object instance.</param>
+    /// <param name="device">The devices in which this button avoids conflicts.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static EnumBuilder<Button> AvoidConflicts(this EnumBuilder<Button> builder, GameInput.Device device)
+    {
+        GameInputPatcher.ConflictEvaders.Add((builder, device));
         return builder;
     }
 

--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_Button.cs
@@ -126,6 +126,22 @@ public static partial class EnumExtensions
         return WithBinding(builder, GameInput.Device.Controller, primaryBindingPath, secondaryBindingPath);
     }
 
+    /// <summary>
+    /// Assigns this button to be bindable in the Mod Input tab.
+    /// </summary>
+    /// <param name="builder">The current custom enum object instance.</param>
+    /// <param name="devices">The devices that will have customized bindings.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static EnumBuilder<Button> SetAsBindable(this EnumBuilder<Button> builder, params GameInput.Device[] devices)
+    {
+        foreach (var device in devices)
+        {
+            GameInputPatcher.BindableButtons.Add((builder, device));
+        }
+        
+        return builder;
+    }
+
     private static void SetBindingDefinition(Button button, GameInput.Device device, GameInput.BindingSet bindingSet, string bindingPath)
     {
         if (device == GameInput.Device.Keyboard)

--- a/Nautilus/Handlers/Enums/Extensions/EnumExtensions_TechType.cs
+++ b/Nautilus/Handlers/Enums/Extensions/EnumExtensions_TechType.cs
@@ -1,4 +1,5 @@
 ﻿using Nautilus.Assets;
+using Nautilus.Handlers.Internals;
 using Nautilus.Patchers;
 using Nautilus.Utility;
 
@@ -7,6 +8,20 @@ namespace Nautilus.Handlers;
 
 public static partial class EnumExtensions
 {
+    [OnEnumRegister<TechType>]
+    private static void OnTechTypeRegistered(EnumBuilder<TechType> builder)
+    {
+        var techType = builder.Value;
+        var name = techType.ToString();
+        var intKey = ((int)techType).ToString();
+        TechTypeExtensions.stringsNormal[techType] = name;
+        TechTypeExtensions.stringsLowercase[techType] = name.ToLowerInvariant();
+        TechTypeExtensions.techTypesNormal[name] = techType;
+        TechTypeExtensions.techTypesIgnoreCase[name] = techType;
+        TechTypeExtensions.techTypeKeys[techType] = intKey;
+        TechTypeExtensions.keyTechTypes[intKey] = techType;
+    }
+    
     /// <summary>
     /// Adds a display name, tooltip to this instance.
     /// </summary>

--- a/Nautilus/Handlers/Enums/Extensions/Internals/OnEnumRegisterAttribute.cs
+++ b/Nautilus/Handlers/Enums/Extensions/Internals/OnEnumRegisterAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Nautilus.Handlers.Internals;
+
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class OnEnumRegisterAttribute<TEnum> : Attribute  where TEnum : Enum
+{
+    
+}

--- a/Nautilus/Handlers/GameInputHandler.cs
+++ b/Nautilus/Handlers/GameInputHandler.cs
@@ -1,0 +1,688 @@
+﻿namespace Nautilus.Handlers;
+
+/// <summary>
+/// A handler class for dealing with the game's UnityEngine.InputSystem implementation.
+/// </summary>
+public static class GameInputHandler
+{
+    /// <summary>
+    /// A super class that then refers to all valid buttons for a respective device.
+    /// </summary>
+    public static class Paths
+    {
+        /// <summary>
+        /// A class containing all valid binding paths for keyboards.
+        /// </summary>
+        public static class Keyboard
+        {
+            /// <summary>
+            /// Represents the 'Escape' in the Keyboard.
+            /// </summary>
+            public const string Escape  = "/Keyboard/escape";
+
+            /// <summary>
+            /// Represents the 'Space' in the Keyboard.
+            /// </summary>
+            public const string Space  = "/Keyboard/space";
+
+            /// <summary>
+            /// Represents the 'Enter' in the Keyboard.
+            /// </summary>
+            public const string Enter  = "/Keyboard/enter";
+
+            /// <summary>
+            /// Represents the 'Tab' in the Keyboard.
+            /// </summary>
+            public const string Tab  = "/Keyboard/tab";
+
+            /// <summary>
+            /// Represents the (`) in the Keyboard.
+            /// </summary>
+            public const string Backquote  = "/Keyboard/backquote";
+
+            /// <summary>
+            /// Represents the (') in the Keyboard.
+            /// </summary>
+            public const string Quote  = "/Keyboard/quote";
+
+            /// <summary>
+            /// Represents the (;) in the Keyboard.
+            /// </summary>
+            public const string Semicolon  = "/Keyboard/semicolon";
+
+            /// <summary>
+            /// Represents the (,) in the Keyboard.
+            /// </summary>
+            public const string Comma  = "/Keyboard/comma";
+
+            /// <summary>
+            /// Represents the (.) in the Keyboard.
+            /// </summary>
+            public const string Period  = "/Keyboard/period";
+
+            /// <summary>
+            /// Represents the (/) in the Keyboard.
+            /// </summary>
+            public const string Slash  = "/Keyboard/slash";
+
+            /// <summary>
+            /// Represents the (\) in the Keyboard.
+            /// </summary>
+            public const string Backslash  = "/Keyboard/backslash";
+
+            /// <summary>
+            /// Represents the '[' in the Keyboard.
+            /// </summary>
+            public const string LeftBracket  = "/Keyboard/leftBracket";
+
+            /// <summary>
+            /// Represents the ']' in the Keyboard.
+            /// </summary>
+            public const string RightBracket  = "/Keyboard/rightBracket";
+
+            /// <summary>
+            /// Represents the (-) in the Keyboard.
+            /// </summary>
+            public const string Minus  = "/Keyboard/minus";
+
+            /// <summary>
+            /// Represents the (=) in the Keyboard.
+            /// </summary>
+            public new const string Equals  = "/Keyboard/equals";
+
+            /// <summary>
+            /// Represents the 'Up Arrow' in the Keyboard.
+            /// </summary>
+            public const string UpArrow  = "/Keyboard/upArrow";
+
+            /// <summary>
+            /// Represents the 'Down Arrow' in the Keyboard.
+            /// </summary>
+            public const string DownArrow  = "/Keyboard/downArrow";
+
+            /// <summary>
+            /// Represents the 'Left Arrow' in the Keyboard.
+            /// </summary>
+            public const string LeftArrow  = "/Keyboard/leftArrow";
+
+            /// <summary>
+            /// Represents the 'Right Arrow' in the Keyboard.
+            /// </summary>
+            public const string RightArrow  = "/Keyboard/rightArrow";
+
+            /// <summary>
+            /// Represents the 'A' in the Keyboard.
+            /// </summary>
+            public const string A  = "/Keyboard/a";
+
+            /// <summary>
+            /// Represents the 'B' in the Keyboard.
+            /// </summary>
+            public const string B  = "/Keyboard/b";
+
+            /// <summary>
+            /// Represents the 'C' in the Keyboard.
+            /// </summary>
+            public const string C  = "/Keyboard/c";
+
+            /// <summary>
+            /// Represents the 'D' in the Keyboard.
+            /// </summary>
+            public const string D  = "/Keyboard/d";
+
+            /// <summary>
+            /// Represents the 'E' in the Keyboard.
+            /// </summary>
+            public const string E  = "/Keyboard/e";
+
+            /// <summary>
+            /// Represents the 'F' in the Keyboard.
+            /// </summary>
+            public const string F  = "/Keyboard/f";
+
+            /// <summary>
+            /// Represents the 'G' in the Keyboard.
+            /// </summary>
+            public const string G  = "/Keyboard/g";
+
+            /// <summary>
+            /// Represents the 'H' in the Keyboard.
+            /// </summary>
+            public const string H  = "/Keyboard/h";
+
+            /// <summary>
+            /// Represents the 'I' in the Keyboard.
+            /// </summary>
+            public const string I  = "/Keyboard/i";
+
+            /// <summary>
+            /// Represents the 'J' in the Keyboard.
+            /// </summary>
+            public const string J  = "/Keyboard/j";
+
+            /// <summary>
+            /// Represents the 'K' in the Keyboard.
+            /// </summary>
+            public const string K  = "/Keyboard/k";
+
+            /// <summary>
+            /// Represents the 'L' in the Keyboard.
+            /// </summary>
+            public const string L  = "/Keyboard/l";
+
+            /// <summary>
+            /// Represents the 'M' in the Keyboard.
+            /// </summary>
+            public const string M  = "/Keyboard/m";
+
+            /// <summary>
+            /// Represents the 'N' in the Keyboard.
+            /// </summary>
+            public const string N  = "/Keyboard/n";
+
+            /// <summary>
+            /// Represents the 'O' in the Keyboard.
+            /// </summary>
+            public const string O  = "/Keyboard/o";
+
+            /// <summary>
+            /// Represents the 'P' in the Keyboard.
+            /// </summary>
+            public const string P  = "/Keyboard/p";
+
+            /// <summary>
+            /// Represents the 'Q' in the Keyboard.
+            /// </summary>
+            public const string Q  = "/Keyboard/q";
+
+            /// <summary>
+            /// Represents the 'R' in the Keyboard.
+            /// </summary>
+            public const string R  = "/Keyboard/r";
+
+            /// <summary>
+            /// Represents the 'S' in the Keyboard.
+            /// </summary>
+            public const string S  = "/Keyboard/s";
+
+            /// <summary>
+            /// Represents the 'T' in the Keyboard.
+            /// </summary>
+            public const string T  = "/Keyboard/t";
+
+            /// <summary>
+            /// Represents the 'U' in the Keyboard.
+            /// </summary>
+            public const string U  = "/Keyboard/u";
+
+            /// <summary>
+            /// Represents the 'V' in the Keyboard.
+            /// </summary>
+            public const string V  = "/Keyboard/v";
+
+            /// <summary>
+            /// Represents the 'W' in the Keyboard.
+            /// </summary>
+            public const string W  = "/Keyboard/w";
+
+            /// <summary>
+            /// Represents the 'X' in the Keyboard.
+            /// </summary>
+            public const string X  = "/Keyboard/x";
+
+            /// <summary>
+            /// Represents the 'Y' in the Keyboard.
+            /// </summary>
+            public const string Y  = "/Keyboard/y";
+
+            /// <summary>
+            /// Represents the 'Z' in the Keyboard.
+            /// </summary>
+            public const string Z  = "/Keyboard/z";
+
+            /// <summary>
+            /// Represents the '1' in the Keyboard.
+            /// </summary>
+            public const string Key1 = "/Keyboard/1";
+
+            /// <summary>
+            /// Represents the '2' in the Keyboard.
+            /// </summary>
+            public const string Key2 = "/Keyboard/2";
+
+            /// <summary>
+            /// Represents the '3' in the Keyboard.
+            /// </summary>
+            public const string Key3 = "/Keyboard/3";
+
+            /// <summary>
+            /// Represents the '4' in the Keyboard.
+            /// </summary>
+            public const string Key4 = "/Keyboard/4";
+
+            /// <summary>
+            /// Represents the '5' in the Keyboard.
+            /// </summary>
+            public const string Key5 = "/Keyboard/5";
+
+            /// <summary>
+            /// Represents the '6' in the Keyboard.
+            /// </summary>
+            public const string Key6 = "/Keyboard/6";
+
+            /// <summary>
+            /// Represents the '7' in the Keyboard.
+            /// </summary>
+            public const string Key7 = "/Keyboard/7";
+
+            /// <summary>
+            /// Represents the '8' in the Keyboard.
+            /// </summary>
+            public const string Key8 = "/Keyboard/8";
+
+            /// <summary>
+            /// Represents the '9' in the Keyboard.
+            /// </summary>
+            public const string Key9 = "/Keyboard/9";
+
+            /// <summary>
+            /// Represents the '0' in the Keyboard.
+            /// </summary>
+            public const string Key0 = "/Keyboard/0";
+
+            /// <summary>
+            /// Represents the 'Shift' in the Keyboard.
+            /// </summary>
+            public const string Shift = "/Keyboard/shift";
+
+            /// <summary>
+            /// Represents the 'Alt' in the Keyboard.
+            /// </summary>
+            public const string Alt = "/Keyboard/alt";
+
+            /// <summary>
+            /// Represents the 'Control' in the Keyboard.
+            /// </summary>
+            public const string Ctrl = "/Keyboard/ctrl";
+
+            /// <summary>
+            /// Represents the 'Left System' in the Keyboard.
+            /// </summary>
+            public const string LeftMeta = "/Keyboard/leftMeta";
+
+            /// <summary>
+            /// Represents the 'Right System' in the Keyboard.
+            /// </summary>
+            public const string RightMeta = "/Keyboard/rightMeta";
+
+            /// <summary>
+            /// Represents the 'Context Menu' in the Keyboard.
+            /// </summary>
+            public const string ContextMenu = "/Keyboard/contextMenu";
+
+            /// <summary>
+            /// Represents the 'Backspace' in the Keyboard.
+            /// </summary>
+            public const string Backspace = "/Keyboard/backspace";
+
+            /// <summary>
+            /// Represents the 'Page Down' in the Keyboard.
+            /// </summary>
+            public const string PageDown = "/Keyboard/pageDown";
+
+            /// <summary>
+            /// Represents the 'Page Up' in the Keyboard.
+            /// </summary>
+            public const string PageUp = "/Keyboard/pageUp";
+
+            /// <summary>
+            /// Represents the 'Home' in the Keyboard.
+            /// </summary>
+            public const string Home = "/Keyboard/home";
+
+            /// <summary>
+            /// Represents the 'End' in the Keyboard.
+            /// </summary>
+            public const string End = "/Keyboard/end";
+
+            /// <summary>
+            /// Represents the 'Insert' in the Keyboard.
+            /// </summary>
+            public const string Insert = "/Keyboard/insert";
+
+            /// <summary>
+            /// Represents the 'Delete' in the Keyboard.
+            /// </summary>
+            public const string Delete = "/Keyboard/delete";
+
+            /// <summary>
+            /// Represents the 'Caps Lock' in the Keyboard.
+            /// </summary>
+            public const string CapsLock = "/Keyboard/capsLock";
+
+            /// <summary>
+            /// Represents the 'Num Lock' in the Keyboard.
+            /// </summary>
+            public const string NumLock = "/Keyboard/numLock";
+
+            /// <summary>
+            /// Represents the 'Print Screen' in the Keyboard.
+            /// </summary>
+            public const string PrintScreen = "/Keyboard/printScreen";
+
+            /// <summary>
+            /// Represents the 'Scroll Lock' in the Keyboard.
+            /// </summary>
+            public const string ScrollLock = "/Keyboard/scrollLock";
+
+            /// <summary>
+            /// Represents the 'Pause/Break' in the Keyboard.
+            /// </summary>
+            public const string Pause = "/Keyboard/pause";
+
+            /// <summary>
+            /// Represents the 'Numpad Enter' in the Keyboard.
+            /// </summary>
+            public const string NumpadEnter = "/Keyboard/numpadEnter";
+
+            /// <summary>
+            /// Represents the 'Numpad /' in the Keyboard.
+            /// </summary>
+            public const string NumpadDivide = "/Keyboard/numpadDivide";
+
+            /// <summary>
+            /// Represents the 'Numpad *' in the Keyboard.
+            /// </summary>
+            public const string NumpadMultiply = "/Keyboard/numpadMultiply";
+
+            /// <summary>
+            /// Represents the 'Numpad +' in the Keyboard.
+            /// </summary>
+            public const string NumpadPlus = "/Keyboard/numpadPlus";
+
+            /// <summary>
+            /// Represents the 'Numpad -' in the Keyboard.
+            /// </summary>
+            public const string NumpadMinus = "/Keyboard/numpadMinus";
+
+            /// <summary>
+            /// Represents the 'Numpad .' in the Keyboard.
+            /// </summary>
+            public const string NumpadPeriod = "/Keyboard/numpadPeriod";
+
+            /// <summary>
+            /// Represents the 'Numpad =' in the Keyboard.
+            /// </summary>
+            public const string NumpadEquals = "/Keyboard/numpadEquals";
+
+            /// <summary>
+            /// Represents the 'Numpad 1' in the Keyboard.
+            /// </summary>
+            public const string Numpad1 = "/Keyboard/numpad1";
+
+            /// <summary>
+            /// Represents the 'Numpad 2' in the Keyboard.
+            /// </summary>
+            public const string Numpad2 = "/Keyboard/numpad2";
+
+            /// <summary>
+            /// Represents the 'Numpad 3' in the Keyboard.
+            /// </summary>
+            public const string Numpad3 = "/Keyboard/numpad3";
+
+            /// <summary>
+            /// Represents the 'Numpad 4' in the Keyboard.
+            /// </summary>
+            public const string Numpad4 = "/Keyboard/numpad4";
+
+            /// <summary>
+            /// Represents the 'Numpad 5' in the Keyboard.
+            /// </summary>
+            public const string Numpad5 = "/Keyboard/numpad5";
+
+            /// <summary>
+            /// Represents the 'Numpad 6' in the Keyboard.
+            /// </summary>
+            public const string Numpad6 = "/Keyboard/numpad6";
+
+            /// <summary>
+            /// Represents the 'Numpad 7' in the Keyboard.
+            /// </summary>
+            public const string Numpad7 = "/Keyboard/numpad7";
+
+            /// <summary>
+            /// Represents the 'Numpad 8' in the Keyboard.
+            /// </summary>
+            public const string Numpad8 = "/Keyboard/numpad8";
+
+            /// <summary>
+            /// Represents the 'Numpad 9' in the Keyboard.
+            /// </summary>
+            public const string Numpad9 = "/Keyboard/numpad9";
+
+            /// <summary>
+            /// Represents the 'Numpad 0' in the Keyboard.
+            /// </summary>
+            public const string Numpad0 = "/Keyboard/numpad0";
+
+            /// <summary>
+            /// Represents the 'F1' in the Keyboard.
+            /// </summary>
+            public const string F1 = "/Keyboard/f1";
+
+            /// <summary>
+            /// Represents the 'F2' in the Keyboard.
+            /// </summary>
+            public const string F2 = "/Keyboard/f2";
+
+            /// <summary>
+            /// Represents the 'F3' in the Keyboard.
+            /// </summary>
+            public const string F3 = "/Keyboard/f3";
+
+            /// <summary>
+            /// Represents the 'F4' in the Keyboard.
+            /// </summary>
+            public const string F4 = "/Keyboard/f4";
+
+            /// <summary>
+            /// Represents the 'F5' in the Keyboard.
+            /// </summary>
+            public const string F5 = "/Keyboard/f5";
+
+            /// <summary>
+            /// Represents the 'F6' in the Keyboard.
+            /// </summary>
+            public const string F6 = "/Keyboard/f6";
+
+            /// <summary>
+            /// Represents the 'F7' in the Keyboard.
+            /// </summary>
+            public const string F7 = "/Keyboard/f7";
+
+            /// <summary>
+            /// Represents the 'F8' in the Keyboard.
+            /// </summary>
+            public const string F8 = "/Keyboard/f8";
+
+            /// <summary>
+            /// Represents the 'F9' in the Keyboard.
+            /// </summary>
+            public const string F9 = "/Keyboard/f9";
+
+            /// <summary>
+            /// Represents the 'F10' in the Keyboard.
+            /// </summary>
+            public const string F10 = "/Keyboard/f10";
+
+            /// <summary>
+            /// Represents the 'F11' in the Keyboard.
+            /// </summary>
+            public const string F11 = "/Keyboard/f11";
+
+            /// <summary>
+            /// Represents the 'F12' in the Keyboard.
+            /// </summary>
+            public const string F12 = "/Keyboard/f12";
+
+            /// <summary>
+            /// Represents the 'OEM1' in the Keyboard.
+            /// </summary>
+            public const string Oem1 = "/Keyboard/OEM1";
+
+            /// <summary>
+            /// Represents the 'OEM2' in the Keyboard.
+            /// </summary>
+            public const string Oem2 = "/Keyboard/OEM2";
+
+            /// <summary>
+            /// Represents the 'OEM3' in the Keyboard.
+            /// </summary>
+            public const string Oem3 = "/Keyboard/OEM3";
+
+            /// <summary>
+            /// Represents the 'OEM4' in the Keyboard.
+            /// </summary>
+            public const string Oem4 = "/Keyboard/OEM4";
+
+            /// <summary>
+            /// Represents the 'OEM5' in the Keyboard.
+            /// </summary>
+            public const string Oem5 = "/Keyboard/OEM5";
+
+            /// <summary>
+            /// Represents the 'IMESelected' in the Keyboard.
+            /// </summary>
+            public const string ImeSelected = "/Keyboard/IMESelected";
+        }
+
+        /// <summary>
+        /// A class containing all valid binding paths for mice.
+        /// </summary>
+        public static class Mouse
+        {
+            /// <summary>
+            /// Represents the 'Scroll' in the Mouse.
+            /// </summary>
+            public const string ScrollUp = "/Mouse/scroll/up";
+            
+            /// <summary>
+            /// Represents the 'Scroll' in the Mouse.
+            /// </summary>
+            public const string ScrollDown = "/Mouse/scroll/down";
+
+            /// <summary>
+            /// Represents the 'Left Button' in the Mouse.
+            /// </summary>
+            public const string LeftButton = "/Mouse/leftButton";
+
+            /// <summary>
+            /// Represents the 'Right Button' in the Mouse.
+            /// </summary>
+            public const string RightButton = "/Mouse/rightButton";
+
+            /// <summary>
+            /// Represents the 'Middle Button' in the Mouse.
+            /// </summary>
+            public const string MiddleButton = "/Mouse/middleButton";
+
+            /// <summary>
+            /// Represents the 'Northern button' in the Mouse.
+            /// </summary>
+            /// <remarks>Only some mouse, especially macro mouse have this button.</remarks>
+            public const string ForwardButton = "/Mouse/forwardButton";
+
+            /// <summary>
+            /// Represents the 'Southern button' in the Mouse.
+            /// </summary>
+            /// <remarks>Only some mouse, especially macro mouse have this button.</remarks>
+            public const string BackButton = "/Mouse/backButton";
+        }
+
+        /// <summary>
+        /// A class containing all valid binding paths for controllers.
+        /// </summary>
+        public static class Gamepad
+        {
+            /// <summary>
+            /// Represents the 'D-Pad Up' in the Gamepad.
+            /// </summary>
+            public const string DpadUp = "<Gamepad>/dpad/up";
+
+            /// <summary>
+            /// Represents the 'D-Pad Down' in the Gamepad.
+            /// </summary>
+            public const string DpadDown = "<Gamepad>/dpad/down";
+
+            /// <summary>
+            /// Represents the 'D-Pad Left' in the Gamepad.
+            /// </summary>
+            public const string DpadLeft = "<Gamepad>/dpad/left";
+
+            /// <summary>
+            /// Represents the 'D-Pad Right' in the Gamepad.
+            /// </summary>
+            public const string DpadRight = "<Gamepad>/dpad/right";
+
+            /// <summary>
+            /// Represents the 'Start' in the Gamepad.
+            /// </summary>
+            public const string Start = "<Gamepad>/start";
+
+            /// <summary>
+            /// Represents the 'Select' in the Gamepad.
+            /// </summary>
+            public const string Select = "<Gamepad>/select";
+
+            /// <summary>
+            /// Represents the 'Left Stick' in the Gamepad.
+            /// </summary>
+            public const string LeftStick = "<Gamepad>/leftStickPress";
+
+            /// <summary>
+            /// Represents the 'Right Stick' in the Gamepad.
+            /// </summary>
+            public const string RightStick = "<Gamepad>/rightStickPress";
+
+            /// <summary>
+            /// Represents the 'Left Bumper' in the Gamepad.
+            /// </summary>
+            public const string LeftBumper = "<Gamepad>/leftShoulder";
+
+            /// <summary>
+            /// Represents the 'Right Bumper' in the Gamepad.
+            /// </summary>
+            public const string RightBumper = "<Gamepad>/rightShoulder";
+
+            /// <summary>
+            /// Represents the 'A' or 'Cross' in the Gamepad.
+            /// </summary>
+            public const string ButtonSouth = "<Gamepad>/buttonSouth";
+
+            /// <summary>
+            /// Represents the 'B' or 'Cricle' in the Gamepad.
+            /// </summary>
+            public const string ButtonEas  = "<Gamepad>/buttonEast";
+
+            /// <summary>
+            /// Represents the 'X' or 'Square' in the Gamepad.
+            /// </summary>
+            public const string ButtonWest = "<Gamepad>/buttonWest";
+
+            /// <summary>
+            /// Represents the 'Y' 'Triangle' in the Gamepad.
+            /// </summary>
+            public const string ButtonNorth = "<Gamepad>/buttonNorth";
+
+            /// <summary>
+            /// Represents the 'Left Trigger' in the Gamepad.
+            /// </summary>
+            public const string LeftTrigger = "<Gamepad>/leftTrigger";
+
+            /// <summary>
+            /// Represents the 'Right Trigger' in the Gamepad.
+            /// </summary>
+            public const string RightTrigger = "<Gamepad>/rightTrigger";
+        }
+    }
+}

--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -91,5 +91,8 @@ public class Initializer : BaseUnityPlugin
         MainMenuPatcher.Patch(_harmony, Config);
         WaitScreenPatcher.Patch(_harmony);
         uGUI_CraftingMenuPatcher.Patch(_harmony);
+#if SUBNAUTICA
+        GameInputPatcher.Patch(_harmony);
+#endif
     }
 }

--- a/Nautilus/Initializer.cs
+++ b/Nautilus/Initializer.cs
@@ -56,6 +56,7 @@ public class Initializer : BaseUnityPlugin
         AssetReferencePatcher.Patch(_harmony);
         PrefabDatabasePatcher.PrePatch(_harmony);
         EnumPatcher.Patch(_harmony);
+        EnumExtensions.Register();
         CraftDataPatcher.Patch(_harmony);
         CraftTreePatcher.Patch(_harmony);
         ConsoleCommandsPatcher.Patch(_harmony);

--- a/Nautilus/MonoBehaviours/ModBindingTooltip.cs
+++ b/Nautilus/MonoBehaviours/ModBindingTooltip.cs
@@ -1,0 +1,15 @@
+﻿using UnityEngine;
+
+namespace Nautilus.MonoBehaviours;
+
+internal class ModBindingTooltip : MonoBehaviour, ITooltip
+{
+    public string tooltip;
+
+    public bool showTooltipOnDrag => true;
+
+    public void GetTooltip(TooltipData tooltipData)
+    {
+        tooltipData.prefix.Append(tooltip);
+    }
+}

--- a/Nautilus/Nautilus.csproj
+++ b/Nautilus/Nautilus.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Nautilus</AssemblyName>
     <BepInExPluginGuid>com.snmodding.nautilus</BepInExPluginGuid>
     <BepInExPluginVersion>$(VersionPrefix).$(SuffixNumber)</BepInExPluginVersion>
-    <LangVersion>11</LangVersion>
+    <LangVersion>12</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <Configurations>SN.STABLE;BZ.STABLE</Configurations>

--- a/Nautilus/Options/Attributes/ConfigFileMetadata.cs
+++ b/Nautilus/Options/Attributes/ConfigFileMetadata.cs
@@ -431,6 +431,7 @@ internal class ConfigFileMetadata<T> where T : ConfigFile, new()
         }
     }
 
+#if BELOWZERO
     /// <summary>
     /// Sets the value in the <see cref="Config"/>, optionally saving the <see cref="Config"/> to disk if the
     /// <see cref="MenuAttribute.SaveEvents.ChangeValue"/> flag is set, before passing off to
@@ -456,6 +457,7 @@ internal class ConfigFileMetadata<T> where T : ConfigFile, new()
             InvokeOnChangeEvents(modOptionMetadata, sender, e);
         }
     }
+#endif
 
     /// <summary>
     /// Sets the value in the <see cref="Config"/>, optionally saving the <see cref="Config"/> to disk if the
@@ -609,12 +611,14 @@ internal class ConfigFileMetadata<T> where T : ConfigFile, new()
             }
                 break;
 
-            case KeybindAttribute _:
+#if BELOWZERO
+            case KeybindAttribute _ when memberInfoMetadata.ValueType == typeof(KeyCode):
             {
                 KeybindChangedEventArgs eventArgs = new(id, memberInfoMetadata.GetValue<KeyCode>(Config));
                 InvokeOnChangeEvents(modOptionMetadata, sender, eventArgs);
             }
                 break;
+#endif
 
             case SliderAttribute _:
             {

--- a/Nautilus/Options/Attributes/OptionsMenuBuilder.cs
+++ b/Nautilus/Options/Attributes/OptionsMenuBuilder.cs
@@ -82,8 +82,10 @@ internal class OptionsMenuBuilder<T> : ModOptions where T : ConfigFile, new()
         }
         else if (e is ColorChangedEventArgs colorChangedEventArgs)
             ConfigFileMetadata.HandleColorChanged(sender, colorChangedEventArgs);
+#if BELOWZERO
         else if (e is KeybindChangedEventArgs keybindChangedEventArgs)
             ConfigFileMetadata.HandleKeybindChanged(sender, keybindChangedEventArgs);
+#endif
         else if (e is SliderChangedEventArgs sliderChangedEventArgs)
             ConfigFileMetadata.HandleSliderChanged(sender, sliderChangedEventArgs);
         else if (e is ToggleChangedEventArgs toggleChangedEventArgs)
@@ -242,10 +244,8 @@ internal class OptionsMenuBuilder<T> : ModOptions where T : ConfigFile, new()
     /// <param name="memberInfoMetadata">The metadata of the corresponding member.</param>
     private void BuildModKeybindOption(string id, string label, MemberInfoMetadata<T> memberInfoMetadata)
     {
+#if BELOWZERO
         KeyCode value = memberInfoMetadata.GetValue<KeyCode>(ConfigFileMetadata.Config);
-#if SUBNAUTICA
-        if(!AddItem(ModKeybindOption.Create(id, label, GameInput.PrimaryDevice, value)))
-#else
         if(!AddItem(ModKeybindOption.Create(id, label, GameInput.GetPrimaryDevice(), value)))
 #endif
             InternalLogger.Warn($"Failed to add ModKeybindOption with id {id} to {Name}");

--- a/Nautilus/Options/ConfigEntryExtensions.cs
+++ b/Nautilus/Options/ConfigEntryExtensions.cs
@@ -226,6 +226,7 @@ public static class ConfigEntryExtensions
         return optionItem;
     }
 
+#if BELOWZERO
     /// <summary>
     /// Converts a Bepinex ConfigEntry/<KeyCode/> into a ModKeyBindOption that will update the value when the keybind changes.
     /// </summary>
@@ -234,11 +235,7 @@ public static class ConfigEntryExtensions
     public static ModKeybindOption ToModKeybindOption(this ConfigEntry<KeyCode> configEntry)
     {
         ModKeybindOption optionItem = ModKeybindOption.Create($"{configEntry.Definition.Section}_{configEntry.Definition.Key}",
-#if SUBNAUTICA
-            configEntry.Definition.Key, GameInput.PrimaryDevice, configEntry.Value, tooltip: configEntry.Description.Description);
-#else
             configEntry.Definition.Key, GameInput.GetPrimaryDevice(), configEntry.Value, tooltip: configEntry.Description.Description);
-#endif
         optionItem.OnChanged += (_, e) =>
         {
             configEntry.Value = e.Value;
@@ -246,6 +243,7 @@ public static class ConfigEntryExtensions
 
         return optionItem;
     }
+#endif
 
     /// <summary>
     /// Converts an Enum ConfigEntry into a ModChoiceOption that will update the value when the choice changes.

--- a/Nautilus/Options/ModKeybindOption_BelowZero.cs
+++ b/Nautilus/Options/ModKeybindOption_BelowZero.cs
@@ -1,3 +1,4 @@
+#if BELOWZERO
 using System;
 using System.Collections;
 using BepInEx.Logging;
@@ -5,6 +6,7 @@ using Nautilus.Extensions;
 using Nautilus.Utility;
 using TMPro;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Nautilus.Options;
 
@@ -95,8 +97,8 @@ public class ModKeybindOption : ModOption<KeyCode, KeybindChangedEventArgs>
 
         // Destroy secondary bindings
         int last = bindings.bindings.Length - 1;
-        UnityEngine.Object.Destroy(bindings.bindings[last].gameObject);
-        UnityEngine.Object.Destroy(bindings);
+        Object.Destroy(bindings.bindings[last].gameObject);
+        Object.Destroy(bindings);
 
         // Update bindings
         binding.device = Device;
@@ -121,7 +123,7 @@ public class ModKeybindOption : ModOption<KeyCode, KeybindChangedEventArgs>
         base.AddToPanel(panel, tabIndex);
     }
     
-     private static KeyCode StringToKeyCode(string s)
+    private static KeyCode StringToKeyCode(string s)
     {
         switch (s)
         {
@@ -217,3 +219,4 @@ public class ModKeybindOption : ModOption<KeyCode, KeybindChangedEventArgs>
     /// </summary>
     public override Type AdjusterComponent => typeof(BindingOptionAdjust);
 }
+#endif

--- a/Nautilus/Patchers/GameInputPatcher.cs
+++ b/Nautilus/Patchers/GameInputPatcher.cs
@@ -18,6 +18,7 @@ internal static class GameInputPatcher
     
     public static Dictionary<GameInput.Button, InputAction> CustomButtons = new();
     public static Dictionary<GameInput.Button, List<InputBinding>> Bindings = new();
+    public static Dictionary<string, HashSet<GameInput.Button>> Categories = new();
     public static List<InputActionMap> CustomActionMaps = new();
     public static HashSet<Hotkey> BindableButtons = new();
     public static HashSet<Hotkey> ConflictEvaders = new();

--- a/Nautilus/Patchers/GameInputPatcher.cs
+++ b/Nautilus/Patchers/GameInputPatcher.cs
@@ -16,7 +16,7 @@ internal static class GameInputPatcher
     
     public static Dictionary<GameInput.Button, InputAction> CustomButtons = new();
     public static Dictionary<GameInput.Button, List<InputBinding>> Bindings = new();
-    public static List<Hotkey> BindableButtons = new();
+    public static HashSet<Hotkey> BindableButtons = new();
     public static List<InputActionMap> CustomActionMaps = new();
 
     public static void Patch(Harmony harmony)

--- a/Nautilus/Patchers/GameInputPatcher.cs
+++ b/Nautilus/Patchers/GameInputPatcher.cs
@@ -1,0 +1,110 @@
+﻿#if SUBNAUTICA
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using HarmonyLib;
+using Nautilus.Utility;
+using UnityEngine.InputSystem;
+using Hotkey = (GameInput.Button button, GameInput.Device device);
+
+namespace Nautilus.Patchers;
+
+[HarmonyPatch(typeof(GameInputSystem))]
+internal static class GameInputPatcher
+{
+    public record InputBinding(GameInput.Device Device, GameInput.BindingSet BindingSet, string Path);
+    
+    public static Dictionary<GameInput.Button, InputAction> CustomButtons = new();
+    public static Dictionary<GameInput.Button, List<InputBinding>> Bindings = new();
+    public static List<Hotkey> BindableButtons = new();
+    public static List<InputActionMap> CustomActionMaps = new();
+
+    public static void Patch(Harmony harmony)
+    {
+        harmony.PatchAll(typeof(GameInputPatcher));
+        InternalLogger.Info("Patched GameInputPatcher.");
+    }
+    
+    public static void RegisterActions(InputActionAsset actionAsset)
+    {
+        CustomActionMaps.AddRange(actionAsset.actionMaps);
+    }
+    
+    [HarmonyPatch(nameof(GameInputSystem.Initialize))]
+    [HarmonyPostfix]
+    private static void InitializePostfix(GameInputSystem __instance)
+    {
+        foreach (var kvp in CustomButtons)
+        {
+            var button = kvp.Key;
+            var action =  kvp.Value;
+            __instance.actions[button] = action;
+            action.started += __instance.OnActionStarted;
+            action.Enable();
+            
+            if (Bindings.TryGetValue(button, out var bindings))
+            {
+                bindings.ForEach(binding => action.AddBinding(binding.Path, groups: __instance.GetCompositeGroup(binding.Device, binding.BindingSet)));
+            }
+        }
+        
+        InternalLogger.Debug("Added all custom buttons.");
+    }
+
+    [HarmonyPatch(nameof(GameInputSystem.Deinitialize))]
+    [HarmonyPostfix]
+    private static void DeinitializePostfix(GameInputSystem __instance)
+    {
+        foreach (var customButton in CustomButtons)
+        {
+            customButton.Value.started -= __instance.OnActionStarted;
+            customButton.Value.Disable();
+        }
+    }
+
+    [HarmonyPatch(typeof(GameInput))]
+    [HarmonyPatch(nameof(GameInput.IsBindable))]
+    [HarmonyPostfix]
+    private static void IsBindablePostfix(GameInput.Device device, GameInput.Button action, ref bool __result)
+    {
+        if (CustomButtons.ContainsKey(action) && BindableButtons.Contains((action, device)))
+        {
+            __result = true;
+        }
+    }
+    
+    [HarmonyPatch(nameof(GameInputSystem.SerializeSettings))]
+    [HarmonyTranspiler]
+    private static IEnumerable<CodeInstruction> SerializeSettingsTranspiler(IEnumerable<CodeInstruction> instructions)
+    {
+        var matcher = new CodeMatcher(instructions)
+            .MatchForward(false,
+                new CodeMatch(OpCodes.Ldsfld, AccessTools.Field(typeof(GameInput), nameof(GameInput.AllActions))))
+            .Advance(1)
+            .Insert(Transpilers.EmitDelegate(IncludeCustomButtons));
+        
+        return matcher.InstructionEnumeration();
+        
+        GameInput.Button[] IncludeCustomButtons(GameInput.Button[] buttons)
+        {
+            var result = buttons.ToHashSet();
+            result.AddRange(BindableButtons.Select(b => b.button));
+            return result.ToArray();
+        }
+    }
+    
+    [HarmonyPatch(typeof(GameInput))]
+    [HarmonyPatch(nameof(GameInput.PrimaryDevice), MethodType.Getter)]
+    [HarmonyPrefix]
+    private static bool PrimaryDevicePrefix(ref GameInput.Device __result)
+    {
+        if (GameInput.input is not null)
+        {
+            return true;
+        }
+        __result = GameInput.Device.Keyboard;
+        return false;
+
+    }
+}
+#endif

--- a/Nautilus/Patchers/GameInputPatcher.cs
+++ b/Nautilus/Patchers/GameInputPatcher.cs
@@ -16,8 +16,9 @@ internal static class GameInputPatcher
     
     public static Dictionary<GameInput.Button, InputAction> CustomButtons = new();
     public static Dictionary<GameInput.Button, List<InputBinding>> Bindings = new();
-    public static HashSet<Hotkey> BindableButtons = new();
     public static List<InputActionMap> CustomActionMaps = new();
+    public static HashSet<Hotkey> BindableButtons = new();
+    public static HashSet<Hotkey> ConflictEvaders = new();
 
     public static void Patch(Harmony harmony)
     {
@@ -105,6 +106,26 @@ internal static class GameInputPatcher
         __result = GameInput.Device.Keyboard;
         return false;
 
+    }
+
+    [HarmonyPatch(typeof(BindConflicts))]
+    [HarmonyPatch(nameof(BindConflicts.GetConflicts))]
+    [HarmonyPrefix]
+    private static bool GetConflictsPrefix(GameInput.Device device, string input, GameInput.Button button,
+        List<BindConflict> conflicts)
+    {
+        if (conflicts is null)
+        {
+            return true;
+        }
+        
+        if (ConflictEvaders.Contains((button, device)))
+        {
+            conflicts.Clear();
+            return false;
+        }
+
+        return true;
     }
 }
 #endif

--- a/Nautilus/Patchers/GameInputPatcher.cs
+++ b/Nautilus/Patchers/GameInputPatcher.cs
@@ -1,8 +1,10 @@
 ﻿#if SUBNAUTICA
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
 using HarmonyLib;
+using Nautilus.Handlers;
 using Nautilus.Utility;
 using UnityEngine.InputSystem;
 using Hotkey = (GameInput.Button button, GameInput.Device device);
@@ -45,7 +47,10 @@ internal static class GameInputPatcher
             
             if (Bindings.TryGetValue(button, out var bindings))
             {
-                bindings.ForEach(binding => action.AddBinding(binding.Path, groups: __instance.GetCompositeGroup(binding.Device, binding.BindingSet)));
+                foreach (var binding in bindings)
+                {
+                    action.AddBinding(binding.Path, groups: __instance.GetCompositeGroup(binding.Device, binding.BindingSet));
+                }
             }
         }
         

--- a/Nautilus/Patchers/GameInputPatcher.cs
+++ b/Nautilus/Patchers/GameInputPatcher.cs
@@ -47,6 +47,18 @@ internal static class GameInputPatcher
             
             if (Bindings.TryGetValue(button, out var bindings))
             {
+                foreach (var bindableButton in BindableButtons)
+                {
+                    foreach (var bindingSet in GameInput.AllBindingSets)
+                    {
+                        var index = bindings.FindIndex(x => x.Device == bindableButton.device && x.BindingSet == bindingSet);
+                        if (index == -1)
+                        {
+                            bindings.Add(new(bindableButton.device, bindingSet, string.Empty));
+                        }
+                    }
+                }
+                
                 foreach (var binding in bindings)
                 {
                     action.AddBinding(binding.Path, groups: __instance.GetCompositeGroup(binding.Device, binding.BindingSet));

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -143,7 +143,8 @@ internal class OptionsPanelPatcher
             panel.AddHeading(tab, assembly.GetName().Name);
             foreach (var hotkey in hotkeys)
             {
-                panel.AddBindingOption(tab, $"Option{hotkey.button.AsString()}", device, hotkey.button);
+                if (hotkey.device == device)
+                    panel.AddBindingOption(tab, $"Option{hotkey.button.AsString()}", device, hotkey.button);
             }
         }
     }

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -1,23 +1,21 @@
+namespace Nautilus.Patchers;
+
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using HarmonyLib;
-using Nautilus.Handlers;
-using Nautilus.Options;
-using Nautilus.Utility;
+using Options;
+using Utility;
 using Newtonsoft.Json;
 using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using UnityEngine.InputSystem;
 using UnityEngine.UI;
-
-namespace Nautilus.Patchers;
-
-#if BELOWZERO
-using static ModKeybindOption;
+#if SUBNAUTICA
+using UnityEngine.InputSystem;
+using Handlers;
 #endif
 
 internal class OptionsPanelPatcher
@@ -54,7 +52,7 @@ internal class OptionsPanelPatcher
     [HarmonyPatch(typeof(uGUI_Binding), nameof(uGUI_Binding.RefreshValue))]
     internal static bool RefreshValue_Prefix(uGUI_Binding __instance)
     {
-        if (__instance.gameObject.GetComponent<ModBindingTag>() is null)
+        if (__instance.gameObject.GetComponent<ModKeybindOption.ModBindingTag>() is null)
         {
             return true;
         }

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -103,11 +103,11 @@ internal class OptionsPanelPatcher
         optionsToAdd.ForEach(options => options.AddOptionsToPanel(optionsPanel, modsTab));
 
 #if SUBNAUTICA
-        optionsPanel.AddHeading(inputTab, "Keyboard");
         var inputTab = optionsPanel.AddTab("Mod Input");
+        optionsPanel.AddHeading(inputTab, "<b>Keyboard</b>");
         PopulateBindings(optionsPanel, inputTab, GameInput.Device.Keyboard);
 
-        optionsPanel.AddHeading(inputTab, "Controller");
+        optionsPanel.AddHeading(inputTab, "<b>Controller</b>");
         PopulateBindings(optionsPanel, inputTab, GameInput.Device.Controller);
 #endif
     }

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -174,8 +174,8 @@ internal class OptionsPanelPatcher
                 (GameInput.input as GameInputSystem)!.bindingOptions.Add(bindings);
                 if (!EnumHandler.TryGetOwnerAssembly(button, out var assembly))
                 {
-                    InternalLogger.Error($"Couldn't find the assembly associated with bindable button '{button}'.");
-                    return;
+                    InternalLogger.Error($"Couldn't find the assembly associated with bindable button '{button}', category '{category}' was skipped.'");
+                    break;
                 }
                 
                 var pluginName = FindPluginNameForAssembly(assembly);

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -105,13 +105,11 @@ internal class OptionsPanelPatcher
 
 #if SUBNAUTICA
         var inputTab = optionsPanel.AddTab("Mod Input");
-        optionsPanel.AddHeading(inputTab, "<b>Keyboard</b>");
         PopulateBindings(optionsPanel, inputTab, GameInput.Device.Keyboard);
 
         // Add dividing line
         optionsPanel.AddHeading(inputTab, new string('\u2500', 34));
         
-        optionsPanel.AddHeading(inputTab, "<b>Controller</b>");
         PopulateBindings(optionsPanel, inputTab, GameInput.Device.Controller);
 #endif
     }
@@ -119,7 +117,14 @@ internal class OptionsPanelPatcher
 #if SUBNAUTICA
     private static void PopulateBindings(uGUI_OptionsPanel panel, int tab, GameInput.Device device)
     {
-        panel.AddBindingsHeader(tab);
+        var bindingsHeader = panel.AddBindingsHeader(tab);
+        bindingsHeader.transform.Find("Caption").GetComponent<TextMeshProUGUI>().text =
+            $"<color=#FFAC09><b>{device switch
+            {
+                GameInput.Device.Keyboard => "Keyboard",
+                GameInput.Device.Controller => "Controller",
+                _ => "Unknown device"
+            }}</b></color>";
 
         /*
          * Category logic order:

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -109,7 +109,7 @@ internal class OptionsPanelPatcher
         PopulateBindings(optionsPanel, inputTab, GameInput.Device.Keyboard);
 
         // Add dividing line
-        optionsPanel.AddHeading(inputTab, new string('-', 95));
+        optionsPanel.AddHeading(inputTab, new string('\u2500', 34));
         
         optionsPanel.AddHeading(inputTab, "<b>Controller</b>");
         PopulateBindings(optionsPanel, inputTab, GameInput.Device.Controller);

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -106,6 +106,9 @@ internal class OptionsPanelPatcher
         optionsPanel.AddHeading(inputTab, "<b>Keyboard</b>");
         PopulateBindings(optionsPanel, inputTab, GameInput.Device.Keyboard);
 
+        // Add dividing line
+        optionsPanel.AddHeading(inputTab, new string('-', 96));
+        
         optionsPanel.AddHeading(inputTab, "<b>Controller</b>");
         PopulateBindings(optionsPanel, inputTab, GameInput.Device.Controller);
 #endif

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using BepInEx.Bootstrap;
 using HarmonyLib;
 using Options;
 using Utility;
@@ -141,7 +142,9 @@ internal class OptionsPanelPatcher
         {
             var assembly = kvp.Key;
             var hotkeys = kvp.Value;
-            panel.AddHeading(tab, assembly.GetName().Name);
+            var pluginName =
+                Chainloader.PluginInfos.FirstOrDefault(x => x.Value.Instance.GetType().Assembly == assembly);
+            panel.AddHeading(tab, pluginName.Value?.Metadata?.Name ?? assembly.GetName().Name);
             foreach (var hotkey in hotkeys)
             {
                 if (hotkey.device == device)

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -1,3 +1,5 @@
+using BepInEx;
+
 namespace Nautilus.Patchers;
 
 using System.Collections;
@@ -142,9 +144,8 @@ internal class OptionsPanelPatcher
         {
             var assembly = kvp.Key;
             var hotkeys = kvp.Value;
-            var pluginName =
-                Chainloader.PluginInfos.FirstOrDefault(x => x.Value.Instance.GetType().Assembly == assembly);
-            panel.AddHeading(tab, pluginName.Value?.Metadata?.Name ?? assembly.GetName().Name);
+            var plugin = assembly.GetTypes().FirstOrDefault(t => t.GetCustomAttribute<BepInPlugin>() is not null)?.GetCustomAttribute<BepInPlugin>();
+            panel.AddHeading(tab, plugin?.Name ?? assembly.GetName().Name);
             foreach (var hotkey in hotkeys)
             {
                 if (hotkey.device == device)

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -103,8 +103,8 @@ internal class OptionsPanelPatcher
         optionsToAdd.ForEach(options => options.AddOptionsToPanel(optionsPanel, modsTab));
 
 #if SUBNAUTICA
-        var inputTab = optionsPanel.AddTab("ModInput");
         optionsPanel.AddHeading(inputTab, "Keyboard");
+        var inputTab = optionsPanel.AddTab("Mod Input");
         PopulateBindings(optionsPanel, inputTab, GameInput.Device.Keyboard);
 
         optionsPanel.AddHeading(inputTab, "Controller");

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -107,7 +107,7 @@ internal class OptionsPanelPatcher
         PopulateBindings(optionsPanel, inputTab, GameInput.Device.Keyboard);
 
         // Add dividing line
-        optionsPanel.AddHeading(inputTab, new string('-', 96));
+        optionsPanel.AddHeading(inputTab, new string('-', 95));
         
         optionsPanel.AddHeading(inputTab, "<b>Controller</b>");
         PopulateBindings(optionsPanel, inputTab, GameInput.Device.Controller);

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -115,8 +115,6 @@ internal class OptionsPanelPatcher
     private static void PopulateBindings(uGUI_OptionsPanel panel, int tab, GameInput.Device device)
     {
         panel.AddBindingsHeader(tab);
-
-        panel.AddButton(tab, "ResetToDefault", () => RemoveAllBindingOverrides(device));
         
         var bindables = GameInputPatcher.BindableButtons.GroupBy(b =>
                 {
@@ -136,6 +134,8 @@ internal class OptionsPanelPatcher
             panel.AddHeading(tab, "[No custom input]");
             return;
         }
+        
+        panel.AddButton(tab, "ResetToDefault", () => RemoveAllBindingOverrides(device));
         
         foreach (var kvp in bindables)
         {

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -129,6 +129,12 @@ internal class OptionsPanelPatcher
             .ToDictionary(
                 g => g.Key, 
                 g => g.ToList());
+
+        if (bindables.Count == 0)
+        {
+            panel.AddHeading(tab, "[No custom input]");
+            return;
+        }
         
         foreach (var kvp in bindables)
         {

--- a/common.props
+++ b/common.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="'$(Configuration)'=='SN.STABLE' Or '$(Configuration)'=='Release' Or '$(Configuration)'=='Debug'">
     <PackageReference Include="Subnautica.GameLibs" Version="82304.0.0-r.0" />
+    <PackageReference Include="Unity.InputSystem" Version="1.4.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='BZ.STABLE'">
     <PackageReference Include="Subnautica.BelowZero.GameLibs" Version="53115.0.0-r.0" />


### PR DESCRIPTION
### Changes made in this pull request

  - Upgraded to C# 12 (REQUIRES .NET 8!)
  - Added support for Unity.InputSystem
  - Made the KeybindOption Below zero only.
  - Added a new options tab called "Mod Input" for custom buttons that are bindable.
  - Added a new enum processing event that's called whenever a custom enum is created.
  
### Changes open for discussion
  - [ ] Provide a way to add inputs created in a Unity project
    - While it's extremely easy to get their bindings and whatnot, the requirement of enum objects for each input action is what complicates it. (source generator?)
  - [ ] The possibility of keeping the `KeybindAttribute` for Subnautica
  - [x] Support raw display name addition

### Breaking changes

  - KeybindOption and `Keybind` attribute no longer exist in SN1.
  
### Build (SN1) Up-to-date with 5d95aac
[Nautilus_SN.STABLE_1.0.0.45.zip](https://github.com/user-attachments/files/22911251/Nautilus_SN.STABLE_1.0.0.45.zip)


## New Input System (2025)
The new input system requires two things:
1. GameInput.Button
2. InputAction corresponding the button enum.

While Unity recommends relying on input action objects, Subnautica took a different approach and instead made wrappers that render the input actions internal-only by making every action type retrievable via `GameInput.GetButtonDown`, `GameInput.GetButtonHeld`, `GameInput.GetButtonUp`, `GameInput.GetFloat`, and `GameInput.GetVector2` methods.

This means that we'll have to add support for creating a new button enum object, but also translate settings to InputAction so custom buttons can be internally sound.

## How to use
To use this system, create a new `GameInput.Button` object using our enum handler, then specify the settings as desired.

Below is an example that demonstrates the usage of the new system, and how to listen to a button press.
```csharp
public GameInput.Button PrintButton = EnumHandler.AddEntry<GameInput.Button>("MyPrint")
    .CreateInput(InputActionType.Button)
    .WithKeyboardBinding("<Keyboard>/l") // Set the default keyboard binding to the button "L"
    
private void Update()
{
   if (GameInput.GetButtonDown(PrintButton))
   {
      ErrorMessage.AddDebug("Button was pressed!");
   }
}
```

~~Since this system if primarily intended to be used inside Unity projects, unfortunately there's no public source that lists every binding path (technically they're a form of regular expression, so they can be many things). However, we can generate a list of constant bindings, similar to the [prefab paths](https://github.com/SubnauticaModding/Nautilus/blob/master/Nautilus/Documentation/resources/SN1-PrefabPaths.json).~~

There's now a class that lists every possible button in every known device in [GameInputHandler.Paths](https://github.com/SubnauticaModding/Nautilus/blob/master/Nautilus/Handlers/GameInputHandler.cs#L11).

## How to migrate from keybind options to the new input system
Because `GameInput.Button` is simply a representation for a set of multiple keybinds and can be many things, we've decided to move them out of the `ModOptions` class and make them their own thing.

Below is a demonstration of how to convert a `KeyCode` keybind option to `GameInput.Button`
`KeyCode` keybind option:
```csharp
[Menu("My awesome configs")]
public class Config : ConfigFile
{
   [Keybind("Print Button")]
   public KeyCode PrintButton = KeyCode.L;
}

public Config MyConfig = OptionsPanelHandler.RegisterModOptions<Config>();

public void Update()
{
   if (Input.GetKeyDown(MyConfig.PrintButton))
   {
     ErrorMessage.AddMessage("Print button was pressed!");
   }
}
```
`GameInput.Button` equivalent:
```csharp
public GameInput.Button PrintButton = EnumHandler.AddEntry<GameInput.Button>("PrintButton")
   .CreateInput("Print Button")
   .WithKeyboardBinding("<Keyboard>/l");
   
public void Update()
{
   if (GameInput.GetButtonDown(PrintButton))
   {
     ErrorMessage.AddMessage("Print button was pressed!");
   }
}
```

Note that the input display names can be localized by the `Option{ENUM_NAME}` language string. For more information, check out [the example mod's localization file](https://github.com/SubnauticaModding/Nautilus/blob/master/Example%20mod/Localization/English.json).

## Categories
With the addition of the new "Mod Input" tab, we've also facilitated a way for modders to create new and name their categories for each button they make. Below demonstrates the usage of this system.

```csharp
public GameInput.Button PrintButton = EnumHandler.AddEntry<GameInput.Button>("PrintButton")
   .CreateInput("My Print")
   .WithKeyboardBinding("<Keyboard>/l")
   .WithCategory("NautilusExamplePrintCategory");
```
The above code produces the following category in the Mod Input tab:
<img width="1061" height="288" alt="image" src="https://github.com/user-attachments/assets/cc08d0e2-f34f-4645-9131-8b9637bb6d23" />

Important to note that categories are unique, meaning if another mod already added a category with the same name, your buttons and the other mod's buttons will be merged into one category.

If a category was not set for a button, the mod name defined in your `BepinPlugin` will be used instead.

Category display names can also be localized by the same string passed to `WithCategory` method.