### PR TITLE
Stop marking custom prefabs as registered when they should fail

### DIFF
--- a/Nautilus/Assets/CustomPrefab.cs
+++ b/Nautilus/Assets/CustomPrefab.cs
@@ -302,6 +302,9 @@ public class CustomPrefab : ICustomPrefab
             InternalLogger.Warn($"Prefab '{Info}' does not contain a TechType.");
         }
 
+        if (!PrefabHandler.Prefabs.TryRegisterPrefab(this))
+            return;
+
         foreach (var reg in _onRegister)
         {
             reg?.Invoke();
@@ -311,8 +314,6 @@ public class CustomPrefab : ICustomPrefab
         {
             gadget.Value.Build();
         }
-        
-        PrefabHandler.Prefabs.RegisterPrefab(this);
 
         _registered = true;
     }

--- a/Nautilus/Assets/CustomPrefab.cs
+++ b/Nautilus/Assets/CustomPrefab.cs
@@ -305,17 +305,26 @@ public class CustomPrefab : ICustomPrefab
         if (!PrefabHandler.Prefabs.TryRegisterPrefab(this))
             return;
 
-        foreach (var reg in _onRegister)
+        try
         {
-            reg?.Invoke();
-        }
+            foreach (var reg in _onRegister)
+            {
+                reg?.Invoke();
+            }
 
-        foreach (var gadget in _gadgets)
+            foreach (var gadget in _gadgets)
+            {
+                gadget.Value.Build();
+            }
+
+            _registered = true;
+        }
+        catch(Exception ex)
         {
-            gadget.Value.Build();
+            // If anything throws before _registered is set to true, unregister the prefab and log the exception.
+            InternalLogger.Error($"Failed to register prefab '{Info}'.\n{ex}");
+            PrefabHandler.Prefabs.UnregisterPrefab(this);
         }
-
-        _registered = true;
     }
 
     /// <summary>

--- a/Nautilus/Handlers/PrefabHandler.cs
+++ b/Nautilus/Handlers/PrefabHandler.cs
@@ -115,7 +115,17 @@ public static class PrefabCollectionExtensions
     /// <param name="customPrefab">The custom prefab to register.</param>
     public static void RegisterPrefab(this PrefabCollection collection, ICustomPrefab customPrefab)
     {
-        collection.Add(customPrefab.Info, customPrefab.Prefab, customPrefab.OnPrefabPostProcess);
+        collection.TryAdd(customPrefab.Info, customPrefab.Prefab, customPrefab.OnPrefabPostProcess);
+    }
+
+    /// <summary>
+    /// Tries to register a <see cref="CustomPrefab"/> into the game.
+    /// </summary>
+    /// <param name="collection">The collection to register to.</param>
+    /// <param name="customPrefab">The custom prefab to register.</param>
+    public static bool TryRegisterPrefab(this PrefabCollection collection, ICustomPrefab customPrefab)
+    {
+        return collection.TryAdd(customPrefab.Info, customPrefab.Prefab, customPrefab.OnPrefabPostProcess);
     }
 
     /// <summary>
@@ -147,24 +157,32 @@ public class PrefabCollection : IEnumerable<KeyValuePair<PrefabInfo, PrefabFacto
     /// <param name="info">The prefab info to register.</param>
     /// <param name="prefabFactory">The function that constructs the game object for this prefab info.</param>
     /// <param name="postProcessor">The prefab post processor that will be invoked after Nautilus's prefab processing.</param>
-    public void Add(PrefabInfo info, PrefabFactoryAsync prefabFactory, PrefabPostProcessorAsync postProcessor = null)
+    public void Add(PrefabInfo info, PrefabFactoryAsync prefabFactory, PrefabPostProcessorAsync postProcessor = null) => TryAdd(info, prefabFactory, postProcessor);
+
+    /// <summary>
+    /// Tries to add a prefab info with the function that constructs the game object into the game.
+    /// </summary>
+    /// <param name="info">The prefab info to register.</param>
+    /// <param name="prefabFactory">The function that constructs the game object for this prefab info.</param>
+    /// <param name="postProcessor">The prefab post processor that will be invoked after Nautilus's prefab processing.</param>
+    public bool TryAdd(PrefabInfo info, PrefabFactoryAsync prefabFactory, PrefabPostProcessorAsync postProcessor = null)
     {
         if (_prefabs.ContainsKey(info))
         {
             InternalLogger.Error($"Another modded prefab already registered the following prefab: {info}");
-            return;
+            return false;
         }
 
         if (_classIdPrefabs.ContainsKey(info.ClassID) || string.IsNullOrWhiteSpace(info.ClassID))
         {
             InternalLogger.Error($"Class ID is required and must be unique for prefab: {info}");
-            return;
+            return false;
         }
         
         if (_fileNamePrefabs.ContainsKey(info.PrefabFileName) || string.IsNullOrWhiteSpace(info.PrefabFileName))
         {
             InternalLogger.Error($"PrefabFileName is required and must be unique for prefab: {info}");
-            return;
+            return false;
         }
 
         if (postProcessor is {})
@@ -182,6 +200,7 @@ public class PrefabCollection : IEnumerable<KeyValuePair<PrefabInfo, PrefabFacto
         }
 
         CraftDataPatcher.ModPrefabsPatched = false;
+        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
### Changes made in this pull request

  - `PrefabHandler.RegisterPrefab` and `PrefabHandler.Add` methods now wire into new `TryRegisterPrefab` and `TryAdd` methods that return whether they succeeded or failed.
  - `CustomPrefab.Register`
    - No longer marks custom prefabs as `_registered` when registration should fail.
    - Now uses a try/catch to unregister any failed half-registered custom prefabs.
    - Returns early if failed `TryRegisterPrefab`, before invoking `_onRegister` events and building `_gadget`'s

### Breaking changes

  - None