### PR TITLE
Docs: Organize and rename tutorial pages in TOC and overview

### DIFF
--- a/Nautilus/Documentation/tutorials/overview.md
+++ b/Nautilus/Documentation/tutorials/overview.md
@@ -5,15 +5,15 @@ This section covers step-by-step tutorials on how to get some of the useful feat
 ## Sections
 
 ### Adding Content
-* [Spawning objects in the world](spawns.md)  
-* [Custom console commands](console-commands.md)
-* [Story goals](story-goals.md)
+* [Audio](audio.md)
+* [Biomes](biomes.md) 
+* [Console commands](console-commands.md)
 * [Databank entries](databank-entries.md)
-* [Custom vehicle upgrade modules](vehicle-module.md)
-* [Biomes](biomes.md)
-* [FMOD and Custom Audio](audio.md)
-* [Custom title screens](title-addons.md)
-* [Custom loading screens](loading-screens.md)
+* [Loading screens](loading-screens.md)
+* [Spawning objects in the world](spawns.md)
+* [Story goals](story-goals.md)
+* [Title screens](title-addons.md)
+* [Vehicle upgrade modules](vehicle-module.md)
 
 ### Prefabs
 * [Prefab basics](prefabs-overview.md)
@@ -21,8 +21,8 @@ This section covers step-by-step tutorials on how to get some of the useful feat
 
 ### Editing Content
 * [Background type](background-type.md)
-* [Equipment type](equipment-type.md)
 * [Crafting recipes](crafting-recipes.md)
+* [Equipment type](equipment-type.md)
 
 
 ### Utilities

--- a/Nautilus/Documentation/tutorials/toc.yml
+++ b/Nautilus/Documentation/tutorials/toc.yml
@@ -3,24 +3,24 @@
   
 - name: Adding Content
   items:
-    - name: Spawning objects in the world
-      href: spawns.md
-    - name: Custom console commands
-      href: console-commands.md
-    - name: Story goals
-      href: story-goals.md
-    - name: Databank entries
-      href: databank-entries.md
-    - name: Custom vehicle upgrade modules
-      href: vehicle-module.md
+    - name: Audio
+      href: audio.md
     - name: Biomes
       href: biomes.md
-    - name: FMOD and Custom Audio
-      href: audio.md
-    - name : Custom title screens
-      href: title-addons.md
-    - name : Custom loading screens
+    - name: Console commands
+      href: console-commands.md
+    - name: Databank entries
+      href: databank-entries.md
+    - name: Loading screens
       href: loading-screens.md
+    - name: Spawning objects in the world
+      href: spawns.md
+    - name: Story goals
+      href: story-goals.md
+    - name: Title screens
+      href: title-addons.md
+    - name: Vehicle upgrade modules
+      href: vehicle-module.md
 
 - name: Prefabs
   items:
@@ -33,10 +33,10 @@
   items:
     - name: Background type
       href: background-type.md
-    - name: Equipment type
-      href: equipment-type.md
     - name: Crafting recipes
       href: crafting-recipes.md
+    - name: Equipment type
+      href: equipment-type.md
   
 - name: Utilities
   items:


### PR DESCRIPTION
### Changes made in this pull request

  - Removed the unnecessary use of the word "custom" in the TOC/Overview
  - Ordered pages alphabetically

Before:
<img width="307" height="608" alt="image" src="https://github.com/user-attachments/assets/3ef44d2a-9242-4ebe-879c-cc1ee83ba6df" />

After:
<img width="308" height="518" alt="image" src="https://github.com/user-attachments/assets/f1fc1d03-ab85-42b8-b1b2-33a757ae00dd" />
