### PR TITLE
Remove warnings for prefabs with no TechType

### DIFF
--- a/Nautilus/Assets/CustomPrefab.cs
+++ b/Nautilus/Assets/CustomPrefab.cs
@@ -293,15 +293,6 @@ public class CustomPrefab : ICustomPrefab
             return;
         }
 
-        /*
-         * It is fine for some prefabs to not have a tech type (E.G: world decorators, or anything that isn't scannable),
-         * so just warn it in-case people forgot to add one.
-         */
-        if (Info.TechType is TechType.None)
-        {
-            InternalLogger.Warn($"Prefab '{Info}' does not contain a TechType.");
-        }
-
         foreach (var reg in _onRegister)
         {
             reg?.Invoke();


### PR DESCRIPTION
### Changes made in this pull request

Removed the warning that said `"Prefab '{Info}' does not contain a TechType."` when registering a CustomPrefab with no TechType. A warning is not needed, because there is nothing wrong with this. All warnings in gadgets that require TechTypes still remain.

### Breaking changes

This is not a breaking change.