### PR TITLE
Update `Customizing your C# Project` tutorial to warn users of different `copy` commands

### DIFF
--- a/Nautilus/Documentation/tutorials/csproj-tutorials.md
+++ b/Nautilus/Documentation/tutorials/csproj-tutorials.md
@@ -105,7 +105,9 @@ Still in the csproj, add the following outside of any PropertyGroups:
 
 You shouldn't have to change this.
 
-### Step 4
+#### Step 4
+
+NOTE: if your OS does not have the `copy` command, such as MacOS, please look up your copy command and the flags necessary to copy files.
 
 Finally, once again in the csproj outside of any PropertyGroups, add the following:
 
@@ -116,6 +118,11 @@ Finally, once again in the csproj outside of any PropertyGroups, add the followi
 </Target>
 ```
 
+If you want to do the same for a .pdb file, add this to just before `</Target>`:
+
+```xml
+    <Exec Command="copy /Y &quot;$(TargetDir)/$(TargetName).pdb&quot; &quot;$(PluginsDir)/$(TargetName)&quot; />"
+```
 Make sure a folder exists in the BepInEx/plugins folder with the same name as your mod DLL.
 
-If everything went correctly, upon building your project the DLL should be automatically placed in the correct location, meaning you do not have to manually move the DLL anymore!
+If everything went correctly, upon building your project the DLL should be automatically placed in the correct location, meaning you do not have to manually move the DLL anymore! If everything did not go correctly, and you get an error when building, then look up your OS's copy command and flags and go from there. Ensure that the flags you use go in front of your copy command but before the path lines, and that the flags are for copying files.

--- a/Nautilus/Documentation/tutorials/csproj-tutorials.md
+++ b/Nautilus/Documentation/tutorials/csproj-tutorials.md
@@ -108,7 +108,7 @@ Finally, once again in the csproj outside of any PropertyGroups, add the followi
 ```xml
 <!--Post-Build event that automatically places your mods folder with the DLL and documentation into your plugins folder as defined in GameDir.targets-->
 <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <MakeDir Directories="$(PluginsDir)\$(TargetName)" />
+	<MakeDir Directories="$(PluginsDir)\$(TargetName)" />
 	<Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginsDir)\$(TargetName)" />
 </Target>
 ```

--- a/Nautilus/Documentation/tutorials/csproj-tutorials.md
+++ b/Nautilus/Documentation/tutorials/csproj-tutorials.md
@@ -112,14 +112,14 @@ Finally, once again in the csproj outside of any PropertyGroups, add the followi
 ```xml
 <!--Post-Build event that automatically places your mods folder with the DLL and documentation into your plugins folder as defined in GameDir.targets-->
 <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-	<Copy SourceFiles="&quot;$(TargetPath)&quot;" DestinationFolder="&quot;$(PluginsDir)\$(TargetName)&quot;" />
+	<Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginsDir)\$(TargetName)" />
 </Target>
 ```
 
 If you want to do the same for a .pdb file, add this to just before `</Target>`:
 
 ```xml
-    <Copy SourceFiles="&quot;$(TargetDir)\(TargetName).pdb&quot;" DestinationFolder="&quot;$(PluginsDir)\$(TargetName)&quot;" />
+    <Copy SourceFiles="$(TargetDir)\(TargetName).pdb" DestinationFolder="$(PluginsDir)\$(TargetName)" />
 ```
 Make sure a folder exists in the BepInEx/plugins folder with the same name as your mod DLL.
 

--- a/Nautilus/Documentation/tutorials/csproj-tutorials.md
+++ b/Nautilus/Documentation/tutorials/csproj-tutorials.md
@@ -108,7 +108,7 @@ Finally, once again in the csproj outside of any PropertyGroups, add the followi
 ```xml
 <!--Post-Build event that automatically places your mods folder with the DLL and documentation into your plugins folder as defined in GameDir.targets-->
 <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <MakeDir Directories="$(PluginsDir)\$(TargetName)"/>
+    <MakeDir Directories="$(PluginsDir)\$(TargetName)" />
 	<Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginsDir)\$(TargetName)" />
 </Target>
 ```

--- a/Nautilus/Documentation/tutorials/csproj-tutorials.md
+++ b/Nautilus/Documentation/tutorials/csproj-tutorials.md
@@ -107,22 +107,20 @@ You shouldn't have to change this.
 
 #### Step 4
 
-NOTE: if your OS does not have the `copy` command, such as MacOS, please look up your copy command and the flags necessary to copy files.
-
 Finally, once again in the csproj outside of any PropertyGroups, add the following:
 
 ```xml
 <!--Post-Build event that automatically places your mods folder with the DLL and documentation into your plugins folder as defined in GameDir.targets-->
 <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-	<Exec Command="copy /Y &quot;$(TargetPath)&quot; &quot;$(PluginsDir)\$(TargetName)&quot;" />
+	<Copy SourceFiles="&quot;$(TargetPath)&quot;" DestinationFolder="&quot;$(PluginsDir)\$(TargetName)&quot;" />
 </Target>
 ```
 
 If you want to do the same for a .pdb file, add this to just before `</Target>`:
 
 ```xml
-    <Exec Command="copy /Y &quot;$(TargetDir)/$(TargetName).pdb&quot; &quot;$(PluginsDir)/$(TargetName)&quot; />"
+    <Copy SourceFiles="&quot;$(TargetDir)\(TargetName).pdb&quot;" DestinationFolder="&quot;$(PluginsDir)\$(TargetName)&quot;" />
 ```
 Make sure a folder exists in the BepInEx/plugins folder with the same name as your mod DLL.
 
-If everything went correctly, upon building your project the DLL should be automatically placed in the correct location, meaning you do not have to manually move the DLL anymore! If everything did not go correctly, and you get an error when building, then look up your OS's copy command and flags and go from there. Ensure that the flags you use go in front of your copy command but before the path lines, and that the flags are for copying files.
+If everything went correctly, upon building your project the DLL should be automatically placed in the correct location, meaning you do not have to manually move the DLL anymore!

--- a/Nautilus/Documentation/tutorials/csproj-tutorials.md
+++ b/Nautilus/Documentation/tutorials/csproj-tutorials.md
@@ -64,8 +64,8 @@ This should be the entire contents of the file:
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<!--If trying to build this project, please make sure the correct directory to your Subnautica folder is listed below:-->
-		<GameDir>C:\Program Files (x86)\Steam\steamapps\common\Subnautica</GameDir>
+      <!--If trying to build this project, please make sure the correct directory to your Subnautica folder is listed below:-->
+      <GameDir>C:\Program Files (x86)\Steam\steamapps\common\Subnautica</GameDir>
 	</PropertyGroup>
 </Project>
 ```

--- a/Nautilus/Documentation/tutorials/csproj-tutorials.md
+++ b/Nautilus/Documentation/tutorials/csproj-tutorials.md
@@ -108,6 +108,7 @@ Finally, once again in the csproj outside of any PropertyGroups, add the followi
 ```xml
 <!--Post-Build event that automatically places your mods folder with the DLL and documentation into your plugins folder as defined in GameDir.targets-->
 <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <MakeDir Directories="$(PluginsDir)\$(TargetName)"/>
 	<Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginsDir)\$(TargetName)" />
 </Target>
 ```
@@ -115,6 +116,7 @@ Finally, once again in the csproj outside of any PropertyGroups, add the followi
 If you want to do the same for a .pdb file, add this to just before `</Target>`:
 
 ```xml
+    
     <Copy SourceFiles="$(TargetDir)\(TargetName).pdb" DestinationFolder="$(PluginsDir)\$(TargetName)" />
 ```
 Make sure a folder exists in the BepInEx/plugins folder with the same name as your mod DLL.

--- a/Nautilus/Documentation/tutorials/csproj-tutorials.md
+++ b/Nautilus/Documentation/tutorials/csproj-tutorials.md
@@ -54,10 +54,6 @@ Example:
 
 It is possible to use post-build scripts that automatically place your mod's DLL into the BepInEx plugins folder right after you hit Build.
 
-> [!IMPORTANT]
-> If you plan on using GitHub Actions to automate mod builds, or have many contributors with varying operating systems, this is NOT recommended. I can only test this on Windows.
-Because of the aforementioned reasons, we do *not* use this in Nautilus. However, it can be very convenient for your own personal projects.
-
 #### Step 1
 
 In the same folder as your csproj, create a file named "GameDir.targets".

--- a/Nautilus/Documentation/tutorials/csproj-tutorials.md
+++ b/Nautilus/Documentation/tutorials/csproj-tutorials.md
@@ -64,8 +64,8 @@ This should be the entire contents of the file:
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-      <!--If trying to build this project, please make sure the correct directory to your Subnautica folder is listed below:-->
-      <GameDir>C:\Program Files (x86)\Steam\steamapps\common\Subnautica</GameDir>
+		<!--If trying to build this project, please make sure the correct directory to your Subnautica folder is listed below:-->
+		<GameDir>C:\Program Files (x86)\Steam\steamapps\common\Subnautica</GameDir>
 	</PropertyGroup>
 </Project>
 ```


### PR DESCRIPTION
Someone mentioned on discord that this tutorial does not offer cross compatibility, so I figured I'd fix my PR that was intended to fix something else to fit cross compatibility.

### Changes made in this pull request

  - Updated the `Customizing your C# Project` quick reference tutorial to use MSBuild's `Copy` instead of terminal copy
  - Fixed `Step 4` being an incorrect header

### Breaking changes
how could there be one its literally a docs change lol