### PR TITLE
MaterialUtils: Major cleanup and material conversions for detail maps

### DIFF
--- a/Nautilus/Utility/MaterialUtils.cs
+++ b/Nautilus/Utility/MaterialUtils.cs
@@ -52,6 +52,7 @@ public static partial class MaterialUtils
     // Transparency, sorting and miscellaneous
     private const string ZWriteKeyword = "_ZWRITE_ON";
     private const string AlphaClipKeyword = "MARMO_ALPHA_CLIP";
+    private const string WboitKeyword = "WBOIT";
 
     internal static void Patch()
     {
@@ -364,7 +365,7 @@ public static partial class MaterialUtils
     {
         if (transparent)
         {
-            material.EnableKeyword("WBOIT");
+            material.EnableKeyword(WboitKeyword);
             material.SetInt(ShaderPropertyID._ZWrite, 0);
             material.SetInt(ShaderPropertyID._Cutoff, 0);
             material.SetFloat(ShaderPropertyID._SrcBlend, 1f);
@@ -387,7 +388,7 @@ public static partial class MaterialUtils
             material.SetFloat(ShaderPropertyID._AddDstBlend, 0f);
             material.SetFloat(ShaderPropertyID._AddSrcBlend2, 1f);
             material.SetFloat(ShaderPropertyID._AddDstBlend2, 0f);
-            material.DisableKeyword("WBOIT");
+            material.DisableKeyword(WboitKeyword);
         }
         material.renderQueue = transparent ? kTransparencyRenderQueue : kOpaqueRenderQueue;
     }

--- a/Nautilus/Utility/MaterialUtils.cs
+++ b/Nautilus/Utility/MaterialUtils.cs
@@ -47,7 +47,7 @@ public static partial class MaterialUtils
     private static readonly int _detailBumpTexSt = Shader.PropertyToID("_DetailBumpTex_ST");
     private static readonly int _detailIntensities = Shader.PropertyToID("_DetailIntensities");
     private const string DetailMapKeyword = "UWE_DETAILMAP";
-    private const float DefaultDetailDiffuseIntensity = 0.5f;
+    private const float DefaultDetailDiffuseIntensity = 1.0f;
     
     // Transparency, sorting and miscellaneous
     private const string ZWriteKeyword = "_ZWRITE_ON";


### PR DESCRIPTION
### Changes made in this pull request

  - Detail maps are now automatically recognized from the `Standard` and `Standard (Specular setup)` shaders and will be applied to MarmosetUBER shaders using the correct textures, normal map intensity, tiling and offset values.
    - This does not cover detail specular textures.
  - Converted many magic values and shader keyword names to constants.
  - Minor formatting updates.

### Breaking changes

  - Materials in mods that used detail maps before this PR will now have them appear in-game. This should not negatively impact most mods that used Unity as a preview for how materials would appear in-game, since the Unity editor is now a *more* accurate preview.