### PR TITLE
Fixed WorldEntityDatabasePatcher destroying performance when loading new areas

### DIFF
--- a/Nautilus/Patchers/WorldEntityDatabasePatcher.cs
+++ b/Nautilus/Patchers/WorldEntityDatabasePatcher.cs
@@ -12,19 +12,15 @@ internal class WorldEntityDatabasePatcher
     internal static void Patch(Harmony harmony)
     {
         harmony.Patch(AccessTools.Method(typeof(WorldEntityDatabase), nameof(WorldEntityDatabase.TryGetInfo)),
-            prefix: new HarmonyMethod(AccessTools.Method(typeof(WorldEntityDatabasePatcher), nameof(WorldEntityDatabasePatcher.Prefix))));
+            prefix: new HarmonyMethod(AccessTools.Method(typeof(WorldEntityDatabasePatcher), nameof(Prefix))));
     }
 
     private static bool Prefix(string classId, ref WorldEntityInfo info, ref bool __result)
     {
-        foreach (KeyValuePair<string, WorldEntityInfo> entry in CustomWorldEntityInfos)
+        if (CustomWorldEntityInfos.TryGetValue(classId, out WorldEntityInfo customInfo))
         {
-            if (entry.Key == classId)
-            {
-                __result = true;
-                info = entry.Value;
-                return false;
-            }
+            info = customInfo;
+            return false;
         }
 
         return true;

--- a/Nautilus/Patchers/WorldEntityDatabasePatcher.cs
+++ b/Nautilus/Patchers/WorldEntityDatabasePatcher.cs
@@ -20,6 +20,7 @@ internal class WorldEntityDatabasePatcher
         if (CustomWorldEntityInfos.TryGetValue(classId, out WorldEntityInfo customInfo))
         {
             info = customInfo;
+            __result = true;
             return false;
         }
 


### PR DESCRIPTION
### Changes made in this pull request

  - The WorldEntityDatabasePatcher no longer iterates over all custom registered ClassIDs (it was thousands on my PC) and is now O(1) time.

### Breaking changes

  - None, this is just a straight upgrade