### PR TITLE
Use more authentic wait screen

### DIFF
--- a/Nautilus/Patchers/WaitScreenPatcher.cs
+++ b/Nautilus/Patchers/WaitScreenPatcher.cs
@@ -278,8 +278,8 @@ internal static class WaitScreenPatcher
         var textMesh = gameObject.AddComponent<TextMeshProUGUI>();
         textMesh.font = FontUtils.Aller_Rg;
         textMesh.fontSize = 24f;
-        textMesh.outlineWidth = 0.3f;
-        textMesh.outlineColor = Color.black;
+        textMesh.outlineWidth = 0.1f;
+        textMesh.outlineColor = new Color32(0, 0, 0, 100);
         textMesh.alignment = TextAlignmentOptions.MidlineLeft;
         // Keep this text label a single line that spans across the screen.
         textMesh.autoSizeTextContainer = false;

--- a/Nautilus/Patchers/WaitScreenPatcher.cs
+++ b/Nautilus/Patchers/WaitScreenPatcher.cs
@@ -28,14 +28,14 @@ internal static class WaitScreenPatcher
     {
         // Early Mod Loading
         {"FadeInDummy", "Preparing..."},
-        {"SaveFilesLoad", "Loading save files"},
-        {"SceneMain", "Loading game environment"},
+        {"SaveFilesLoad", "Preparing..."},
+        {"SceneMain", "Preparing..."},
         // Mod Loading
-        {"SceneEssentials", "Loading game environment"},
-        {"SceneCyclops", "Loading Cyclops assets"},
-        {"SceneEscapePod", "Loading Lifepod assets"},
-        {"SceneAurora", "Loading Aurora assets"},
-        {"Builder", "Loading world"},
+        {"SceneEssentials", "Loading level"},
+        {"SceneCyclops", "Loading Cyclops"},
+        {"SceneEscapePod", "Loading Escape pod"},
+        {"SceneAurora", "Loading Aurora"},
+        {"Builder", "Preloading base"},
         {"WorldMount", "Loading world"},
         {"WorldTiles", "Loading world"},
         {"Batches", "Loading world"},
@@ -43,8 +43,8 @@ internal static class WaitScreenPatcher
         {"Terrain", "Loading world"},
         {"Clipmap", "Loading world"},
         {"UpdatingVisibility", "Loading world"},
-        {"EntityCells", "Loading entities"},
-        {"WorldSettle", "Finalising world"},
+        {"EntityCells", "Loading entity cells"},
+        {"WorldSettle", "Finalizing world"},
         {"Equipment", "Loading equipment"}
         // Late Mod Loading
     };


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed outline being too prominent and breaking the style
  - Updated wait screen text localization to match how it looked at SN1's launch

### Breaking changes

  - None