### PR TITLE
Allow ConsoleCommandsHandler to recognize private commands

### DIFF
--- a/Nautilus/Handlers/ConsoleCommandsHandler.cs
+++ b/Nautilus/Handlers/ConsoleCommandsHandler.cs
@@ -13,7 +13,7 @@ namespace Nautilus.Handlers;
 public static class ConsoleCommandsHandler
 {
     /// <summary>
-    /// Registers your custom console command by targeting a <see langword="public"/> <see langword="static"/> method.
+    /// Registers your custom console command by targeting a <see langword="static"/> method.
     /// </summary>
     /// <remarks>
     /// <para>Target method must be <see langword="static"/>.</para>
@@ -61,7 +61,7 @@ public static class ConsoleCommandsHandler
     }
 
     /// <summary>
-    /// Registers <see langword="public"/> <see langword="static"/> methods decorated with the
+    /// Registers <see langword="static"/> methods decorated with the
     /// <see cref="ConsoleCommandAttribute"/> within the <paramref name="type"/> as console commands.
     /// </summary>
     /// <remarks>

--- a/Nautilus/Patchers/ConsoleCommandsPatcher.cs
+++ b/Nautilus/Patchers/ConsoleCommandsPatcher.cs
@@ -117,7 +117,7 @@ internal static class ConsoleCommandsPatcher
     /// <param name="type">The type within which to search.</param>
     public static void ParseCustomCommands(Type type)
     {
-        foreach (MethodInfo targetMethod in type.GetMethods(BindingFlags.Public | BindingFlags.Static))
+        foreach (MethodInfo targetMethod in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
         {
             ConsoleCommandAttribute customCommandAttribute = targetMethod.GetCustomAttribute<ConsoleCommandAttribute>(false);
             if (customCommandAttribute != null)


### PR DESCRIPTION
### Changes made in this pull request

  - Private methods are now recognized by Nautilus for commands (no longer only public methods)
  - Updated documentation

### Breaking changes

  - Commands that may have been 'disabled' by being made private will be usable once again, which could cause exceptions in rare cases