### PR TITLE
Prevent Player.log spam when debug logging is disabled

### DIFF
--- a/Nautilus/Utility/InternalLogger.cs
+++ b/Nautilus/Utility/InternalLogger.cs
@@ -125,6 +125,8 @@ internal static class InternalLogger
 
             return;
         }
+        
+        if (level == LogLevel.Debug && !EnableDebugging) return;
 
         Logger.Log(level, text);
     }


### PR DESCRIPTION
### Changes made in this pull request

Log messages using the debug level will not be logged at all when the 'Enable debug logs' option is disabled. Writing to the log like that can be painstakingly slow especially on older devices, and is particularly horrible for areas with a large number of coordinated spawns.