### PR TITLE
Recipe data removal

### DIFF
--- a/Nautilus/Handlers/CraftDataHandler.cs
+++ b/Nautilus/Handlers/CraftDataHandler.cs
@@ -16,10 +16,16 @@ public static class CraftDataHandler
     /// <para>Can be used for existing TechTypes too.</para>
     /// </summary>
     /// <param name="techType">The TechType whose RecipeData you want to edit.</param>
-    /// <param name="recipeData">The RecipeData for that TechType.</param>
+    /// <param name="recipeData">The RecipeData for that TechType. If null and the tech type already has a recipe, it will get removed instead.</param>
     /// <seealso cref="RecipeData"/>
     public static void SetRecipeData(TechType techType, RecipeData recipeData)
     {
+        if (recipeData is null)
+        {
+            RemoveRecipeData(techType);
+            return;
+        }
+        
         if (CraftDataPatcher.CustomRecipeData.TryGetValue(techType, out JsonValue jsonValue))
         {
             jsonValue[TechData.PropertyToID("techType")] = new JsonValue((int)techType);

--- a/Nautilus/Handlers/CraftDataHandler.cs
+++ b/Nautilus/Handlers/CraftDataHandler.cs
@@ -60,19 +60,19 @@ public static class CraftDataHandler
     {
         if (CraftDataPatcher.CustomRecipeData.TryGetValue(techType, out JsonValue jsonValue))
         {
-            jsonValue[TechData.PropertyToID("techType")] = null;
-            jsonValue[TechData.PropertyToID("craftAmount")] = null;
-            jsonValue[TechData.PropertyToID("ingredients")] = null;
-            jsonValue[TechData.PropertyToID("amount")] = null;
+            jsonValue[TechData.PropertyToID("techType")] = new();
+            jsonValue[TechData.PropertyToID("craftAmount")] = new();
+            jsonValue[TechData.PropertyToID("ingredients")] = new();
+            jsonValue[TechData.PropertyToID("amount")] = new();
         }
         else
         {
             jsonValue = new JsonValue
             {
-                {TechData.PropertyToID("techType"), null},
-                {TechData.PropertyToID("craftAmount"), null},
-                {TechData.PropertyToID("ingredients"), null},
-                {TechData.PropertyToID("amount"), null}
+                {TechData.PropertyToID("techType"), new()},
+                {TechData.PropertyToID("craftAmount"), new()},
+                {TechData.PropertyToID("ingredients"), new()},
+                {TechData.PropertyToID("amount"), new()}
             };
             
             CraftDataPatcher.CustomRecipeData.Add(techType, jsonValue);

--- a/Nautilus/Handlers/CraftDataHandler.cs
+++ b/Nautilus/Handlers/CraftDataHandler.cs
@@ -47,6 +47,39 @@ public static class CraftDataHandler
     }
 
     /// <summary>
+    /// Removes the recipe data from an item.
+    /// </summary>
+    /// <param name="techType">The item Tech type.</param>
+    public static void RemoveRecipeData(TechType techType)
+    {
+        if (CraftDataPatcher.CustomRecipeData.TryGetValue(techType, out JsonValue jsonValue))
+        {
+            jsonValue[TechData.PropertyToID("techType")] = null;
+            jsonValue[TechData.PropertyToID("craftAmount")] = null;
+            jsonValue[TechData.PropertyToID("ingredients")] = null;
+            jsonValue[TechData.PropertyToID("amount")] = null;
+        }
+        else
+        {
+            jsonValue = new JsonValue
+            {
+                {TechData.PropertyToID("techType"), null},
+                {TechData.PropertyToID("craftAmount"), null},
+                {TechData.PropertyToID("ingredients"), null},
+                {TechData.PropertyToID("amount"), null}
+            };
+            
+            CraftDataPatcher.CustomRecipeData.Add(techType, jsonValue);
+        }
+
+        if (Player.main)
+        {
+            TechData.cachedIngredients.Remove(techType);
+            TechData.cachedLinkedItems.Remove(techType);
+        }
+    }
+
+    /// <summary>
     /// <para>Allows you to edit recipes for TechTypes.</para>
     /// <para>Can be used for existing TechTypes too.</para>
     /// </summary>

--- a/Nautilus/Patchers/CraftDataPatcher.cs
+++ b/Nautilus/Patchers/CraftDataPatcher.cs
@@ -47,8 +47,15 @@ internal class CraftDataPatcher
                 if (techData != jsonValue)
                 {
                     updated.Add(techType);
+                    
                     foreach (int key in jsonValue.Keys)
                     {
+                        if (jsonValue[key] is null)
+                        {
+                            techData.Remove(key);
+                            continue;
+                        }
+                        
                         techData[key] = jsonValue[key];
                     }
                 }

--- a/Nautilus/Patchers/CraftDataPatcher.cs
+++ b/Nautilus/Patchers/CraftDataPatcher.cs
@@ -50,7 +50,7 @@ internal class CraftDataPatcher
                     
                     foreach (int key in jsonValue.Keys)
                     {
-                        if (jsonValue[key] is null)
+                        if (jsonValue[key] is null or { propertyType: JsonValue.Type.None })
                         {
                             techData.Remove(key);
                             continue;


### PR DESCRIPTION
### Changes made in this pull request

  - Added a new `RemoveRecipeData` method
  - Setting `SetRecipeData(TechType, null)` now removes the recipe data for TechType, if it exists.

Fixes #654