### PR TITLE
IMPORTANT: Prevent entities from spawning in unloaded batches

### DIFF
--- a/Nautilus/MonoBehaviours/EntitySpawner.cs
+++ b/Nautilus/MonoBehaviours/EntitySpawner.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace Nautilus.MonoBehaviours;
 
 using System.Collections;
@@ -37,7 +39,7 @@ internal class EntitySpawner : MonoBehaviour
         
         yield return new WaitUntil(() => lw != null && lw.streamer.globalRoot != null); // need to make sure global root is ready too for global spawns.
 
-        var remainingSpawns = new List<SpawnInfo>(spawnInfos);
+        var remainingSpawns = spawnInfos.Reverse().ToList();
         while (remainingSpawns.Count > 0)
         {
             if (!global)

--- a/Nautilus/MonoBehaviours/EntitySpawner.cs
+++ b/Nautilus/MonoBehaviours/EntitySpawner.cs
@@ -25,12 +25,12 @@ internal class EntitySpawner : MonoBehaviour
         LargeWorldStreamer lws = LargeWorldStreamer.main;
         yield return new WaitUntil(() => lws != null && lws.IsReady()); // first we make sure the world streamer is initialized
         
-        var batchReadyCheck = () => lws.IsBatchReadyToCompile(batchId);
+        var waitUntilBatchReady = new WaitUntil(() => lws.IsBatchReadyToCompile(batchId));
 
         if (!global)
         {
             // then we wait until the terrain is fully loaded (must be checked on each frame for faster spawns)
-            yield return new WaitUntil(batchReadyCheck);
+            yield return waitUntilBatchReady;
         }
 
         LargeWorld lw = LargeWorld.main;
@@ -42,7 +42,7 @@ internal class EntitySpawner : MonoBehaviour
         {
             if (!global)
             {
-                yield return new WaitUntil(batchReadyCheck);
+                yield return waitUntilBatchReady;
             }
 
             for (int i = remainingSpawns.Count - 1; i >= 0; i--)

--- a/Nautilus/MonoBehaviours/EntitySpawner.cs
+++ b/Nautilus/MonoBehaviours/EntitySpawner.cs
@@ -35,45 +35,60 @@ internal class EntitySpawner : MonoBehaviour
         
         yield return new WaitUntil(() => lw != null && lw.streamer.globalRoot != null); // need to make sure global root is ready too for global spawns.
 
-        foreach (var spawnInfo in spawnInfos)
+        var remainingSpawns = new List<SpawnInfo>(spawnInfos);
+        while (remainingSpawns.Count > 0)
         {
-            string stringToLog = spawnInfo.Type switch
+            if (!global)
+                yield return new WaitUntil(() => lws.IsBatchReadyToCompile(batchId));
+
+            for (int i = remainingSpawns.Count - 1; i >= 0; i--)
             {
-                SpawnInfo.SpawnType.ClassId => spawnInfo.ClassId,
-                _ => spawnInfo.TechType.AsString()
-            };
+                var spawnInfo = remainingSpawns[i];
+                
+                string stringToLog = spawnInfo.Type switch
+                {
+                    SpawnInfo.SpawnType.ClassId => spawnInfo.ClassId,
+                    _ => spawnInfo.TechType.AsString()
+                };
             
-            InternalLogger.Debug($"Spawning {stringToLog}");
+                InternalLogger.Debug($"Spawning {stringToLog}");
             
-            TaskResult<GameObject> task = new();
-            yield return GetPrefabAsync(spawnInfo, task);
+                TaskResult<GameObject> task = new();
+                yield return GetPrefabAsync(spawnInfo, task);
 
-            GameObject prefab = task.Get();
-            if (prefab == null)
-            {
-                InternalLogger.Error($"no prefab found for {stringToLog}; process for Coordinated Spawn canceled.");
-                continue;
+                if (!global && !lws.IsBatchReadyToCompile(batchId))
+                {
+                    break;
+                }
+
+                GameObject prefab = task.Get();
+                if (prefab == null)
+                {
+                    InternalLogger.Error($"no prefab found for {stringToLog}; process for Coordinated Spawn canceled.");
+                    continue;
+                }
+
+                LargeWorldEntity lwe = prefab.GetComponent<LargeWorldEntity>();
+
+                if (!lwe)
+                {
+                    InternalLogger.Error($"No LargeWorldEntity component found for prefab '{stringToLog}'; process for Coordinated Spawn canceled.");
+                    continue;
+                }
+
+                GameObject obj = Instantiate(prefab, spawnInfo.SpawnPosition, spawnInfo.Rotation);
+                obj.transform.localScale = spawnInfo.ActualScale;
+
+                obj.SetActive(true);
+
+                spawnInfo.OnSpawned?.Invoke(obj);
+                remainingSpawns.RemoveAt(i);
+
+                LargeWorldEntity.Register(obj);
+
+                LargeWorldStreamerPatcher.SavedSpawnInfos.Add(spawnInfo);
+                InternalLogger.Debug($"spawned {stringToLog}.");
             }
-
-            LargeWorldEntity lwe = prefab.GetComponent<LargeWorldEntity>();
-
-            if (!lwe)
-            {
-                InternalLogger.Error($"No LargeWorldEntity component found for prefab '{stringToLog}'; process for Coordinated Spawn canceled.");
-                continue;
-            }
-
-            GameObject obj = Instantiate(prefab, spawnInfo.SpawnPosition, spawnInfo.Rotation);
-            obj.transform.localScale = spawnInfo.ActualScale;
-
-            obj.SetActive(true);
-
-            spawnInfo.OnSpawned?.Invoke(obj);
-
-            LargeWorldEntity.Register(obj);
-
-            LargeWorldStreamerPatcher.SavedSpawnInfos.Add(spawnInfo);
-            InternalLogger.Debug($"spawned {stringToLog}.");
         }
     }
 

--- a/Nautilus/MonoBehaviours/EntitySpawner.cs
+++ b/Nautilus/MonoBehaviours/EntitySpawner.cs
@@ -24,11 +24,13 @@ internal class EntitySpawner : MonoBehaviour
     {
         LargeWorldStreamer lws = LargeWorldStreamer.main;
         yield return new WaitUntil(() => lws != null && lws.IsReady()); // first we make sure the world streamer is initialized
+        
+        var batchReadyCheck = () => lws.IsBatchReadyToCompile(batchId);
 
         if (!global)
         {
             // then we wait until the terrain is fully loaded (must be checked on each frame for faster spawns)
-            yield return new WaitUntil(() => lws.IsBatchReadyToCompile(batchId));
+            yield return new WaitUntil(batchReadyCheck);
         }
 
         LargeWorld lw = LargeWorld.main;
@@ -39,7 +41,9 @@ internal class EntitySpawner : MonoBehaviour
         while (remainingSpawns.Count > 0)
         {
             if (!global)
-                yield return new WaitUntil(() => lws.IsBatchReadyToCompile(batchId));
+            {
+                yield return new WaitUntil(batchReadyCheck);
+            }
 
             for (int i = remainingSpawns.Count - 1; i >= 0; i--)
             {

--- a/Nautilus/MonoBehaviours/EntitySpawner.cs
+++ b/Nautilus/MonoBehaviours/EntitySpawner.cs
@@ -69,6 +69,7 @@ internal class EntitySpawner : MonoBehaviour
                 if (prefab == null)
                 {
                     InternalLogger.Error($"no prefab found for {stringToLog}; process for Coordinated Spawn canceled.");
+                    remainingSpawns.RemoveAt(i);
                     continue;
                 }
 
@@ -77,6 +78,7 @@ internal class EntitySpawner : MonoBehaviour
                 if (!lwe)
                 {
                     InternalLogger.Error($"No LargeWorldEntity component found for prefab '{stringToLog}'; process for Coordinated Spawn canceled.");
+                    remainingSpawns.RemoveAt(i);
                     continue;
                 }
 


### PR DESCRIPTION
### Changes made in this pull request

  - Previously, entities could continue to spawn in batches even after the batch unloaded, causing them to remain unparented and be deleted in the next session. This issue has plagued mods for years. This could fix most deleting prop issues and potentially some 0 0 0 issues.

### Breaking changes

  - None, only fixing changes.