### PR TITLE
Add tooltip for "Enable debug logs" option in Nautilus

### DIFF
--- a/Nautilus/NautilusConfig.cs
+++ b/Nautilus/NautilusConfig.cs
@@ -7,7 +7,7 @@ namespace Nautilus;
 [ConfigFile("NautilusConfig")]
 internal class NautilusConfig : ConfigFile
 {
-    [Toggle(Label = "Enable debug logs")]
+    [Toggle(Label = "Enable debug logs", Tooltip = "WARNING: Enabling this can lead to a major decrease in performance. Debug logs are comprehensive messages that are only intended for debugging mods.")]
     [OnChange(nameof(OnDebugLogChange))]
     public bool enableDebugLogs = false;
 

--- a/Nautilus/NautilusConfig.cs
+++ b/Nautilus/NautilusConfig.cs
@@ -7,7 +7,7 @@ namespace Nautilus;
 [ConfigFile("NautilusConfig")]
 internal class NautilusConfig : ConfigFile
 {
-    [Toggle(Label = "Enable debug logs", Tooltip = "WARNING: Enabling this can lead to a major decrease in performance. Debug logs are comprehensive messages that are only intended for debugging mods.")]
+    [Toggle(Label = "Enable debug logs", Tooltip = "WARNING: Enabling this option may reduce performance. Debug logging produces a large volume of detailed messages intended for mod development.")]
     [OnChange(nameof(OnDebugLogChange))]
     public bool enableDebugLogs = false;
 


### PR DESCRIPTION
### Changes made in this pull request

Added a tooltip for the "Enable debug logs" option in Nautilus. This was added to prevent avoidable performance issues for users and to inform people of its purpose.

> WARNING: Enabling this option may reduce performance. Debug logging produces a large volume of detailed messages intended for mod development.
 
<img width="1036" height="520" alt="image" src="https://github.com/user-attachments/assets/ae154ef5-8ab0-4798-82df-4f822a5e4908" />
