### PR TITLE
Add ConstructionEmissiveTex to MaterialUtils and assign within PrefabUtils.AddConstructable()

### DIFF
--- a/Nautilus/Utility/MaterialUtils.cs
+++ b/Nautilus/Utility/MaterialUtils.cs
@@ -80,22 +80,22 @@ public static partial class MaterialUtils
     public static bool IsReady { get; private set; }
 
     /// <summary>
-    /// Gets the basic glass material
+    /// Gets the basic glass material.
     /// </summary>
     public static Material GlassMaterial { get; private set; }
 
     /// <summary>
-    /// Gets the material for the outside of glass, such as for base windows
+    /// Gets the material for the outside of glass, such as for base windows.
     /// </summary>
     public static Material ExteriorGlassMaterial { get; private set; }
 
     /// <summary>
-    /// Gets the material for the inside of glass, such as the inside of the Cyclops windshield
+    /// Gets the material for the inside of glass, such as the inside of the Cyclops windshield.
     /// </summary>
     public static Material InteriorGlassMaterial { get; private set; }
 
     /// <summary>
-    /// Gets a shiny glass material
+    /// Gets a shiny glass material.
     /// </summary>
     public static Material ShinyGlassMaterial { get; private set; }
 

--- a/Nautilus/Utility/MaterialUtils_Subnautica.cs
+++ b/Nautilus/Utility/MaterialUtils_Subnautica.cs
@@ -52,7 +52,7 @@ public static partial class MaterialUtils
     public static Material GhostMaterial { get; private set; }
 
     /// <summary>
-    /// Gets the material used by the UI in the Cyclops
+    /// Gets the material used by the UI in the Cyclops.
     /// </summary>
     public static Material HolographicUIMaterial { get; private set; }
 

--- a/Nautilus/Utility/MaterialUtils_Subnautica.cs
+++ b/Nautilus/Utility/MaterialUtils_Subnautica.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using UnityEngine;
+using UnityEngine.UI;
 using UWE;
 
 #if SUBNAUTICA
@@ -17,6 +18,7 @@ public static partial class MaterialUtils
         yield return LoadGhostMaterial();
         yield return LoadGlassMaterials();
         yield return LoadUIMaterial();
+        yield return Textures.LoadConstructionTextures();
     }
 
     /// <summary>
@@ -54,6 +56,24 @@ public static partial class MaterialUtils
     /// </summary>
     public static Material HolographicUIMaterial { get; private set; }
 
+    /// <summary>
+    /// Contains references to various textures.
+    /// </summary>
+    public static class Textures
+    {
+        /// <summary>
+        /// Gets the circuit board Texture used by FX_BUILDING for constructing.
+        /// </summary>
+        public static Texture ConstructionEmissiveTex { get; private set; }
+
+        internal static IEnumerator LoadConstructionTextures()
+        {
+            var fabricatorTask = CraftData.GetPrefabForTechTypeAsync(TechType.Fabricator);
+            yield return fabricatorTask;
+            ConstructionEmissiveTex = fabricatorTask.GetResult().GetComponent<Fabricator>().ghost._EmissiveTex;
+        }
+    }
+    
     private static IEnumerator LoadIonCubeMaterial()
     {
         if (IonCubeMaterial)

--- a/Nautilus/Utility/MaterialUtils_Subnautica.cs
+++ b/Nautilus/Utility/MaterialUtils_Subnautica.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using UnityEngine;
-using UnityEngine.UI;
 using UWE;
 
 #if SUBNAUTICA

--- a/Nautilus/Utility/PrefabUtils.cs
+++ b/Nautilus/Utility/PrefabUtils.cs
@@ -144,6 +144,7 @@ public static class PrefabUtils
         // TODO: Add ghost material for BZ
 #if SUBNAUTICA
         constructable.ghostMaterial = MaterialUtils.GhostMaterial;
+        constructable._EmissiveTex = MaterialUtils.Textures.ConstructionEmissiveTex;
 #endif
         constructable.techType = techType;
         constructable.allowedInBase = constructableFlags.HasFlag(ConstructableFlags.Base);


### PR DESCRIPTION
### Changes made in this pull request

  - Adds MaterialUtils.Textures.ConstructionEmissiveTex. This is the circuit board texture used while building prefabs/vehicles.
  - Assigns this texture within PrefabUtils.AddConstructable()

### Breaking changes

  - None that will prevent mods loading. Buildables by default will have correct textures assigned for their constructing which my improve mods that previously didn't account for it (TRP for example)