### PR TITLE
Use correct bus for FMOD to fix PDA pause issue

### DIFF
--- a/Nautilus/Utility/AudioUtils_BelowZero.cs
+++ b/Nautilus/Utility/AudioUtils_BelowZero.cs
@@ -11,47 +11,47 @@ public static partial class AudioUtils
         /// <summary>
         /// Used for underwater creature SFXs. Tied to the master volume.
         /// </summary>
-        public const string UnderwaterCreatures = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/creatures underwater";
+        public static readonly string UnderwaterCreatures = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/creatures underwater";
 
         /// <summary>
         /// Used for surface creature SFXs that dont get muted when at the surface of the ocean. Tied to the master volume.
         /// </summary>
-        public const string SurfaceCreatures = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/creatures surface";
+        public static readonly string SurfaceCreatures = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/creatures surface";
 
         /// <summary>
         /// Used for PDA voices. Tied to the voice volume.
         /// </summary>
-        public const string PDAVoice = "bus:/master/SFX_for_pause/PDA_pause/all/all voice/AI voice";
+        public static readonly string PDAVoice = "bus:/master/SFX_for_pause/PDA_pause/all/all voice/AI voice";
 
         /// <summary>
         /// Used for encyclopedia VOs. Tied to the voice volume.
         /// </summary>
-        public const string VoiceOvers = "bus:/master/SFX_for_pause/PDA_pause/all/all voice/VOs";
+        public static readonly string VoiceOvers = "bus:/master/SFX_for_pause/PDA_pause/all/all voice/VOs";
 
         /// <summary>
         /// Used for main music. Tied to the music volume.
         /// </summary>
-        public const string Music = "bus:/master/Music_no_pause/music";
+        public static readonly string Music = "bus:/master/Music_no_pause/music";
 
         /// <summary>
         /// Used for environmental music. Tied to the music volume.
         /// </summary>
-        public const string EnvironmentalMusic = "bus:/master/Music_no_pause/music/mutable music";
+        public static readonly string EnvironmentalMusic = "bus:/master/Music_no_pause/music/mutable music";
 
         /// <summary>
         /// Used for underwater ambience SFXs. Tied to the ambient volume.
         /// </summary>
-        public const string UnderwaterAmbient = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/backgrounds";
+        public static readonly string UnderwaterAmbient = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/backgrounds";
 
         /// <summary>
         /// Used for ambience SFXs that dont get muted when at the surface of the ocean. Tied to the ambient volume.
         /// </summary>
-        public const string SurfaceAmbient = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/backgrounds/surface";
+        public static readonly string SurfaceAmbient = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/backgrounds/surface";
         
         /// <summary>
         /// Used for player and hand-held tools SFXs. Tied to the master volume.
         /// </summary>
-        public const string PlayerSFXs = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/reverbsend";
+        public static readonly string PlayerSFXs = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/reverbsend";
     }
 }
 #endif

--- a/Nautilus/Utility/AudioUtils_Subnautica.cs
+++ b/Nautilus/Utility/AudioUtils_Subnautica.cs
@@ -21,7 +21,7 @@ public static partial class AudioUtils
         /// <summary>
         /// Used for PDA voices. Tied to the voice volume.
         /// </summary>
-        public static readonly string PDAVoice = "bus:/master/SFX_for_pause/PDA_pause/all/all voice/AI voice";
+        public static readonly string PDAVoice = "bus:/master/SFX_for_pause/all_no_pda_pause/all_voice_no_pda_pause/aI_voice";
 
         /// <summary>
         /// Used for encyclopedia VOs. Tied to the voice volume.

--- a/Nautilus/Utility/AudioUtils_Subnautica.cs
+++ b/Nautilus/Utility/AudioUtils_Subnautica.cs
@@ -11,57 +11,57 @@ public static partial class AudioUtils
         /// <summary>
         /// Used for underwater creature SFXs. Tied to the master volume.
         /// </summary>
-        public const string UnderwaterCreatures = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/creatures";
+        public static readonly string UnderwaterCreatures = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/creatures";
 
         /// <summary>
         /// Used for surface creature SFXs that dont get muted when at the surface of the ocean. Tied to the master volume.
         /// </summary>
-        public const string SurfaceCreatures = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/creatures surface";
+        public static readonly string SurfaceCreatures = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/creatures surface";
 
         /// <summary>
         /// Used for PDA voices. Tied to the voice volume.
         /// </summary>
-        public const string PDAVoice = "bus:/master/SFX_for_pause/PDA_pause/all/all voice/AI voice";
+        public static readonly string PDAVoice = "bus:/master/SFX_for_pause/PDA_pause/all/all voice/AI voice";
 
         /// <summary>
         /// Used for encyclopedia VOs. Tied to the voice volume.
         /// </summary>
-        public const string VoiceOvers = "bus:/master/SFX_for_pause/PDA_pause/all/all voice/VOs";
+        public static readonly string VoiceOvers = "bus:/master/SFX_for_pause/PDA_pause/all/all voice/VOs";
 
         /// <summary>
         /// Used for main music. Tied to the music volume.
         /// </summary>
-        public const string Music = "bus:/master/SFX_for_pause/nofilter/music";
+        public static readonly string Music = "bus:/master/SFX_for_pause/nofilter/music";
 
         /// <summary>
         /// Used for environmental music. Tied to the music volume.
         /// </summary>
-        public const string EnvironmentalMusic = "bus:/master/SFX_for_pause/nofilter/music/mutable music";
+        public static readonly string EnvironmentalMusic = "bus:/master/SFX_for_pause/nofilter/music/mutable music";
 
         /// <summary>
         /// Used for underwater ambience SFXs. Tied to the ambient volume.
         /// </summary>
-        public const string UnderwaterAmbient = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/backgrounds";
+        public static readonly string UnderwaterAmbient = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/backgrounds";
 
         /// <summary>
         /// Used for ambience SFXs that dont get muted when at the surface of the ocean. Tied to the ambient volume.
         /// </summary>
-        public const string SurfaceAmbient = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/backgrounds/surface";
+        public static readonly string SurfaceAmbient = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/backgrounds/surface";
 
         /// <summary>
         /// Used for player and hand-held tools SFXs. Tied to the master volume.
         /// </summary>
-        public const string PlayerSFXs = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/reverbsend";
+        public static readonly string PlayerSFXs = "bus:/master/SFX_for_pause/PDA_pause/all/SFX/reverbsend";
         
         /// <summary>
         /// Used for general SFX that plays above and below water. Tied to the ambient volume.
         /// </summary>
-        public const string SFX = "bus:/master/SFX_for_pause/PDA_pause/all/SFX";
+        public static readonly string SFX = "bus:/master/SFX_for_pause/PDA_pause/all/SFX";
         
         /// <summary>
         /// Used for the Cyclops voice. Tied to the voice volume.
         /// </summary>
-        public const string CyclopsVoice = "bus:/master/SFX_for_pause/PDA_pause/all/all voice/cyclops voice";
+        public static readonly string CyclopsVoice = "bus:/master/SFX_for_pause/PDA_pause/all/all voice/cyclops voice";
     }
 }
 #endif


### PR DESCRIPTION
This change is necessary for PDA lines to play properly (particularly in the log tab) with the 'PDA pause' accessibility setting enabled.

Issue reported by @Indigocoder1.

### Changes made in this pull request

  - Changed the PDAVoice bus path from `bus:/master/SFX_for_pause/PDA_pause/all/all voice/AI voice` to `bus:/master/SFX_for_pause/all_no_pda_pause/all_voice_no_pda_pause/aI_voice`
  - Converted BusPath class members from constants to static readonly fields.

### Breaking changes

The BusPath class constants were converted to static readonly fields to help with future bus path changes. However, since constants are almost always inlined upon compilation, this is a nonissue for normal usage. I tested this with many large mods installed and they loaded as intended without any exceptions.