### PR TITLE
Add utility method to simplify spawning prefabs as children

### DIFF
--- a/Nautilus/Utility/PrefabUtils.cs
+++ b/Nautilus/Utility/PrefabUtils.cs
@@ -428,7 +428,7 @@ public static class PrefabUtils
             return;
         }
 
-        var child = Object.Instantiate(prefab);
+        var child = UWE.Utils.InstantiateDeactivated(prefab);
         var childTransform = child.transform;
 
         childTransform.SetParent(parentObject.transform);
@@ -452,6 +452,8 @@ public static class PrefabUtils
             }
         }
 
+        child.SetActive(true);
+        
         result?.Set(child);
     }
 }

--- a/Nautilus/Utility/PrefabUtils.cs
+++ b/Nautilus/Utility/PrefabUtils.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UWE;
+using Object = UnityEngine.Object;
 
 namespace Nautilus.Utility;
 
@@ -358,5 +361,97 @@ public static class PrefabUtils
         wf.underwaterGravity = underwaterGravity;
         wf.underwaterDrag = underwaterDrag;
         return wf;
+    }
+    
+    /// <summary>
+    /// Instantiates the prefab with the given Class ID as a child of <paramref name="parentObject"/>, removing the specified components.
+    /// </summary>
+    /// <param name="parentObject">The parent GameObject to instantiate the child under.</param>
+    /// <param name="classId">The Class ID of the entity to instantiate as the child object.</param>
+    /// <param name="result">If provided, receives a reference to the spawned child object. You may want to use an instance of the <see cref="TaskResult{T}"/> class.</param>
+    /// <param name="stripComponents">If this parameter is true, this utility destroys any <see cref="LargeWorldEntity"/>, <see cref="PrefabIdentifier"/>, <see cref="Rigidbody"/>, <see cref="WorldForces"/>, and <see cref="TechTag"/> components on the root.</param>
+    /// <param name="stripSkyAppliers">If this parameter is true, all <see cref="SkyApplier"/> components on the object and its children will be destroyed.</param>
+    /// <remarks>
+    /// <para>The instantiated child object will be given default values (0, 0, 0) for its local position and rotation.</para>
+    /// <para>This method must be called asynchronously (using coroutines).</para>
+    /// </remarks>
+    public static IEnumerator AddChildPrefab(GameObject parentObject, string classId, IOut<GameObject> result = null, bool stripComponents = true, bool stripSkyAppliers = true)
+    {
+        var task = PrefabDatabase.GetPrefabAsync(classId);
+        yield return task;
+
+        if (!task.TryGetPrefab(out var prefab) || prefab == null)
+        {
+            InternalLogger.Error(
+                $"Could not load prefab by ClassId '{classId}' to add to parent '{parentObject}'");
+            result?.Set(null);
+            yield break;
+        }
+
+        AddPrefabAsChildInternal(parentObject, prefab, result, stripComponents, stripSkyAppliers);
+    }
+    
+    /// <summary>
+    /// Instantiates the prefab with the given <see cref="TechType"/> as a child of <paramref name="parentObject"/>, removing the specified components.
+    /// </summary>
+    /// <param name="parentObject">The parent GameObject to instantiate the child under.</param>
+    /// <param name="techType">The <see cref="TechType"/> of the entity to instantiate as the child object.</param>
+    /// <param name="result">If provided, receives a reference to the spawned child object. You may want to use an instance of the <see cref="TaskResult{T}"/> class.</param>
+    /// <param name="stripComponents">If this parameter is true, this utility destroys any <see cref="LargeWorldEntity"/>, <see cref="PrefabIdentifier"/>, <see cref="Rigidbody"/>, <see cref="WorldForces"/>, and <see cref="TechTag"/> components on the root.</param>
+    /// <param name="stripSkyAppliers">If this parameter is true, all <see cref="SkyApplier"/> components on the object and its children will be destroyed.</param>
+    /// <remarks>
+    /// <para>The instantiated child object will be given default values (0, 0, 0) for its local position and rotation.</para>
+    /// <para>This method must be called asynchronously (using coroutines).</para>
+    /// </remarks>
+    public static IEnumerator AddChildPrefab(GameObject parentObject, TechType techType, IOut<GameObject> result = null, bool stripComponents = true, bool stripSkyAppliers = true)
+    {
+        var task = CraftData.GetPrefabForTechTypeAsync(techType);
+        yield return task;
+        var prefab = task.GetResult();
+        
+        if (prefab == null)
+        {
+            InternalLogger.Error(
+                $"Could not load prefab by TechType '{techType}' to add to parent '{parentObject}'");
+            result?.Set(null);
+            yield break;
+        }
+
+        AddPrefabAsChildInternal(parentObject, prefab, result, stripComponents, stripSkyAppliers);
+    }
+
+    private static void AddPrefabAsChildInternal(GameObject parentObject, GameObject prefab, IOut<GameObject> result, bool stripComponents, bool stripSkyAppliers)
+    {
+        if (parentObject == null)
+        {
+            InternalLogger.Error($"Failed to instantiate '{prefab}'; parent is null");
+            return;
+        }
+
+        var child = Object.Instantiate(prefab);
+        var childTransform = child.transform;
+
+        childTransform.SetParent(parentObject.transform);
+        childTransform.localPosition = Vector3.zero;
+        childTransform.localRotation = Quaternion.identity;
+
+        if (stripComponents)
+        {
+            Object.DestroyImmediate(child.GetComponent<LargeWorldEntity>());
+            Object.DestroyImmediate(child.GetComponent<TechTag>());
+            Object.DestroyImmediate(child.GetComponent<PrefabIdentifier>());
+            Object.DestroyImmediate(child.GetComponent<WorldForces>());
+            Object.DestroyImmediate(child.GetComponent<Rigidbody>());
+        }
+
+        if (stripSkyAppliers)
+        {
+            foreach (var skyApplier in child.GetComponentsInChildren<SkyApplier>(true))
+            {
+                Object.DestroyImmediate(skyApplier);
+            }
+        }
+
+        result?.Set(child);
     }
 }


### PR DESCRIPTION
### Changes made in this pull request

  - Added a new utility method that simplifies spawning a specified prefab as a child of any given GameObject.
  - Overloads:
    - `AddChildPrefab(GameObject parentObject, string classId, IOut<GameObject> result = null, bool stripComponents = true, bool stripSkyAppliers = true)`
    - `AddChildPrefab(GameObject parentObject, TechType techType, IOut<GameObject> result = null, bool stripComponents = true, bool stripSkyAppliers = true)`

### Breaking changes

  - None