### PR TITLE
WaitScreenHandler improvements

### DIFF
--- a/Nautilus/Handlers/WaitScreenHandler.cs
+++ b/Nautilus/Handlers/WaitScreenHandler.cs
@@ -20,11 +20,12 @@ public static class WaitScreenHandler
     /// scene and any GameObjects you create now will be destroyed once the in-game Main scene is loaded. Consider using
     /// <see cref="RegisterAsyncLoadTask"/> or <see cref="RegisterLateAsyncLoadTask"/> for that instead.
     /// </summary>
-    /// <param name="modName">The name of your mod. Will be displayed while this task is being worked on.</param>
+    /// <param name="modName">The name of your mod. Will be displayed while this task is being worked on. Accepts a
+    /// language key and can optionally be localised with <see cref="LanguageHandler"/>.</param>
     /// <param name="loadingFunction">The function that will be called.</param>
     /// <param name="description">An optional description to give users detailed information about what your task is
     /// doing. Can be updated even while your task is executing by setting
-    /// <see cref="WaitScreenTask"/>.<see cref="WaitScreenTask.Status"/>.</param>
+    /// <see cref="WaitScreenTask"/>.<see cref="WaitScreenTask.Status"/>. Accepts language keys for localisation.</param>
     public static void RegisterEarlyLoadTask(string modName, Action<WaitScreenTask> loadingFunction, string description = null)
     {
         WaitScreenPatcher.EarlyInitTasks.Add(new WaitScreenTask(modName, loadingFunction, description));
@@ -47,11 +48,12 @@ public static class WaitScreenHandler
     /// similar at this time during the loading process. For that purpose, consider using
     /// <see cref="RegisterLateAsyncLoadTask"/>.
     /// </summary>
-    /// <param name="modName">The name of your mod. Will be displayed while this task is being worked on.</param>
+    /// <param name="modName">The name of your mod. Will be displayed while this task is being worked on. Accepts a
+    /// language key and can optionally be localised with <see cref="LanguageHandler"/>.</param>
     /// <param name="loadingFunction">The function that will be called.</param>
     /// <param name="description">An optional description to give users detailed information about what your task is
     /// doing. Can be updated even while your task is executing by setting
-    /// <see cref="WaitScreenTask"/>.<see cref="WaitScreenTask.Status"/>.</param>
+    /// <see cref="WaitScreenTask"/>.<see cref="WaitScreenTask.Status"/>. Accepts language keys for localisation.</param>
     public static void RegisterLoadTask(string modName, Action<WaitScreenTask> loadingFunction, string description = null)
     {
         WaitScreenPatcher.InitTasks.Add(new WaitScreenTask(modName, loadingFunction, description));
@@ -71,11 +73,12 @@ public static class WaitScreenHandler
     /// setup at this point and is only waiting for any tasks registered through this method. Use this method for tasks
     /// that heavily rely on other GameObjects or singletons to be present, such as the Player, Inventory, or other mods.
     /// </summary>
-    /// <param name="modName">The name of your mod. Will be displayed while this task is being worked on.</param>
+    /// <param name="modName">The name of your mod. Will be displayed while this task is being worked on. Accepts a
+    /// language key and can optionally be localised with <see cref="LanguageHandler"/>.</param>
     /// <param name="loadingFunction">The function that will be called.</param>
     /// <param name="description">An optional description to give users detailed information about what your task is
     /// doing. Can be updated even while your task is executing by setting
-    /// <see cref="WaitScreenTask"/>.<see cref="WaitScreenTask.Status"/>.</param>
+    /// <see cref="WaitScreenTask"/>.<see cref="WaitScreenTask.Status"/>. Accepts language keys for localisation.</param>
     public static void RegisterLateLoadTask(string modName, Action<WaitScreenTask> loadingFunction, string description = null)
     {
         WaitScreenPatcher.LateInitTasks.Add(new WaitScreenTask(modName, loadingFunction, description));
@@ -101,6 +104,8 @@ public static class WaitScreenHandler
         /// <summary>
         /// Optional detailed information about what the mod is working on during this task. Can be updated during
         /// tasks to give the user detailed feedback about what exactly the mod is doing.
+        /// <br />
+        /// Accepts a language key and can be localised with <see cref="LanguageHandler"/> if desired.
         /// </summary>
         public string Status { get; set; }
 

--- a/Nautilus/Patchers/WaitScreenPatcher.cs
+++ b/Nautilus/Patchers/WaitScreenPatcher.cs
@@ -139,7 +139,7 @@ internal static class WaitScreenPatcher
         for (int i = 0; i < tasks.Count; i++)
         {
             var task = tasks[i];
-            InternalLogger.Debug($"Processing mod task by '{task.ModName}' ({i}/{tasks.Count})");
+            InternalLogger.Debug($"Processing mod task by '{task.ModName}' ({i + 1}/{tasks.Count})");
             loadingStage.SetProgress((float)i / tasks.Count);
             SetModStatus(loadingStage, task.ModName, task.Status, i + 1, tasks.Count);
 

--- a/Nautilus/Patchers/WaitScreenPatcher.cs
+++ b/Nautilus/Patchers/WaitScreenPatcher.cs
@@ -277,8 +277,6 @@ internal static class WaitScreenPatcher
         var gameObject = new GameObject("WaitScreenStatus");
         // Parent it to the loading screen itself.
         gameObject.transform.SetParent(uGUI.main.loading.loadingBackground.transform, false);
-        // Put the text right next to the spinning loading icon.
-        gameObject.transform.localPosition = new Vector3(-685f, -395f);
 
         var textMesh = gameObject.AddComponent<TextMeshProUGUI>();
         textMesh.font = FontUtils.Aller_Rg;
@@ -292,8 +290,10 @@ internal static class WaitScreenPatcher
         // If a mod message somehow gets too long, cut if off with an ellipsis (...)
         textMesh.overflowMode = TextOverflowModes.Ellipsis;
         textMesh.rectTransform.pivot = new Vector2(0f, 1f);
+        // Put the text right next to the spinning loading icon.
+        textMesh.rectTransform.anchorMin = new Vector2(0.12f, 0.15f);
         // Extend the available space to just before the other edge of the screen.
-        textMesh.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 1600f);
+        textMesh.rectTransform.anchorMax = new Vector2(0.85f, 0.15f);
 
         return textMesh;
     }

--- a/Nautilus/Patchers/WaitScreenPatcher.cs
+++ b/Nautilus/Patchers/WaitScreenPatcher.cs
@@ -283,6 +283,8 @@ internal static class WaitScreenPatcher
         var textMesh = gameObject.AddComponent<TextMeshProUGUI>();
         textMesh.font = FontUtils.Aller_Rg;
         textMesh.fontSize = 24f;
+        textMesh.outlineWidth = 0.3f;
+        textMesh.outlineColor = Color.black;
         textMesh.alignment = TextAlignmentOptions.MidlineLeft;
         // Keep this text label a single line that spans across the screen.
         textMesh.autoSizeTextContainer = false;

--- a/Nautilus/Patchers/WaitScreenPatcher.cs
+++ b/Nautilus/Patchers/WaitScreenPatcher.cs
@@ -184,7 +184,12 @@ internal static class WaitScreenPatcher
         var text = $"{stageDescriptor} ({current}/{total}): {modName}";
         if (!string.IsNullOrEmpty(status))
             text += " - " + status;
-        _statusText.text = text;
+
+        if (_statusText.text != text)
+        {
+            InternalLogger.Debug($"{modName} updated task status to '{status}'");
+            _statusText.text = text;
+        }
     }
 
     /// <summary>

--- a/Nautilus/Patchers/WaitScreenPatcher.cs
+++ b/Nautilus/Patchers/WaitScreenPatcher.cs
@@ -236,11 +236,12 @@ internal static class WaitScreenPatcher
 
     private static void SetModStatus(WaitScreen.ManualWaitItem stage, string modName, string status, int current, int total)
     {
+        var language = Language.main;
         var stageDescriptor = _modStatusMap[stage.stage];
         StringBuilder sb = new StringBuilder(stageDescriptor);
-        sb.AppendFormat(" ({0}/{1}): {2}", current, total, modName);
+        sb.AppendFormat(" ({0}/{1}): {2}", current, total, language.Get(modName));
         if (!string.IsNullOrEmpty(status))
-            sb.AppendFormat(" - {0}", status);
+            sb.AppendFormat(" - {0}", language.Get(status));
 
         var text = sb.ToString();
         if (_statusText.text != text)
@@ -255,10 +256,11 @@ internal static class WaitScreenPatcher
     /// </summary>
     private static void SetModError(string modName, string status)
     {
+        var language = Language.main;
         StringBuilder sb = new StringBuilder();
-        sb.AppendFormat("<color=#FF0000FF><b>CRASHED: {0}", modName);
+        sb.AppendFormat("<color=#FF0000FF><b>CRASHED: {0}", language.Get(modName));
         if (!string.IsNullOrEmpty(status))
-            sb.AppendFormat(" during '{0}'", status);
+            sb.AppendFormat(" during '{0}'", language.Get(status));
         sb.AppendLine("</b></color>");
         sb.Append("Please check the log file for more error information.");
 


### PR DESCRIPTION
### Changes made in this pull request

  - The task number in the debug logs reflects the task number on screen (previously off by one).
  - Write to the debug log when a mod changes its task status for easier debugging for mod authors.
  - Async tasks with nested IEnumerators are able to update their task status properly during execution of the nested method.
  - Any exceptions thrown during a task are highlighted in red on screen for the benefit of the user.
    - Execution of the rest of the WaitScreen is halted, forcing the user to Alt-F4. Previously, execution would only halt during the Early stage while regular and Late would continue despite the error.
    - Halting execution is preferable to protect users' save files.
 - Mod task names and statuses accept language keys and can be localised.
   - This is a bit awkward as the parts of the message provided by Nautilus (loading stage names) are still hardcoded to English. This should be addressed in a separate PR which localises Nautilus as a whole.
 - Task status has a small outline that makes the otherwise white-on-white text more legible, especially on BZ.
 - Text position is set via anchors, fixing widescreen monitors.

### Breaking changes

  - None.