### PR TITLE
Remove extra plugins folder from zip folder

### DIFF
--- a/PostBuild.targets
+++ b/PostBuild.targets
@@ -54,7 +54,7 @@
         <MakeDir Directories="$(TemporaryBuildDir)" />
 
         <!-- Main zip file -->
-        <Copy SourceFiles="@(PluginsFiles)" DestinationFolder="$(TemporaryBuildDir)\plugins\%(RecursiveDir)" SkipUnchangedFiles="true" />
+        <Copy SourceFiles="@(PluginsFiles)" DestinationFolder="$(TemporaryBuildDir)\%(RecursiveDir)" SkipUnchangedFiles="true" />
         
         <!-- Main build zip file -->
         <ZipDirectory SourceDirectory="$(TemporaryBuildDir)"


### PR DESCRIPTION
I disliked the fact that there was an extra plugins folder in the zip file created upon build, which is a discrepancy between many mods, but I'd like it to start here, where people are going to assume this is how modding works. I don't mind if this gets rejected, but if it does, I would still appreciate feedback.
### Changes made in this pull request

  - Updated `PostBuild.targets` to remove an extra plugins folder from the zip folder automatically made upon build

### Breaking changes
n/a