### PR TITLE
Corrected bindable error log

### DIFF
--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -171,9 +171,16 @@ internal class OptionsPanelPatcher
             panel.AddHeading(tab, category);
             foreach (var button in buttons)
             {
-                if (!GameInputPatcher.BindableButtons.Contains((button, device)))
+                // ReSharper disable once SimplifyLinqExpressionUseAll
+                if (!GameInputPatcher.BindableButtons.Any(h => h.button == button))
                 {
                     InternalLogger.Error($"Button '{button}' has a category but wasn't set to be bindable. Please set the button to be bindable first.");
+                    continue;
+                }
+                
+                if (!GameInputPatcher.BindableButtons.Contains((button, device)))
+                {
+                    InternalLogger.Debug($"Button '{button}' wasn't set to be bindable for device '{device}', skipping binding option.");
                     continue;
                 }
                 


### PR DESCRIPTION
### Changes made in this pull request

  - Changed the error log for bindable buttons to only check if a button was set to bindable, rather than also look-up the device.
  - Added a new debug log that checks for the device
  
Fixes #643
