### PR TITLE
Docs: Documented support for language IDs in `ChoiceAttribute`'s `Options` list

### DIFF
--- a/Nautilus/Options/Attributes/ChoiceAttribute.cs
+++ b/Nautilus/Options/Attributes/ChoiceAttribute.cs
@@ -50,7 +50,7 @@ public sealed class ChoiceAttribute : ModOptionAttribute
     /// </remarks>
     /// <param name="label">The label for the choice. If none is set, the name of the member will be used.</param>
     /// <param name="options">The list of options for the user to choose from. Values may be either ordinary strings for
-    /// direct display, or IDs for lookup with <see cref="Language.Get(string)"/> for translation. Use the
+    /// direct display, or IDs for lookup with <c>Language.Get(string)</c> for translation. Use the
     /// <see cref="Handlers.LanguageHandler"/> API to register translation strings.</param>
     public ChoiceAttribute(string label = null, params string[] options) : base(label)
     {
@@ -66,7 +66,7 @@ public sealed class ChoiceAttribute : ModOptionAttribute
     /// <see cref="Enum"/> choices can also be parsed from their values by merely omitting the <paramref name="options"/>.
     /// </remarks>
     /// <param name="options">The list of options for the user to choose from. Values may be either ordinary strings for
-    /// direct display, or IDs for lookup with <see cref="Language.Get(string)"/> for translation. Use the
+    /// direct display, or IDs for lookup with <c>Language.Get(string)</c> for translation. Use the
     /// <see cref="Handlers.LanguageHandler"/> API to register translation strings.</param>
     public ChoiceAttribute(string[] options) : this(null, options) { }
 

--- a/Nautilus/Options/Attributes/ChoiceAttribute.cs
+++ b/Nautilus/Options/Attributes/ChoiceAttribute.cs
@@ -49,7 +49,8 @@ public sealed class ChoiceAttribute : ModOptionAttribute
     /// <see cref="Enum"/> choices can also be parsed from their values by merely omitting the <paramref name="options"/>.
     /// </remarks>
     /// <param name="label">The label for the choice. If none is set, the name of the member will be used.</param>
-    /// <param name="options">The list of options for the user to choose from.</param>
+    /// <param name="options">The list of options for the user to choose from. Values may be either ordinary strings for
+    /// direct display, or IDs for language-based lookup using the <see cref="Handlers.LanguageHandler"/> API.</param>
     public ChoiceAttribute(string label = null, params string[] options) : base(label)
     {
         Options = options;
@@ -63,7 +64,8 @@ public sealed class ChoiceAttribute : ModOptionAttribute
     /// <remarks>
     /// <see cref="Enum"/> choices can also be parsed from their values by merely omitting the <paramref name="options"/>.
     /// </remarks>
-    /// <param name="options">The list of options for the user to choose from.</param>
+    /// <param name="options">The list of options for the user to choose from. Values may be either ordinary strings for
+    /// direct display, or IDs for language-based lookup using the <see cref="Handlers.LanguageHandler"/> API.</param>
     public ChoiceAttribute(string[] options) : this(null, options) { }
 
     /// <summary>

--- a/Nautilus/Options/Attributes/ChoiceAttribute.cs
+++ b/Nautilus/Options/Attributes/ChoiceAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Nautilus.Json;
 
 namespace Nautilus.Options.Attributes;
@@ -50,7 +50,8 @@ public sealed class ChoiceAttribute : ModOptionAttribute
     /// </remarks>
     /// <param name="label">The label for the choice. If none is set, the name of the member will be used.</param>
     /// <param name="options">The list of options for the user to choose from. Values may be either ordinary strings for
-    /// direct display, or IDs for language-based lookup using the <see cref="Handlers.LanguageHandler"/> API.</param>
+    /// direct display, or IDs for lookup with <see cref="Language.Get(string)"/> for translation. Use the
+    /// <see cref="Handlers.LanguageHandler"/> API to register translation strings.</param>
     public ChoiceAttribute(string label = null, params string[] options) : base(label)
     {
         Options = options;
@@ -65,7 +66,8 @@ public sealed class ChoiceAttribute : ModOptionAttribute
     /// <see cref="Enum"/> choices can also be parsed from their values by merely omitting the <paramref name="options"/>.
     /// </remarks>
     /// <param name="options">The list of options for the user to choose from. Values may be either ordinary strings for
-    /// direct display, or IDs for language-based lookup using the <see cref="Handlers.LanguageHandler"/> API.</param>
+    /// direct display, or IDs for lookup with <see cref="Language.Get(string)"/> for translation. Use the
+    /// <see cref="Handlers.LanguageHandler"/> API to register translation strings.</param>
     public ChoiceAttribute(string[] options) : this(null, options) { }
 
     /// <summary>


### PR DESCRIPTION
### Changes made in this pull request

  - Modified doc comments for `ChoiceAttribute` constructors to mention localization-lookup support in the `options` list parameters.

### Breaking changes

  - n/a