### PR TITLE
Remove any and all references to QMods and QModManager in Nautilus

### DIFF
--- a/Nautilus/Commands/ConsoleCommand.cs
+++ b/Nautilus/Commands/ConsoleCommand.cs
@@ -18,7 +18,7 @@ internal class ConsoleCommand
     public string Trigger { get; }
 
     /// <summary>
-    /// The QMod that registered the command.
+    /// The plugin/mod that registered the command.
     /// </summary>
     public string ModName { get; }
 

--- a/Nautilus/Documentation/guides/dev-setup.md
+++ b/Nautilus/Documentation/guides/dev-setup.md
@@ -41,8 +41,8 @@ Output:
 
 ## Picking an IDE
 The top 3 IDEs for writing C# code are the following:
-- [Visual Studio Community](https://visualstudio.microsoft.com/vs/community) - Free, great IDE designed for .NET development (Windows and Mac only)
-- [JetBrains Rider](https://www.jetbrains.com/rider) - Paid, outstanding IDE, incredible code-completion and code suggestions with the power of ReSharper, cross-platform
+- [Visual Studio Community](https://visualstudio.microsoft.com/vs/community) - Free, great IDE designed for .NET development (Windows only)
+- [JetBrains Rider](https://www.jetbrains.com/rider) - Optional subscription, outstanding IDE, incredible code-completion and code suggestions with the power of ReSharper, cross-platform
 - [Visual Studio Code](https://code.visualstudio.com) - Free, multi-purpose editor, cross-platform, can be used for C# development with plugins.
 
 ## Installing IDE

--- a/Nautilus/Json/ConfigFile.cs
+++ b/Nautilus/Json/ConfigFile.cs
@@ -80,7 +80,7 @@ public abstract class ConfigFile : IJsonFile
     /// {
     ///     public KeyCode ActivationKey { get; set; } = KeyCode.Escape;
     ///     public MyConfig() : base("options", "Config Files") { }
-    ///     // The config file will be stored at the path "BepInEx\plugins\YourModName\Config Files\options.json"
+    ///     // The config file will be stored at the path "BepInEx\config\YourModName\Config Files\options.json"
     /// }
     /// </code>
     /// </example>

--- a/Nautilus/Json/ConfigFile.cs
+++ b/Nautilus/Json/ConfigFile.cs
@@ -80,7 +80,7 @@ public abstract class ConfigFile : IJsonFile
     /// {
     ///     public KeyCode ActivationKey { get; set; } = KeyCode.Escape;
     ///     public MyConfig() : base("options", "Config Files") { }
-    ///     // The config file will be stored at the path "QMods\YourModName\Config Files\options.json"
+    ///     // The config file will be stored at the path "BepInEx\plugins\YourModName\Config Files\options.json"
     /// }
     /// </code>
     /// </example>

--- a/Nautilus/Json/SaveDataCache.cs
+++ b/Nautilus/Json/SaveDataCache.cs
@@ -14,7 +14,7 @@ namespace Nautilus.Json;
 /// </summary>
 public abstract class SaveDataCache : JsonFile
 {
-    private string QModId { get; init; }
+    private string ModId { get; init; }
 
     private bool InGame => !string.IsNullOrWhiteSpace(SaveLoadManager.GetTemporarySavePath());
 
@@ -22,13 +22,13 @@ public abstract class SaveDataCache : JsonFile
     private string JsonFileName => jsonFileName ??= GetType().GetCustomAttribute<FileNameAttribute>() switch
     {
         FileNameAttribute fileNameAttribute => fileNameAttribute.FileName,
-        _ => QModId
+        _ => ModId
     };
 
     /// <summary>
     /// The file path at which the JSON file is accessible for reading and writing.
     /// </summary>
-    public override string JsonFilePath => Path.Combine(SaveLoadManager.GetTemporarySavePath(), QModId, $"{JsonFileName}.json");
+    public override string JsonFilePath => Path.Combine(SaveLoadManager.GetTemporarySavePath(), ModId, $"{JsonFileName}.json");
 
     /// <summary>
     /// Creates a new instance of <see cref="SaveDataCache"/>, parsing the file name from <see cref="FileNameAttribute"/>
@@ -36,7 +36,7 @@ public abstract class SaveDataCache : JsonFile
     /// </summary>
     public SaveDataCache()
     {
-        QModId = GetType().Assembly.GetName().Name;
+        ModId = GetType().Assembly.GetName().Name;
     }
 
     /// <summary>
@@ -57,11 +57,11 @@ public abstract class SaveDataCache : JsonFile
         if (InGame)
         {
             base.Load(createFileIfNotExist);
-            InternalLogger.Log($"[{QModId}] Loaded save data from {JsonFileName}.json");
+            InternalLogger.Log($"[{ModId}] Loaded save data from {JsonFileName}.json");
         }
         else
         {
-            throw new InvalidOperationException($"[{QModId}] Cannot load save data when not in game!");
+            throw new InvalidOperationException($"[{ModId}] Cannot load save data when not in game!");
         }
     }
     
@@ -79,11 +79,11 @@ public abstract class SaveDataCache : JsonFile
         if (InGame)
         {
             await base.LoadAsync(createFileIfNotExist);
-            InternalLogger.Log($"[{QModId}] Loaded save data from {JsonFileName}.json");
+            InternalLogger.Log($"[{ModId}] Loaded save data from {JsonFileName}.json");
         }
         else
         {
-            throw new InvalidOperationException($"[{QModId}] Cannot load save data when not in game!");
+            throw new InvalidOperationException($"[{ModId}] Cannot load save data when not in game!");
         }
     }
 
@@ -103,11 +103,11 @@ public abstract class SaveDataCache : JsonFile
         if (InGame)
         {
             base.Save();
-            InternalLogger.Log($"[{QModId}] Saved save data to {JsonFileName}.json");
+            InternalLogger.Log($"[{ModId}] Saved save data to {JsonFileName}.json");
         }
         else
         {
-            throw new InvalidOperationException($"[{QModId}] Cannot save save data when not in game!");
+            throw new InvalidOperationException($"[{ModId}] Cannot save save data when not in game!");
         }
     }
     
@@ -123,11 +123,11 @@ public abstract class SaveDataCache : JsonFile
         if (InGame)
         {
             await base.SaveAsync();
-            InternalLogger.Log($"[{QModId}] Saved save data to {JsonFileName}.json");
+            InternalLogger.Log($"[{ModId}] Saved save data to {JsonFileName}.json");
         }
         else
         {
-            throw new InvalidOperationException($"[{QModId}] Cannot save save data when not in game!");
+            throw new InvalidOperationException($"[{ModId}] Cannot save save data when not in game!");
         }
     }
 
@@ -146,11 +146,11 @@ public abstract class SaveDataCache : JsonFile
         if (InGame)
         {
             base.LoadWithConverters(createFileIfNotExist, jsonConverters);
-            InternalLogger.Log($"[{QModId}] Loaded save data from {JsonFileName}.json");
+            InternalLogger.Log($"[{ModId}] Loaded save data from {JsonFileName}.json");
         }
         else
         {
-            throw new InvalidOperationException($"[{QModId}] Cannot load save data when not in game!");
+            throw new InvalidOperationException($"[{ModId}] Cannot load save data when not in game!");
         }
     }
     
@@ -169,11 +169,11 @@ public abstract class SaveDataCache : JsonFile
         if (InGame)
         {
             await base.LoadWithConvertersAsync(createFileIfNotExist, jsonConverters);
-            InternalLogger.Log($"[{QModId}] Loaded save data from {JsonFileName}.json");
+            InternalLogger.Log($"[{ModId}] Loaded save data from {JsonFileName}.json");
         }
         else
         {
-            throw new InvalidOperationException($"[{QModId}] Cannot load save data when not in game!");
+            throw new InvalidOperationException($"[{ModId}] Cannot load save data when not in game!");
         }
     }
 
@@ -190,11 +190,11 @@ public abstract class SaveDataCache : JsonFile
         if (InGame)
         {
             base.SaveWithConverters(jsonConverters);
-            InternalLogger.Log($"[{QModId}] Saved save data to {JsonFileName}.json");
+            InternalLogger.Log($"[{ModId}] Saved save data to {JsonFileName}.json");
         }
         else
         {
-            throw new InvalidOperationException($"[{QModId}] Cannot save save data when not in game!");
+            throw new InvalidOperationException($"[{ModId}] Cannot save save data when not in game!");
         }
     }
     
@@ -211,11 +211,11 @@ public abstract class SaveDataCache : JsonFile
         if (InGame)
         {
             await base.SaveWithConvertersAsync(jsonConverters);
-            InternalLogger.Log($"[{QModId}] Saved save data to {JsonFileName}.json");
+            InternalLogger.Log($"[{ModId}] Saved save data to {JsonFileName}.json");
         }
         else
         {
-            throw new InvalidOperationException($"[{QModId}] Cannot save save data when not in game!");
+            throw new InvalidOperationException($"[{ModId}] Cannot save save data when not in game!");
         }
     }
 }

--- a/Nautilus/Options/Attributes/ButtonAttribute.cs
+++ b/Nautilus/Options/Attributes/ButtonAttribute.cs
@@ -13,7 +13,6 @@ namespace Nautilus.Options.Attributes;
 /// <code>
 /// using Nautilus.Json;
 /// using Nautilus.Options;
-/// using QModManager.Utility;
 /// 
 /// [Menu("My Options Menu")]
 /// public class Config : ConfigFile

--- a/Nautilus/Options/Attributes/MenuAttribute.cs
+++ b/Nautilus/Options/Attributes/MenuAttribute.cs
@@ -13,7 +13,6 @@ namespace Nautilus.Options.Attributes;
 /// <code>
 /// using Nautilus.Json;
 /// using Nautilus.Options;
-/// using QModManager.Utility;
 /// using UnityEngine;
 /// 
 /// [Menu("Nautilus Example Mod")]

--- a/Nautilus/Options/Attributes/OnChangeAttribute.cs
+++ b/Nautilus/Options/Attributes/OnChangeAttribute.cs
@@ -27,7 +27,6 @@ namespace Nautilus.Options.Attributes;
 /// <code>
 /// using Nautilus.Json;
 /// using Nautilus.Options;
-/// using QModManager.Utility;
 /// using UnityEngine;
 /// 
 /// [Menu("Nautilus Example Mod")]

--- a/Nautilus/Options/Attributes/OnGameObjectCreatedAttribute.cs
+++ b/Nautilus/Options/Attributes/OnGameObjectCreatedAttribute.cs
@@ -21,7 +21,6 @@ namespace Nautilus.Options.Attributes;
 /// <code>
 /// using Nautilus.Json;
 /// using Nautilus.Options;
-/// using QModManager.Utility;
 /// using UnityEngine;
 /// 
 /// [Menu("Nautilus Example Mod")]

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -36,8 +36,7 @@ internal class OptionsPanelPatcher
         harmony.PatchAll(typeof(ScrollPosKeeper));
         harmony.PatchAll(typeof(ModOptionsHeadingsToggle));
     }
-
-    // 'Mods' tab also added in QModManager (is it added in BepInEx?), so we can't rely on 'modsTab' in AddTabs_Postfix
+    
     [HarmonyPostfix]
     [HarmonyPatch(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.AddTab))]
     internal static void AddTab_Postfix(uGUI_TabbedControlsPanel __instance, string label, int __result)

--- a/Nautilus/Patchers/OptionsPanelPatcher.cs
+++ b/Nautilus/Patchers/OptionsPanelPatcher.cs
@@ -37,7 +37,7 @@ internal class OptionsPanelPatcher
         harmony.PatchAll(typeof(ModOptionsHeadingsToggle));
     }
 
-    // 'Mods' tab also added in QModManager, so we can't rely on 'modsTab' in AddTabs_Postfix
+    // 'Mods' tab also added in QModManager (is it added in BepInEx?), so we can't rely on 'modsTab' in AddTabs_Postfix
     [HarmonyPostfix]
     [HarmonyPatch(typeof(uGUI_TabbedControlsPanel), nameof(uGUI_TabbedControlsPanel.AddTab))]
     internal static void AddTab_Postfix(uGUI_TabbedControlsPanel __instance, string label, int __result)


### PR DESCRIPTION
### Changes made in this pull request

  - Remove any and all references to QMods and QModManager in Nautilus

### Breaking changes

  - (not sure if this is breaking) Renamed variable in class SaveDataCache from `QModID` to `ModID`