### PR TITLE
Add several log warnings to bring attention to common mistakes

### DIFF
--- a/Nautilus/Assets/ModPrefabCache.cs
+++ b/Nautilus/Assets/ModPrefabCache.cs
@@ -109,6 +109,13 @@ internal class ModPrefabCacheInstance: MonoBehaviour
             return;
         }
 
+        if (prefab.activeInHierarchy)
+        {
+            InternalLogger.Warn($"Adding prefab '{prefab.name}' to cache while it is active. Prefabs must be deactivated " +
+                                $"as early as possible during setup to avoid duplication issues.\n" +
+                                $"Use UWE.Utils.InstantiateDeactivated when possible or call SetActive(false) before initialization.");
+        }
+
         if (BannedPrefabs.Contains(prefabIdentifier.classId))
         {
             return;

--- a/Nautilus/Handlers/LootDistributionHandler.cs
+++ b/Nautilus/Handlers/LootDistributionHandler.cs
@@ -86,6 +86,11 @@ public static class LootDistributionHandler
         }
 
         LootDistributionPatcher.CustomSrcData[classId] = data;
+
+        if (LootDistributionPatcher.AlreadyInitialized)
+        {
+            InternalLogger.Warn($"Registering {classId}-{data.prefabPath} to LootDistribution while in-game. This is likely too late.");
+        }
     }
 
     /// <summary>

--- a/Nautilus/Handlers/WorldEntityDatabaseHandler.cs
+++ b/Nautilus/Handlers/WorldEntityDatabaseHandler.cs
@@ -42,11 +42,22 @@ public static class WorldEntityDatabaseHandler
     /// <param name="data">The <see cref="WorldEntityInfo"/> data. Data is stored in the fields of the class, so they must be populated when passed in.</param>
     public static void AddCustomInfo(string classId, WorldEntityInfo data)
     {
+        if (string.IsNullOrEmpty(classId))
+        {
+            InternalLogger.Warn($"Registering WorldEntityInfo (TechType: {data.techType}) for null ClassID. Skipping.");
+            return;
+        }
+        
         if(WorldEntityDatabasePatcher.CustomWorldEntityInfos.ContainsKey(classId))
         {
             InternalLogger.Log($"{classId}-{data.techType} already has custom WorldEntityInfo. Replacing with latest.", LogLevel.Debug);
         }
 
         WorldEntityDatabasePatcher.CustomWorldEntityInfos[classId] = data;
+
+        if (data.localScale.sqrMagnitude <= Mathf.Epsilon)
+        {
+            InternalLogger.Warn($"Registering WorldEntityInfo for {classId}-{data.techType} with zero scale.");
+        }
     }
 }

--- a/Nautilus/Patchers/LargeWorldStreamerPatcher.cs
+++ b/Nautilus/Patchers/LargeWorldStreamerPatcher.cs
@@ -173,7 +173,11 @@ internal static class LargeWorldStreamerPatcher
             InternalLogger.Error($"No LargeWorldEntity found on {prefabInfo.ClassID}; Please ensure the prefab has a LargeWorldEntity component when using Coordinated Spawns.");
             lwe = prefab.AddComponent<LargeWorldEntity>();
         }
-        if (lwe is { cellLevel: LargeWorldEntity.CellLevel.Global })
+        if (lwe is {cellLevel: LargeWorldEntity.CellLevel.Batch})
+        {
+            InternalLogger.Warn($"Cannot spawn {info.ClassId} with coordinated spawns because it uses the batch cell level.");
+        }
+        else if (lwe is { cellLevel: LargeWorldEntity.CellLevel.Global })
         {
             var batch = LargeWorldStreamer.main.GetContainingBatch(info.SpawnPosition);
             CreateSpawner(batch, new []{info}, true);

--- a/Nautilus/Patchers/LootDistributionPatcher.cs
+++ b/Nautilus/Patchers/LootDistributionPatcher.cs
@@ -8,6 +8,8 @@ namespace Nautilus.Patchers;
 internal class LootDistributionPatcher
 {
     internal static readonly SelfCheckingDictionary<string, LootDistributionData.SrcData> CustomSrcData = new("CustomSrcData");
+    internal static bool AlreadyInitialized { get; private set; }
+
 
     internal static void Patch(Harmony harmony)
     {
@@ -15,6 +17,8 @@ internal class LootDistributionPatcher
             postfix: new HarmonyMethod(AccessTools.Method(typeof(LootDistributionPatcher), nameof(LootDistributionPatcher.InitializePostfix))));
 
         InternalLogger.Log("LootDistributionPatcher is done.", LogLevel.Debug);
+        
+        SaveUtils.RegisterOnQuitEvent(() => AlreadyInitialized = false);
     }
 
     private static void InitializePostfix(LootDistributionData __instance)
@@ -35,6 +39,8 @@ internal class LootDistributionPatcher
                 }
             }
         }
+
+        AlreadyInitialized = true;
     }
 
     private static void EditExistingData(string classId, LootDistributionData.SrcData existingData, LootDistributionData.SrcData changes, Dictionary<BiomeType, LootDistributionData.DstData> dstData)

--- a/Nautilus/Patchers/MainMenuPatcher.cs
+++ b/Nautilus/Patchers/MainMenuPatcher.cs
@@ -30,6 +30,7 @@ internal static class MainMenuPatcher
     internal static event Action onActiveModChanged;
     private static ConfigEntry<string> _activeModGuid;
     private static uGUI_Choice _choiceOption;
+    private static bool _initializedAddons;
     
     internal static void Patch(Harmony harmony, ConfigFile config)
     {
@@ -61,6 +62,8 @@ internal static class MainMenuPatcher
         {
             InitializeAddons(titleObjectData.Key, titleObjectData.Value);
         }
+
+        _initializedAddons = true;
     }
 
     private static void SceneLoadingAwakePostfix(uGUI_SceneLoading __instance)
@@ -353,6 +356,11 @@ internal static class MainMenuPatcher
 
     internal static void RegisterTitleObjectData(string key, TitleScreenHandler.CustomTitleData data)
     {
+        if (_initializedAddons)
+        {
+            InternalLogger.Warn($"Registering custom title screen '{key}' after addons are already initialized.");
+        }
+        
         if (TitleObjectDatas.ContainsKey(key))
         {
             InternalLogger.Log($"MainMenuPatcher already contain title data for {key}! Skipping.", LogLevel.Error);

--- a/Nautilus/Utility/PrefabUtils.cs
+++ b/Nautilus/Utility/PrefabUtils.cs
@@ -84,6 +84,12 @@ public static class PrefabUtils
     /// <param name="cellLevel">Level of distance this prefab can stay visible before unloading.</param>
     public static void AddBasicComponents(GameObject prefab, string classId, TechType techType, LargeWorldEntity.CellLevel cellLevel)
     {
+        if (prefab.activeInHierarchy)
+        {
+            InternalLogger.Warn($"Calling PrefabUtils.AddBasicComponents on prefab '{prefab.name}' (ClassID: {classId}) while it is active. " +
+                                $"Prefabs must be inactive during setup to prevent duplication issues.");
+        }
+        
         prefab.EnsureComponent<PrefabIdentifier>().ClassId = classId;
             
         if (techType != TechType.None)


### PR DESCRIPTION
Resolves #660. Nautilus currently allows many mistakes to stay silent and go unnoticed.

### Changes made in this pull request

Added log warnings for the following situations:
  1. Using `PrefabUtils.AddBasicComponents` on a prefab that is active in the scene.
  2. Registering an active prefab into the prefab cache
  3. Adding loot distribution after the database has already been initialized
  4. Registering WorldEntityInfo with 0 scale
  5. Registering WorldEntityInfo with no ClassId (which also returns early now)
  6. Adding a coordinated spawn with a prefab that has the `Batch` cell level
  7. Registering a custom title screen after the addons have already been initialized

### Breaking changes

  - None