### PR TITLE
Recipes added in-game not getting registered

### DIFF
--- a/Nautilus/Handlers/CraftDataHandler.cs
+++ b/Nautilus/Handlers/CraftDataHandler.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using Nautilus.Crafting;
 using Nautilus.Extensions;

--- a/Nautilus/Handlers/CraftDataHandler.cs
+++ b/Nautilus/Handlers/CraftDataHandler.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using Nautilus.Crafting;
 using Nautilus.Extensions;
 using Nautilus.Patchers;
@@ -85,6 +87,11 @@ public static class CraftDataHandler
             };
             current++;
         }
+
+        if (Player.main)
+        {
+            TechData.cachedIngredients[techType] = ingredients.ToList().AsReadOnly();
+        }
     }
 
     /// <summary>
@@ -120,6 +127,11 @@ public static class CraftDataHandler
             linkedItemslist.Add(new JsonValue(current));
             linkedItemslist[current] = new JsonValue((int)i);
             current++;
+        }
+        
+        if (Player.main)
+        {
+            TechData.cachedLinkedItems[techType] = linkedItems.ToList().AsReadOnly();
         }
     }
 


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed a bug where recipes were tied to patch-time, so when you register one in-game you'll still able to retrieve it using `CraftDataHandler.GetRecipe`, but it isn't actually added to the game's dictionaries, resulting in NREs or recipes with empty ingredients.