### PR TITLE
Survival Handler Fixes/Improvements

### DIFF
--- a/Nautilus/Handlers/SurvivalHandler.cs
+++ b/Nautilus/Handlers/SurvivalHandler.cs
@@ -24,7 +24,10 @@ public static class SurvivalHandler
         }
 
         if (!SurvivalPatcher.CustomSurvivalInventoryAction.TryGetValue(techType, out List<Action> actions))
+        {
             actions = new List<Action>();
+            SurvivalPatcher.CustomSurvivalInventoryAction[techType] = actions;
+        }
 
         // add an action to the list
         actions.Add(() => 
@@ -35,8 +38,6 @@ public static class SurvivalHandler
             else
                 oxygenManager.RemoveOxygen(-oxygenGiven);
         });
-
-        SurvivalPatcher.CustomSurvivalInventoryAction[techType] = actions;
     }
 
     /// <summary>
@@ -54,8 +55,11 @@ public static class SurvivalHandler
         }
 
         if (!SurvivalPatcher.CustomSurvivalInventoryAction.TryGetValue(techType, out List<Action> actions))
+        {
             actions = new List<Action>();
-
+            SurvivalPatcher.CustomSurvivalInventoryAction[techType] = actions;
+        }
+        
         actions.Add(() => {
             var liveMixin = Player.main.GetComponent<LiveMixin>();
             if (healthBack > 0)
@@ -63,8 +67,6 @@ public static class SurvivalHandler
             else
                 liveMixin.TakeDamage(-healthBack, default, DamageType.Poison);
         }); 
-
-        SurvivalPatcher.CustomSurvivalInventoryAction[techType] = actions;
     }
 
     /// <summary>
@@ -87,9 +89,11 @@ public static class SurvivalHandler
         }
 
         if (!SurvivalPatcher.CustomSurvivalInventoryAction.TryGetValue(techType, out List<Action> actions))
+        {
             actions = new List<Action>();
+            SurvivalPatcher.CustomSurvivalInventoryAction[techType] = actions;
+        }
 
         actions.Add(customAction);
-        SurvivalPatcher.CustomSurvivalInventoryAction[techType] = actions;
     }
 }

--- a/Nautilus/Handlers/SurvivalHandler.cs
+++ b/Nautilus/Handlers/SurvivalHandler.cs
@@ -9,20 +9,16 @@ namespace Nautilus.Handlers;
 /// </summary>
 public static class SurvivalHandler
 {
+    [Obsolete]
+    private static void GiveOxygenOnConsume(TechType techType, float oxygenGiven, bool isEdible) => GiveOxygenOnConsume(techType, oxygenGiven);
+    
     /// <summary>
     /// <para>makes the item gives oxygen on use.</para>
     /// </summary>
     /// <param name="techType">the TechType that you want to make it give oxygen on use</param>
     /// <param name="oxygenGiven">the oxygen amount the item gives</param>
-    /// <param name="isEdible">set it to <see langword="true" /> if the item is edible and has the <see cref="Eatable"/> component attached to it. 
-    /// </param>
-    public static void GiveOxygenOnConsume(TechType techType, float oxygenGiven, bool isEdible)
+    public static void GiveOxygenOnConsume(TechType techType, float oxygenGiven)
     {
-        if (!isEdible)
-        {
-            SurvivalPatcher.InventoryUseables.Add(techType); // add it to the HashSet of useables if its not edible
-        }
-
         if (!SurvivalPatcher.CustomSurvivalInventoryAction.TryGetValue(techType, out List<Action> actions))
         {
             actions = new List<Action>();
@@ -40,20 +36,16 @@ public static class SurvivalHandler
         });
     }
 
+    [Obsolete]
+    private static void GiveHealthOnConsume(TechType techType, float healthBack, bool isEdible) => GiveHealthOnConsume(techType, healthBack);
+    
     /// <summary>
     /// <para>makes the item Heal the player on consume.</para>
     /// </summary>
     /// <param name="techType">the TechType that you want it to heal back</param>
     /// <param name="healthBack">amount to heal the player</param>
-    /// <param name="isEdible">set it to <see langword="true" /> if the item is edible and has the <see cref="Eatable"/> component attached to it. 
-    /// </param>
-    public static void GiveHealthOnConsume(TechType techType, float healthBack, bool isEdible)
+    public static void GiveHealthOnConsume(TechType techType, float healthBack)
     {
-        if (!isEdible)
-        {
-            SurvivalPatcher.InventoryUseables.Add(techType); // add it to the HashSet of useables if its not edible
-        }
-
         if (!SurvivalPatcher.CustomSurvivalInventoryAction.TryGetValue(techType, out List<Action> actions))
         {
             actions = new List<Action>();
@@ -69,24 +61,20 @@ public static class SurvivalHandler
         }); 
     }
 
+    [Obsolete]
+    private static void RunActionOnConsume(TechType techType, Action customAction, bool isEdible) => RunActionOnConsume(techType, customAction);
+    
     /// <summary>
     /// <para>runs a custom action on consume.</para>
     /// </summary>
     /// <param name="techType">the TechType that you want it to heal back</param>
     /// <param name="customAction"> the Action to perform.</param>
-    /// <param name="isEdible">set it to <see langword="true" /> if the item is edible and has the <see cref="Eatable"/> component attached to it. 
-    /// </param>
-    public static void RunActionOnConsume(TechType techType, Action customAction, bool isEdible)
+    public static void RunActionOnConsume(TechType techType, Action customAction)
     {
         if (techType == TechType.None)
             throw new ArgumentNullException(nameof(techType), "TechType cannot be None.");
         if (customAction == null)
             throw new ArgumentNullException(nameof(customAction), "Action cannot be null.");
-
-        if (!isEdible)
-        {
-            SurvivalPatcher.InventoryUseables.Add(techType); // add it to the HashSet of useables if its not edible
-        }
 
         if (!SurvivalPatcher.CustomSurvivalInventoryAction.TryGetValue(techType, out List<Action> actions))
         {

--- a/Nautilus/Handlers/SurvivalHandler.cs
+++ b/Nautilus/Handlers/SurvivalHandler.cs
@@ -37,7 +37,7 @@ public static class SurvivalHandler
     }
 
     [Obsolete]
-    private static void GiveHealthOnConsume(TechType techType, float healthBack, bool isEdible) => GiveHealthOnConsume(techType, healthBack);
+    public static void GiveHealthOnConsume(TechType techType, float healthBack, bool isEdible) => GiveHealthOnConsume(techType, healthBack);
     
     /// <summary>
     /// <para>makes the item Heal the player on consume.</para>
@@ -62,7 +62,7 @@ public static class SurvivalHandler
     }
 
     [Obsolete]
-    private static void RunActionOnConsume(TechType techType, Action customAction, bool isEdible) => RunActionOnConsume(techType, customAction);
+    public static void RunActionOnConsume(TechType techType, Action customAction, bool isEdible) => RunActionOnConsume(techType, customAction);
     
     /// <summary>
     /// <para>runs a custom action on consume.</para>

--- a/Nautilus/Handlers/SurvivalHandler.cs
+++ b/Nautilus/Handlers/SurvivalHandler.cs
@@ -10,7 +10,7 @@ namespace Nautilus.Handlers;
 public static class SurvivalHandler
 {
     [Obsolete]
-    private static void GiveOxygenOnConsume(TechType techType, float oxygenGiven, bool isEdible) => GiveOxygenOnConsume(techType, oxygenGiven);
+    public static void GiveOxygenOnConsume(TechType techType, float oxygenGiven, bool isEdible) => GiveOxygenOnConsume(techType, oxygenGiven);
     
     /// <summary>
     /// <para>makes the item gives oxygen on use.</para>

--- a/Nautilus/Patchers/SurvivalPatcher.cs
+++ b/Nautilus/Patchers/SurvivalPatcher.cs
@@ -10,7 +10,6 @@ namespace Nautilus.Patchers;
 internal class SurvivalPatcher
 {
     internal static IDictionary<TechType, List<Action>> CustomSurvivalInventoryAction = new SelfCheckingDictionary<TechType, List<Action>>("CustomSurvivalInventoryAction", TechTypeExtensions.sTechTypeComparer);
-    internal static HashSet<TechType> InventoryUseables = new();
 
     internal static void Patch(Harmony harmony)
     {

--- a/Nautilus/Patchers/SurvivalPatcher.cs
+++ b/Nautilus/Patchers/SurvivalPatcher.cs
@@ -9,7 +9,7 @@ namespace Nautilus.Patchers;
 
 internal class SurvivalPatcher
 {
-    internal static IDictionary<TechType, List<Action>> CustomSurvivalInventoryAction = new SelfCheckingDictionary<TechType, List<Action>>("CustomSurvivalInventoryAction", TechTypeExtensions.sTechTypeComparer);
+    internal static readonly IDictionary<TechType, List<Action>> CustomSurvivalInventoryAction = new SelfCheckingDictionary<TechType, List<Action>>("CustomSurvivalInventoryAction", TechTypeExtensions.sTechTypeComparer);
 
     internal static void Patch(Harmony harmony)
     {


### PR DESCRIPTION
### Changes made in this pull request

  -  Fixes #680. `SurvivalHandler` would get the `List<Action>` from SurvivalPatcher, and reassign it to a `SelfCheckingDictionary`. This causes a warning error as this dictionary type allows reassignments for a key, but warns as a result. The fix simply only assigns the  `List<Action>`  for a given `TechType` if none already exist. If an entry for a `TechType` already exists, it simply adds it to the list without reassigning it at the end to the dictionary.
  - Removed `bool isEdible` paramter from `SurvivalHandler`. This parameter served no purpose as if it was true, it would add the `TechType` to a `HashSet` within `SurvivalPatcher`. This `HashSet` is entirely unused beyond adding techtypes tho and is never checked for anything :/
  - Made the `CustomSurvivalInventoryAction` Dictionary readonly

### Breaking changes

  - None for already compiled mods, the old parameter methods have been left in to keep this compatibility but were made private and marked explicitly [Obsolete]. No new mods can (under *normal* circumstances) access these methods and will have to remove the third parameter to properly recompile, tho this is a simple fix and shouldn't be an issue.
```C#
[Obsolete]
private static void GiveOxygenOnConsume(TechType techType, float oxygenGiven, bool isEdible) => GiveOxygenOnConsume(techType, oxygenGiven);
```
  - If this breaking change is too controversial, just merging my first commit fixing the warning message might be better. I just noticed how this parameter was unused and might be confusing to end users about what it does.