### PR TITLE
SaveDataCache carries ref values across saves

### DIFF
--- a/Nautilus/Utility/JsonUtils.cs
+++ b/Nautilus/Utility/JsonUtils.cs
@@ -18,21 +18,6 @@ namespace Nautilus.Utility;
 /// </summary>
 public static class JsonUtils
 {
-    private static class Defaults
-    {
-        private static Dictionary<Type, object> _defaults = new();
-
-        public static object GetValue(Type type)
-        {
-            if (_defaults.TryGetValue(type, out var result))
-            {
-                return result;
-            }
-            
-            return _defaults[type] = Activator.CreateInstance(type);
-        }
-    }
-    
     private static string GetDefaultPath<T>(Assembly assembly) where T : class
     {
         return Path.Combine(
@@ -61,7 +46,7 @@ public static class JsonUtils
             throw new ArgumentNullException(nameof(contract));
         }
 
-        var @default = Defaults.GetValue(target.GetType());
+        var @default = Activator.CreateInstance(target.GetType());
         
         foreach (var property in contract.Properties)
         {


### PR DESCRIPTION
### Changes made in this pull request

  - Fixed a bug where if you get into a save that has a save data cache, then you quit to main menu, then create a new world, the cache from the previous save would get carried to the new one.

#600 only fixed the issue for value types; this one should make it work for any member.
Fixes #658

### Builds (up-to-date with 92613e5)
- SN1: [Nautilus_SN.STABLE_1.0.0.1.49.zip](https://github.com/user-attachments/files/25263016/Nautilus_SN.STABLE_1.0.0.1.49.zip)
- BZ: [Nautilus_BZ.STABLE_1.0.0.1.49.zip](https://github.com/user-attachments/files/25263062/Nautilus_BZ.STABLE_1.0.0.1.49.zip)
